### PR TITLE
Add GitHub CI workflows for linting, testing, and coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo registry
         uses: actions/cache@v4
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
 
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
 
@@ -80,7 +80,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo registry
         uses: actions/cache@v4
@@ -103,7 +103,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo registry
         uses: actions/cache@v4

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview
 


### PR DESCRIPTION
## Summary

- Adds CI workflow with cargo check, clippy, rustfmt, tests, and documentation checks
- Adds code coverage workflow with enforcement that coverage cannot decrease on PRs
- Coverage reports are posted as PR comments with comparison to master baseline

## CI Workflow (`ci.yml`)

Runs on all pushes and PRs to master:
- **Check**: `cargo check --all-targets`
- **Format**: `cargo fmt --all -- --check`
- **Clippy**: `cargo clippy --all-targets -- -D warnings`
- **Test**: `cargo test --all-targets`
- **Documentation**: `cargo doc` with warnings as errors

## Coverage Workflow (`coverage.yml`)

- Generates coverage using `cargo-llvm-cov`
- Stores coverage artifact from master as baseline
- On PRs, compares coverage against master baseline
- **Fails the check if coverage decreases**
- Posts coverage summary as a PR comment
- Uploads HTML coverage report as artifact