### PR TITLE
feat(rate-limiter): add rate limit logic before and after token decryption

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ service-account*.json
 *.swp
 *.swo
 *~
+.cursor/
 
 # macOS
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -51,6 +51,19 @@ Transponder uses TOML configuration files with environment variable overrides. T
 # SECURITY: Store in environment variable for production
 private_key = ""
 
+# Graceful shutdown timeout in seconds
+shutdown_timeout_secs = 10
+
+# Event deduplication cache size (default: 100000)
+# max_dedup_cache_size = 100000
+
+# Rate limiting to prevent spam and replay attacks
+# max_rate_limit_cache_size = 100000           # LRU cache size per limiter
+# encrypted_token_rate_limit_per_minute = 240  # Per encrypted token (replay protection)
+# encrypted_token_rate_limit_per_hour = 5000
+# device_token_rate_limit_per_minute = 240     # Per device (spam protection)
+# device_token_rate_limit_per_hour = 5000
+
 [relays]
 # ClearNet relays to subscribe to
 clearnet = [
@@ -250,6 +263,16 @@ Transponder exposes Prometheus metrics at `/metrics` on the health server port (
 | `transponder_dedup_cache_evictions_total` | Counter | Total dedup cache evictions |
 | `transponder_tokens_decrypted_total` | Counter | Total tokens successfully decrypted |
 | `transponder_tokens_decryption_failed_total` | Counter | Total token decryption failures |
+
+#### Token Rate Limiting
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `transponder_tokens_rate_limited_total` | Counter | `type`, `reason` | Tokens skipped due to rate limiting |
+| `transponder_rate_limit_cache_size` | Gauge | `type` | Current rate limit cache size |
+| `transponder_rate_limit_evictions_total` | Counter | `type` | Rate limit cache evictions |
+
+Label values: `type` = `encrypted_token` or `device_token`; `reason` = `minute` or `hour`
 
 #### Push Notifications
 

--- a/config/default.toml
+++ b/config/default.toml
@@ -15,6 +15,29 @@ shutdown_timeout_secs = 10
 # Default: 100000
 # max_dedup_cache_size = 100000
 
+# Maximum size for rate limit caches (encrypted_token and device_token).
+# Each cache uses LRU eviction to prevent unbounded memory growth.
+# Default: 100000 entries per cache
+# max_rate_limit_cache_size = 100000
+
+# Rate limit: max notifications per encrypted token per minute.
+# Limits identical encrypted blobs to prevent replay attacks.
+# Default: 240 (4 per second)
+# encrypted_token_rate_limit_per_minute = 240
+
+# Rate limit: max notifications per encrypted token per hour.
+# Default: 5000
+# encrypted_token_rate_limit_per_hour = 5000
+
+# Rate limit: max notifications per device token per minute.
+# Limits notifications to the same device to prevent spam.
+# Default: 240 (4 per second)
+# device_token_rate_limit_per_minute = 240
+
+# Rate limit: max notifications per device token per hour.
+# Default: 5000
+# device_token_rate_limit_per_hour = 5000
+
 [relays]
 # ClearNet relays to subscribe to
 clearnet = [

--- a/src/crypto/token.rs
+++ b/src/crypto/token.rs
@@ -65,6 +65,15 @@ impl Platform {
             ))),
         }
     }
+
+    /// Convert platform to byte identifier.
+    #[must_use]
+    pub const fn as_byte(self) -> u8 {
+        match self {
+            Platform::Apns => PLATFORM_APNS,
+            Platform::Fcm => PLATFORM_FCM,
+        }
+    }
 }
 
 /// Parsed encrypted token structure.
@@ -538,5 +547,17 @@ mod tests {
 
         let err = Platform::from_byte(0x00).unwrap_err();
         assert!(err.to_string().contains("0x00"));
+    }
+
+    #[test]
+    fn test_platform_byte_roundtrip() {
+        assert_eq!(
+            Platform::from_byte(Platform::Apns.as_byte()).unwrap(),
+            Platform::Apns
+        );
+        assert_eq!(
+            Platform::from_byte(Platform::Fcm.as_byte()).unwrap(),
+            Platform::Fcm
+        );
     }
 }

--- a/src/nostr/events.rs
+++ b/src/nostr/events.rs
@@ -1,6 +1,7 @@
 //! Event processing for incoming Nostr events.
 //!
-//! Handles deduplication and processing of gift-wrapped notification requests.
+//! Handles deduplication and processing of gift-wrapped notification requests,
+//! including rate limiting to prevent spam and replay attacks.
 
 use std::num::NonZeroUsize;
 use std::sync::Arc;
@@ -8,45 +9,27 @@ use std::time::Duration;
 
 use lru::LruCache;
 use nostr_sdk::prelude::*;
+use sha2::{Digest, Sha256};
 use tokio::sync::RwLock;
 use tokio::time::Instant;
 use tracing::{debug, trace, warn};
 
-use crate::crypto::{Nip59Handler, TokenDecryptor};
+use crate::crypto::{Nip59Handler, TokenDecryptor, TokenPayload};
 use crate::error::Result;
 use crate::metrics::Metrics;
 use crate::push::PushDispatcher;
+use crate::rate_limiter::{
+    DEFAULT_MAX_SIZE, DEFAULT_RATE_LIMIT_PER_HOUR, DEFAULT_RATE_LIMIT_PER_MINUTE, RateLimitConfig,
+    RateLimiter,
+};
 
 /// Duration to keep event IDs for deduplication (5 minutes).
 const DEDUP_WINDOW: Duration = Duration::from_secs(300);
 
 /// Maximum number of entries to scan per cleanup cycle.
-///
-/// Limits the time spent holding the write lock during cleanup to prevent
-/// latency spikes for event processing. With 60-second cleanup intervals,
-/// a batch size of 1000 can scan up to 100,000 entries in ~100 cleanup cycles
-/// (~100 minutes), which is well within the 5-minute dedup window for memory
-/// reclamation. The LRU eviction handles capacity limits regardless.
 const CLEANUP_BATCH_SIZE: usize = 1000;
 
-// Compile-time assertions to ensure CLEANUP_BATCH_SIZE is reasonable:
-// - Large enough to make progress on cleanup (>= 100)
-// - Small enough to avoid long lock holds (<= 10,000)
-const _: () = assert!(
-    CLEANUP_BATCH_SIZE >= 100,
-    "Batch size too small for efficient cleanup"
-);
-const _: () = assert!(
-    CLEANUP_BATCH_SIZE <= 10_000,
-    "Batch size too large, may cause lock contention"
-);
-
 /// Default maximum size for the deduplication cache.
-///
-/// This value (100,000 entries) provides a reasonable upper bound on memory
-/// usage while allowing sufficient capacity for high-traffic scenarios.
-/// Each entry consists of an `EventId` (32 bytes) and an `Instant` (16 bytes),
-/// so the maximum memory usage is approximately 4.8 MB at full capacity.
 pub const DEFAULT_MAX_DEDUP_CACHE_SIZE: usize = 100_000;
 
 /// Event processor for handling incoming gift-wrapped notifications.
@@ -54,62 +37,110 @@ pub struct EventProcessor {
     nip59_handler: Nip59Handler,
     token_decryptor: TokenDecryptor,
     push_dispatcher: Arc<PushDispatcher>,
+    /// Event ID deduplication cache.
     seen_events: Arc<RwLock<LruCache<EventId, Instant>>>,
+    /// Encrypted token rate limiter.
+    encrypted_token_limiter: RateLimiter<[u8; 32]>,
+    /// Device token rate limiter.
+    device_token_limiter: RateLimiter<[u8; 32]>,
     metrics: Option<Metrics>,
 }
 
+/// Configuration for token rate limiting.
+#[derive(Debug, Clone, Copy)]
+pub struct TokenRateLimitConfig {
+    /// Maximum entries in each rate limit cache.
+    pub max_cache_size: usize,
+    /// Max encrypted token requests per minute.
+    pub encrypted_token_per_minute: u32,
+    /// Max encrypted token requests per hour.
+    pub encrypted_token_per_hour: u32,
+    /// Max device token requests per minute.
+    pub device_token_per_minute: u32,
+    /// Max device token requests per hour.
+    pub device_token_per_hour: u32,
+}
+
+impl Default for TokenRateLimitConfig {
+    fn default() -> Self {
+        Self {
+            max_cache_size: DEFAULT_MAX_SIZE,
+            encrypted_token_per_minute: DEFAULT_RATE_LIMIT_PER_MINUTE,
+            encrypted_token_per_hour: DEFAULT_RATE_LIMIT_PER_HOUR,
+            device_token_per_minute: DEFAULT_RATE_LIMIT_PER_MINUTE,
+            device_token_per_hour: DEFAULT_RATE_LIMIT_PER_HOUR,
+        }
+    }
+}
+
 impl EventProcessor {
-    /// Create a new event processor with default cache size.
-    #[allow(dead_code)]
+    /// Create a new event processor with default settings.
+    ///
+    /// Uses default cache sizes and rate limits. For production use,
+    /// prefer `with_full_config` to specify all parameters explicitly.
+    #[cfg(test)]
     pub fn new(
         nip59_handler: Nip59Handler,
         token_decryptor: TokenDecryptor,
         push_dispatcher: Arc<PushDispatcher>,
     ) -> Self {
-        Self::with_cache_size(
+        Self::with_full_config(
             nip59_handler,
             token_decryptor,
             push_dispatcher,
             DEFAULT_MAX_DEDUP_CACHE_SIZE,
+            TokenRateLimitConfig::default(),
+            None,
         )
     }
 
-    /// Create a new event processor with a custom cache size limit.
-    ///
-    /// The cache will automatically evict the least recently used entries
-    /// when the size limit is reached, preventing unbounded memory growth.
+    /// Create a new event processor with a custom dedup cache size.
+    #[cfg(test)]
     pub fn with_cache_size(
         nip59_handler: Nip59Handler,
         token_decryptor: TokenDecryptor,
         push_dispatcher: Arc<PushDispatcher>,
         max_cache_size: usize,
     ) -> Self {
-        Self::with_cache_size_and_metrics(
+        Self::with_full_config(
             nip59_handler,
             token_decryptor,
             push_dispatcher,
             max_cache_size,
+            TokenRateLimitConfig::default(),
             None,
         )
     }
 
-    /// Create a new event processor with a custom cache size limit and metrics.
-    pub fn with_cache_size_and_metrics(
+    /// Create a new event processor with full configuration.
+    pub fn with_full_config(
         nip59_handler: Nip59Handler,
         token_decryptor: TokenDecryptor,
         push_dispatcher: Arc<PushDispatcher>,
-        max_cache_size: usize,
+        max_dedup_cache_size: usize,
+        rate_limit_config: TokenRateLimitConfig,
         metrics: Option<Metrics>,
     ) -> Self {
-        let cache_size = NonZeroUsize::new(max_cache_size).unwrap_or(
+        let cache_size = NonZeroUsize::new(max_dedup_cache_size).unwrap_or(
             NonZeroUsize::new(DEFAULT_MAX_DEDUP_CACHE_SIZE)
                 .expect("DEFAULT_MAX_DEDUP_CACHE_SIZE is non-zero"),
         );
+
         Self {
             nip59_handler,
             token_decryptor,
             push_dispatcher,
             seen_events: Arc::new(RwLock::new(LruCache::new(cache_size))),
+            encrypted_token_limiter: RateLimiter::new(RateLimitConfig {
+                max_per_minute: rate_limit_config.encrypted_token_per_minute,
+                max_per_hour: rate_limit_config.encrypted_token_per_hour,
+                max_entries: rate_limit_config.max_cache_size,
+            }),
+            device_token_limiter: RateLimiter::new(RateLimitConfig {
+                max_per_minute: rate_limit_config.device_token_per_minute,
+                max_per_hour: rate_limit_config.device_token_per_hour,
+                max_entries: rate_limit_config.max_cache_size,
+            }),
             metrics,
         }
     }
@@ -185,15 +216,36 @@ impl EventProcessor {
 
         debug!(token_count = token_bytes.len(), "Decrypting tokens");
 
-        // Decrypt each token and dispatch notifications
+        // Decrypt each token and dispatch notifications, with rate limiting.
+        //
+        // Rate limiting happens BEFORE decryption intentionally:
+        // Prevents wasting CPU on tokens we'll immediately rate-limit anyway.
         let mut payloads = Vec::with_capacity(token_bytes.len());
         for bytes in token_bytes {
-            match self.token_decryptor.decrypt_bytes(&bytes) {
-                Ok(payload) => {
+            // Rate limit check 1: encrypted token (replay protection)
+            let encrypted_key = Self::hash_bytes(&bytes);
+            let encrypted_result = self
+                .encrypted_token_limiter
+                .check_and_increment(&encrypted_key)
+                .await;
+            if !encrypted_result.is_allowed() {
+                trace!(
+                    reason = encrypted_result.limit_reason(),
+                    "Rate limited encrypted token"
+                );
+                if let Some(ref m) = self.metrics {
+                    m.record_rate_limited("encrypted_token", encrypted_result.limit_reason());
+                }
+                continue;
+            }
+
+            // Decrypt the token
+            let payload = match self.token_decryptor.decrypt_bytes(&bytes) {
+                Ok(p) => {
                     if let Some(ref m) = self.metrics {
                         m.record_token_decrypted();
                     }
-                    payloads.push(payload);
+                    p
                 }
                 Err(e) => {
                     // Silently ignore invalid tokens per MIP-05 spec
@@ -201,8 +253,28 @@ impl EventProcessor {
                     if let Some(ref m) = self.metrics {
                         m.record_token_decryption_failed();
                     }
+                    continue;
                 }
+            };
+
+            // Rate limit check 2: Is this device token within rate limits?
+            let device_key = Self::hash_device_token_key(&payload);
+            let device_result = self
+                .device_token_limiter
+                .check_and_increment(&device_key)
+                .await;
+            if !device_result.is_allowed() {
+                trace!(
+                    reason = device_result.limit_reason(),
+                    "Rate limited device token"
+                );
+                if let Some(ref m) = self.metrics {
+                    m.record_rate_limited("device_token", device_result.limit_reason());
+                }
+                continue;
             }
+
+            payloads.push(payload);
         }
 
         if payloads.is_empty() {
@@ -216,6 +288,21 @@ impl EventProcessor {
         Ok(count)
     }
 
+    /// Hash arbitrary bytes to a fixed-size key for rate limiting.
+    fn hash_bytes(data: &[u8]) -> [u8; 32] {
+        let mut hasher = Sha256::new();
+        hasher.update(data);
+        hasher.finalize().into()
+    }
+
+    /// Hash device token key (platform || device_token) for rate limiting.
+    fn hash_device_token_key(payload: &TokenPayload) -> [u8; 32] {
+        let mut hasher = Sha256::new();
+        hasher.update([payload.platform.as_byte()]);
+        hasher.update(&payload.device_token);
+        hasher.finalize().into()
+    }
+
     /// Check if an event has been seen recently.
     async fn is_duplicate(&self, event_id: &EventId) -> bool {
         let seen = self.seen_events.read().await;
@@ -223,9 +310,6 @@ impl EventProcessor {
     }
 
     /// Mark an event as seen.
-    ///
-    /// The LRU cache automatically evicts the oldest entries when the
-    /// configured size limit is reached, preventing unbounded memory growth.
     async fn mark_seen(&self, event_id: EventId) {
         let mut seen = self.seen_events.write().await;
         seen.put(event_id, Instant::now());
@@ -236,50 +320,73 @@ impl EventProcessor {
         }
     }
 
-    /// Clean up the deduplication cache by removing entries older than `DEDUP_WINDOW`.
+    /// Clean up all caches by removing expired entries.
     ///
-    /// This method uses incremental cleanup to avoid holding the write lock for
-    /// extended periods. Instead of scanning all entries, it processes up to
-    /// `CLEANUP_BATCH_SIZE` entries per call. Since cleanup runs periodically
-    /// (every 60 seconds by default), all expired entries will eventually be
-    /// removed across multiple cleanup cycles.
-    ///
-    /// Note: The LRU cache also provides automatic eviction based on size,
-    /// so this cleanup is for time-based expiration of stale entries to free memory.
+    /// Uses incremental cleanup to avoid holding write locks for extended
+    /// periods. Call periodically for full cleanup of all expired entries.
     pub async fn cleanup(&self) {
-        let mut seen = self.seen_events.write().await;
-        let now = Instant::now();
-        let before = seen.len();
+        // Clean event deduplication cache
+        let (evicted, remaining) = {
+            let mut seen = self.seen_events.write().await;
+            let now = Instant::now();
 
-        // Scan up to CLEANUP_BATCH_SIZE entries to find expired ones.
-        // This limits the time spent holding the write lock.
-        let expired_keys: Vec<_> = seen
-            .iter()
-            .take(CLEANUP_BATCH_SIZE)
-            .filter(|(_, seen_at)| now.duration_since(**seen_at) >= DEDUP_WINDOW)
-            .map(|(id, _)| *id)
-            .collect();
+            let expired_keys: Vec<_> = seen
+                .iter()
+                .take(CLEANUP_BATCH_SIZE)
+                .filter(|(_, seen_at)| now.duration_since(**seen_at) >= DEDUP_WINDOW)
+                .map(|(id, _)| *id)
+                .collect();
 
-        for key in &expired_keys {
-            seen.pop(key);
-        }
+            for key in &expired_keys {
+                seen.pop(key);
+            }
 
-        let after = seen.len();
-        let evicted = before - after;
+            (expired_keys.len(), seen.len())
+        };
 
-        // Update metrics
         if let Some(ref m) = self.metrics {
-            m.set_dedup_cache_size(after);
+            m.set_dedup_cache_size(remaining);
             if evicted > 0 {
                 m.record_dedup_evictions(evicted);
             }
         }
-
-        if before != after {
+        if evicted > 0 {
             debug!(
                 removed = evicted,
-                remaining = after,
-                "Cleaned up deduplication cache"
+                remaining = remaining,
+                "Cleaned up event deduplication cache"
+            );
+        }
+
+        // Clean encrypted token rate limiter cache
+        let encrypted_stats = self.encrypted_token_limiter.cleanup().await;
+        if let Some(ref m) = self.metrics {
+            m.set_rate_limit_cache_size("encrypted_token", encrypted_stats.remaining);
+            if encrypted_stats.evicted > 0 {
+                m.record_rate_limit_evictions("encrypted_token", encrypted_stats.evicted);
+            }
+        }
+        if encrypted_stats.evicted > 0 {
+            debug!(
+                removed = encrypted_stats.evicted,
+                remaining = encrypted_stats.remaining,
+                "Cleaned up encrypted token rate limit cache"
+            );
+        }
+
+        // Clean device token rate limiter cache
+        let device_stats = self.device_token_limiter.cleanup().await;
+        if let Some(ref m) = self.metrics {
+            m.set_rate_limit_cache_size("device_token", device_stats.remaining);
+            if device_stats.evicted > 0 {
+                m.record_rate_limit_evictions("device_token", device_stats.evicted);
+            }
+        }
+        if device_stats.evicted > 0 {
+            debug!(
+                removed = device_stats.evicted,
+                remaining = device_stats.remaining,
+                "Cleaned up device token rate limit cache"
             );
         }
     }
@@ -287,7 +394,6 @@ impl EventProcessor {
     /// Returns the current number of entries in the deduplication cache.
     #[cfg(test)]
     pub fn cache_len(&self) -> usize {
-        // Use try_read to avoid blocking in tests
         self.seen_events
             .try_read()
             .map(|guard| guard.len())
@@ -301,7 +407,6 @@ mod tests {
     use crate::push::PushDispatcher;
     use crate::test_vectors::scenarios;
 
-    /// Create an EventProcessor with the given server keys and no push clients.
     fn create_processor(server_keys: &Keys) -> EventProcessor {
         let nip59_handler = Nip59Handler::new(server_keys.clone());
         let secp_secret_key =
@@ -312,23 +417,30 @@ mod tests {
         EventProcessor::new(nip59_handler, token_decryptor, push_dispatcher)
     }
 
+    fn create_processor_with_cache_size(server_keys: &Keys, cache_size: usize) -> EventProcessor {
+        let nip59_handler = Nip59Handler::new(server_keys.clone());
+        let secp_secret_key =
+            secp256k1::SecretKey::from_slice(&server_keys.secret_key().to_secret_bytes())
+                .expect("valid secret key");
+        let token_decryptor = TokenDecryptor::new(secp_secret_key);
+        let push_dispatcher = Arc::new(PushDispatcher::new(None, None));
+        EventProcessor::with_cache_size(nip59_handler, token_decryptor, push_dispatcher, cache_size)
+    }
+
     #[tokio::test]
     async fn test_process_valid_gift_wrap_event() {
         let server_keys = Keys::generate();
         let sender_keys = Keys::generate();
         let device_token = "aabbccdd11223344aabbccdd11223344";
 
-        // Create a valid gift-wrapped notification
         let event =
             scenarios::single_apns_notification(&server_keys, &sender_keys, device_token).await;
 
-        // Process the event
         let processor = create_processor(&server_keys);
         let result = processor.process(&event).await;
 
-        // Should succeed (even without push clients, decryption should work)
         assert!(result.is_ok());
-        assert!(result.unwrap()); // true = processed successfully
+        assert!(result.unwrap());
     }
 
     #[tokio::test]
@@ -353,7 +465,7 @@ mod tests {
         // Second processing of same event should be deduplicated
         let result2 = processor.process(&event).await;
         assert!(result2.is_ok());
-        assert!(!result2.unwrap()); // false = deduplicated
+        assert!(!result2.unwrap());
     }
 
     #[tokio::test]
@@ -377,7 +489,6 @@ mod tests {
 
         let processor = create_processor(&server_keys);
 
-        // Both events should be processed (different event IDs)
         let result1 = processor.process(&event1).await;
         let result2 = processor.process(&event2).await;
 
@@ -391,7 +502,6 @@ mod tests {
         let wrong_server_keys = Keys::generate();
         let sender_keys = Keys::generate();
 
-        // Create event for wrong server
         let event = scenarios::single_apns_notification(
             &wrong_server_keys,
             &sender_keys,
@@ -399,11 +509,9 @@ mod tests {
         )
         .await;
 
-        // Try to process with different server keys
         let processor = create_processor(&server_keys);
         let result = processor.process(&event).await;
 
-        // Should return Ok(false) - failed to process but didn't error out
         assert!(result.is_ok());
         assert!(!result.unwrap());
     }
@@ -418,7 +526,6 @@ mod tests {
         let processor = create_processor(&server_keys);
         let result = processor.process(&event).await;
 
-        // Should succeed but process 0 tokens
         assert!(result.is_ok());
         assert!(result.unwrap());
     }
@@ -442,7 +549,6 @@ mod tests {
         let server_keys = Keys::generate();
         let some_keys = Keys::generate();
 
-        // Create a regular text note (not a gift wrap)
         let event = EventBuilder::text_note("Hello, world!")
             .sign_with_keys(&some_keys)
             .unwrap();
@@ -450,32 +556,31 @@ mod tests {
         let processor = create_processor(&server_keys);
         let result = processor.process(&event).await;
 
-        // Should return Ok(false) - failed to process but should remain retryable
         assert!(result.is_ok());
         assert!(!result.unwrap());
     }
 
     #[tokio::test]
     async fn test_cleanup_removes_old_entries() {
+        tokio::time::pause();
+
         let server_keys = Keys::generate();
         let processor = create_processor(&server_keys);
 
-        // Manually add an event ID to the seen list
-        {
-            let mut seen = processor.seen_events.write().await;
-            seen.put(EventId::all_zeros(), Instant::now());
-        }
-
-        // Verify it's there
+        // Add an event
+        processor.mark_seen(EventId::all_zeros()).await;
         assert!(processor.is_duplicate(&EventId::all_zeros()).await);
 
         // Cleanup shouldn't remove it (it's recent)
         processor.cleanup().await;
         assert!(processor.is_duplicate(&EventId::all_zeros()).await);
 
-        // The entry would need to be older than DEDUP_WINDOW to be removed
-        // We can't easily test that without mocking time, but we've verified
-        // the basic cleanup logic runs
+        // Advance time past the dedup window
+        tokio::time::advance(DEDUP_WINDOW + Duration::from_secs(1)).await;
+
+        // Now cleanup should remove it
+        processor.cleanup().await;
+        assert!(!processor.is_duplicate(&EventId::all_zeros()).await);
     }
 
     #[tokio::test]
@@ -497,24 +602,11 @@ mod tests {
         assert!(result.unwrap());
     }
 
-    /// Create an EventProcessor with a custom cache size for testing.
-    fn create_processor_with_cache_size(server_keys: &Keys, cache_size: usize) -> EventProcessor {
-        let nip59_handler = Nip59Handler::new(server_keys.clone());
-        let secp_secret_key =
-            secp256k1::SecretKey::from_slice(&server_keys.secret_key().to_secret_bytes())
-                .expect("valid secret key");
-        let token_decryptor = TokenDecryptor::new(secp_secret_key);
-        let push_dispatcher = Arc::new(PushDispatcher::new(None, None));
-        EventProcessor::with_cache_size(nip59_handler, token_decryptor, push_dispatcher, cache_size)
-    }
-
     #[tokio::test]
     async fn test_cache_size_limit_evicts_oldest_entries() {
         let server_keys = Keys::generate();
-        // Create processor with small cache size
         let processor = create_processor_with_cache_size(&server_keys, 3);
 
-        // Generate 5 event IDs
         let event_ids: Vec<EventId> = (0..5)
             .map(|i| {
                 let mut bytes = [0u8; 32];
@@ -523,12 +615,10 @@ mod tests {
             })
             .collect();
 
-        // Add all 5 events - should evict oldest ones
         for event_id in &event_ids {
             processor.mark_seen(*event_id).await;
         }
 
-        // Cache should only contain the last 3 entries
         assert_eq!(processor.cache_len(), 3);
 
         // First two entries should have been evicted (LRU)
@@ -544,10 +634,8 @@ mod tests {
     #[tokio::test]
     async fn test_cache_size_zero_uses_default() {
         let server_keys = Keys::generate();
-        // Creating with cache size 0 should fall back to default
         let processor = create_processor_with_cache_size(&server_keys, 0);
 
-        // Add an event - should work without panic
         let event_id = EventId::all_zeros();
         processor.mark_seen(event_id).await;
         assert!(processor.is_duplicate(&event_id).await);
@@ -566,7 +654,6 @@ mod tests {
             })
             .collect();
 
-        // Add first 3 events
         processor.mark_seen(event_ids[0]).await;
         processor.mark_seen(event_ids[1]).await;
         processor.mark_seen(event_ids[2]).await;
@@ -577,10 +664,7 @@ mod tests {
         // Add a 4th event - should evict event_ids[1] (now the LRU)
         processor.mark_seen(event_ids[3]).await;
 
-        // event_ids[1] should be evicted
         assert!(!processor.is_duplicate(&event_ids[1]).await);
-
-        // event_ids[0], [2], and [3] should still be present
         assert!(processor.is_duplicate(&event_ids[0]).await);
         assert!(processor.is_duplicate(&event_ids[2]).await);
         assert!(processor.is_duplicate(&event_ids[3]).await);
@@ -588,13 +672,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_cleanup_processes_limited_entries() {
-        // This test verifies that cleanup doesn't scan all entries at once.
-        // We add entries with old timestamps and verify cleanup only removes
-        // up to CLEANUP_BATCH_SIZE entries per call.
+        tokio::time::pause();
+
         let server_keys = Keys::generate();
         let processor = create_processor(&server_keys);
 
-        // Add more entries than CLEANUP_BATCH_SIZE, all with "old" timestamps
+        // Add more entries than CLEANUP_BATCH_SIZE
         let num_entries = CLEANUP_BATCH_SIZE + 500;
         let old_time = Instant::now() - DEDUP_WINDOW - Duration::from_secs(1);
 
@@ -608,13 +691,11 @@ mod tests {
             }
         }
 
-        // Verify all entries are present
         assert_eq!(processor.cache_len(), num_entries);
 
         // Run cleanup once - should only remove up to CLEANUP_BATCH_SIZE entries
         processor.cleanup().await;
 
-        // After one cleanup, we should have removed at most CLEANUP_BATCH_SIZE entries
         let remaining = processor.cache_len();
         assert!(
             remaining >= num_entries - CLEANUP_BATCH_SIZE,
@@ -626,7 +707,6 @@ mod tests {
         // Run cleanup again - should remove remaining old entries
         processor.cleanup().await;
 
-        // All expired entries should now be removed
         assert_eq!(
             processor.cache_len(),
             0,
@@ -636,6 +716,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_cleanup_preserves_recent_entries() {
+        tokio::time::pause();
+
         let server_keys = Keys::generate();
         let processor = create_processor(&server_keys);
 
@@ -667,11 +749,208 @@ mod tests {
         // Cleanup should remove old entries but keep recent ones
         processor.cleanup().await;
 
-        // Should have exactly 50 recent entries remaining
         assert_eq!(
             processor.cache_len(),
             50,
             "Expected 50 recent entries to remain after cleanup"
+        );
+    }
+
+    // === Rate Limiting Integration Tests ===
+
+    fn create_processor_with_rate_limits(
+        server_keys: &Keys,
+        rate_limit_config: TokenRateLimitConfig,
+    ) -> EventProcessor {
+        let nip59_handler = Nip59Handler::new(server_keys.clone());
+        let secp_secret_key =
+            secp256k1::SecretKey::from_slice(&server_keys.secret_key().to_secret_bytes())
+                .expect("valid secret key");
+        let token_decryptor = TokenDecryptor::new(secp_secret_key);
+        let push_dispatcher = Arc::new(PushDispatcher::new(None, None));
+        EventProcessor::with_full_config(
+            nip59_handler,
+            token_decryptor,
+            push_dispatcher,
+            DEFAULT_MAX_DEDUP_CACHE_SIZE,
+            rate_limit_config,
+            None,
+        )
+    }
+
+    #[tokio::test]
+    async fn test_device_token_rate_limiting() {
+        let server_keys = Keys::generate();
+        let sender_keys = Keys::generate();
+
+        // Create processor with very low device token rate limit
+        let processor = create_processor_with_rate_limits(
+            &server_keys,
+            TokenRateLimitConfig {
+                max_cache_size: 100,
+                encrypted_token_per_minute: 100, // High limit for encrypted tokens
+                encrypted_token_per_hour: 1000,
+                device_token_per_minute: 2, // Only allow 2 per minute per device
+                device_token_per_hour: 100,
+            },
+        );
+
+        // Same device token, but different encrypted blobs (re-encrypted each time)
+        let device_token = "aabbccdd11223344aabbccdd11223344";
+
+        // First notification should succeed
+        let event1 =
+            scenarios::single_apns_notification(&server_keys, &sender_keys, device_token).await;
+        let result1 = processor.process(&event1).await;
+        assert!(result1.is_ok());
+        assert!(result1.unwrap(), "First notification should be processed");
+
+        // Second notification to same device should succeed (within limit)
+        let event2 =
+            scenarios::single_apns_notification(&server_keys, &sender_keys, device_token).await;
+        let result2 = processor.process(&event2).await;
+        assert!(result2.is_ok());
+        assert!(result2.unwrap(), "Second notification should be processed");
+
+        // Third notification to same device should be rate limited
+        // The event processes OK (returns true) but the token is skipped internally
+        let event3 =
+            scenarios::single_apns_notification(&server_keys, &sender_keys, device_token).await;
+        let result3 = processor.process(&event3).await;
+        assert!(result3.is_ok());
+        // Still returns true because event was processed, but 0 notifications sent
+        assert!(result3.unwrap());
+
+        // A different device should still work
+        let other_device = "11111111222222223333333344444444";
+        let event4 =
+            scenarios::single_apns_notification(&server_keys, &sender_keys, other_device).await;
+        let result4 = processor.process(&event4).await;
+        assert!(result4.is_ok());
+        assert!(
+            result4.unwrap(),
+            "Different device should not be rate limited"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_encrypted_token_rate_limiting() {
+        use crate::test_vectors::{GiftWrapBuilder, TestToken, TokenEncryptor};
+
+        let server_keys = Keys::generate();
+        let sender_keys = Keys::generate();
+
+        // Create processor with very low encrypted token rate limit
+        let processor = create_processor_with_rate_limits(
+            &server_keys,
+            TokenRateLimitConfig {
+                max_cache_size: 100,
+                encrypted_token_per_minute: 2, // Only allow 2 per minute per encrypted token
+                encrypted_token_per_hour: 100,
+                device_token_per_minute: 100, // High limit for device tokens
+                device_token_per_hour: 1000,
+            },
+        );
+
+        // Encrypt a token once and reuse the same encrypted blob
+        let encryptor = TokenEncryptor::from_keys(&server_keys);
+        let test_token = TestToken::apns("deadbeef12345678deadbeef12345678");
+        let encrypted_b64 = encryptor.encrypt_base64(&test_token);
+
+        // Create events with the exact same encrypted token
+        let content = serde_json::to_string(&vec![&encrypted_b64]).unwrap();
+
+        let event1 = GiftWrapBuilder::new(server_keys.clone(), sender_keys.clone())
+            .build(&content)
+            .await;
+        let result1 = processor.process(&event1).await;
+        assert!(result1.is_ok());
+        assert!(
+            result1.unwrap(),
+            "First use of encrypted token should succeed"
+        );
+
+        let event2 = GiftWrapBuilder::new(server_keys.clone(), sender_keys.clone())
+            .build(&content)
+            .await;
+        let result2 = processor.process(&event2).await;
+        assert!(result2.is_ok());
+        assert!(
+            result2.unwrap(),
+            "Second use of encrypted token should succeed"
+        );
+
+        // Third use of the same encrypted blob should be rate limited
+        let event3 = GiftWrapBuilder::new(server_keys.clone(), sender_keys.clone())
+            .build(&content)
+            .await;
+        let result3 = processor.process(&event3).await;
+        assert!(result3.is_ok());
+        // Event processes but token is skipped
+        assert!(result3.unwrap());
+
+        // A different encrypted token (same device) should work since we rate limit
+        // encrypted tokens first
+        let encrypted_b64_2 = encryptor.encrypt_base64(&test_token);
+        let content2 = serde_json::to_string(&vec![&encrypted_b64_2]).unwrap();
+        let event4 = GiftWrapBuilder::new(server_keys.clone(), sender_keys.clone())
+            .build(&content2)
+            .await;
+        let result4 = processor.process(&event4).await;
+        assert!(result4.is_ok());
+        assert!(result4.unwrap(), "Different encrypted token should work");
+    }
+
+    #[tokio::test]
+    async fn test_rate_limit_window_reset() {
+        use crate::test_vectors::{GiftWrapBuilder, TestToken, TokenEncryptor};
+
+        tokio::time::pause();
+
+        let server_keys = Keys::generate();
+        let sender_keys = Keys::generate();
+
+        let processor = create_processor_with_rate_limits(
+            &server_keys,
+            TokenRateLimitConfig {
+                max_cache_size: 100,
+                encrypted_token_per_minute: 1,
+                encrypted_token_per_hour: 100,
+                device_token_per_minute: 100,
+                device_token_per_hour: 1000,
+            },
+        );
+
+        let encryptor = TokenEncryptor::from_keys(&server_keys);
+        let test_token = TestToken::apns("aabbccdd11223344aabbccdd11223344");
+        let encrypted_b64 = encryptor.encrypt_base64(&test_token);
+        let content = serde_json::to_string(&vec![&encrypted_b64]).unwrap();
+
+        // First request succeeds
+        let event1 = GiftWrapBuilder::new(server_keys.clone(), sender_keys.clone())
+            .build(&content)
+            .await;
+        assert!(processor.process(&event1).await.unwrap());
+
+        // Second request is rate limited (same encrypted token)
+        let event2 = GiftWrapBuilder::new(server_keys.clone(), sender_keys.clone())
+            .build(&content)
+            .await;
+        processor.process(&event2).await.unwrap();
+        // Can't easily assert the token was skipped without metrics, but we can test window reset
+
+        // Advance time past the minute window
+        tokio::time::advance(Duration::from_secs(61)).await;
+
+        // Now the same token should be allowed again
+        let event3 = GiftWrapBuilder::new(server_keys.clone(), sender_keys.clone())
+            .build(&content)
+            .await;
+        let result3 = processor.process(&event3).await;
+        assert!(result3.is_ok());
+        assert!(
+            result3.unwrap(),
+            "Token should be allowed after window reset"
         );
     }
 }

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -1,0 +1,421 @@
+//! Rate limiting for token processing.
+//!
+//! Provides a fixed-window rate limiter with per-minute and per-hour limits
+//! to prevent spam and replay attacks.
+
+use std::hash::Hash;
+use std::num::NonZeroUsize;
+use std::time::Duration;
+
+use lru::LruCache;
+use tokio::sync::RwLock;
+use tokio::time::Instant;
+
+/// Default maximum cache size (100,000 entries).
+pub const DEFAULT_MAX_SIZE: usize = 100_000;
+
+/// Default rate limit per minute (240 = 4 per second).
+pub const DEFAULT_RATE_LIMIT_PER_MINUTE: u32 = 240;
+
+/// Default rate limit per hour.
+pub const DEFAULT_RATE_LIMIT_PER_HOUR: u32 = 5000;
+
+/// Maximum entries to scan per cleanup cycle.
+const CLEANUP_BATCH_SIZE: usize = 1000;
+
+/// Result of a rate limit check.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RateLimitResult {
+    /// Request is allowed.
+    Allowed,
+    /// Exceeded per-minute limit.
+    ExceededMinuteLimit,
+    /// Exceeded per-hour limit.
+    ExceededHourLimit,
+}
+
+impl RateLimitResult {
+    /// Returns `true` if the request was allowed.
+    #[must_use]
+    pub fn is_allowed(self) -> bool {
+        matches!(self, Self::Allowed)
+    }
+
+    /// Returns the reason string for metrics/logging (if rate limited).
+    #[must_use]
+    pub fn limit_reason(self) -> Option<&'static str> {
+        match self {
+            Self::Allowed => None,
+            Self::ExceededMinuteLimit => Some("minute"),
+            Self::ExceededHourLimit => Some("hour"),
+        }
+    }
+}
+
+/// Entry tracking rate limit counters for a single key.
+#[derive(Debug, Clone)]
+struct RateLimitEntry {
+    minute_count: u32,
+    minute_window_start: Instant,
+    hour_count: u32,
+    hour_window_start: Instant,
+}
+
+impl RateLimitEntry {
+    fn new(now: Instant) -> Self {
+        Self {
+            minute_count: 0,
+            minute_window_start: now,
+            hour_count: 0,
+            hour_window_start: now,
+        }
+    }
+}
+
+/// Statistics returned from rate limiter cleanup.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CleanupStats {
+    /// Number of entries evicted during cleanup.
+    pub evicted: usize,
+    /// Number of entries remaining after cleanup.
+    pub remaining: usize,
+}
+
+/// Configuration for rate limiting.
+#[derive(Debug, Clone, Copy)]
+pub struct RateLimitConfig {
+    /// Maximum requests per minute.
+    pub max_per_minute: u32,
+    /// Maximum requests per hour.
+    pub max_per_hour: u32,
+    /// Maximum entries in the cache (LRU eviction).
+    pub max_entries: usize,
+}
+
+impl Default for RateLimitConfig {
+    fn default() -> Self {
+        Self {
+            max_per_minute: DEFAULT_RATE_LIMIT_PER_MINUTE,
+            max_per_hour: DEFAULT_RATE_LIMIT_PER_HOUR,
+            max_entries: DEFAULT_MAX_SIZE,
+        }
+    }
+}
+
+/// Fixed-window rate limiter with per-minute and per-hour limits.
+///
+/// Uses an LRU cache to bound memory usage. When the cache is full,
+/// the least recently used entries are evicted.
+pub struct RateLimiter<K: Hash + Eq + Clone + Send + Sync + 'static> {
+    entries: RwLock<LruCache<K, RateLimitEntry>>,
+    max_per_minute: u32,
+    max_per_hour: u32,
+}
+
+impl<K: Hash + Eq + Clone + Send + Sync + 'static> RateLimiter<K> {
+    /// Creates a new rate limiter with the given configuration.
+    pub fn new(config: RateLimitConfig) -> Self {
+        let size = NonZeroUsize::new(config.max_entries)
+            .unwrap_or(NonZeroUsize::new(DEFAULT_MAX_SIZE).expect("DEFAULT_MAX_SIZE is non-zero"));
+
+        Self {
+            entries: RwLock::new(LruCache::new(size)),
+            max_per_minute: config.max_per_minute,
+            max_per_hour: config.max_per_hour,
+        }
+    }
+
+    /// Checks if a request is allowed and increments counters if so.
+    ///
+    /// Returns:
+    /// - `Allowed` if the request is within limits (counters are incremented)
+    /// - `ExceededMinuteLimit` if per-minute limit is reached
+    /// - `ExceededHourLimit` if per-hour limit is reached
+    pub async fn check_and_increment(&self, key: &K) -> RateLimitResult {
+        let now = Instant::now();
+        let mut entries = self.entries.write().await;
+
+        // Get or create entry (updates LRU position)
+        let entry = if let Some(entry) = entries.get_mut(key) {
+            entry
+        } else {
+            entries.put(key.clone(), RateLimitEntry::new(now));
+            entries.get_mut(key).expect("just inserted")
+        };
+
+        // Reset minute window if expired
+        if now.duration_since(entry.minute_window_start) >= Duration::from_secs(60) {
+            entry.minute_count = 0;
+            entry.minute_window_start = now;
+        }
+
+        // Reset hour window if expired
+        if now.duration_since(entry.hour_window_start) >= Duration::from_secs(3600) {
+            entry.hour_count = 0;
+            entry.hour_window_start = now;
+        }
+
+        // Check minute limit first (more likely to be hit)
+        if entry.minute_count >= self.max_per_minute {
+            return RateLimitResult::ExceededMinuteLimit;
+        }
+
+        // Check hour limit
+        if entry.hour_count >= self.max_per_hour {
+            return RateLimitResult::ExceededHourLimit;
+        }
+
+        // Increment counters
+        entry.minute_count += 1;
+        entry.hour_count += 1;
+
+        RateLimitResult::Allowed
+    }
+
+    /// Removes stale entries that haven't been accessed recently.
+    ///
+    /// Entries are considered stale if both windows have expired
+    /// (no activity in the last hour). Processes up to `CLEANUP_BATCH_SIZE`
+    /// entries per call.
+    pub async fn cleanup(&self) -> CleanupStats {
+        let mut entries = self.entries.write().await;
+        let now = Instant::now();
+        let before = entries.len();
+        let hour = Duration::from_secs(3600);
+
+        // Collect stale keys (hour window expired)
+        let stale: Vec<K> = entries
+            .iter()
+            .take(CLEANUP_BATCH_SIZE)
+            .filter(|(_, entry)| now.duration_since(entry.hour_window_start) >= hour)
+            .map(|(k, _)| k.clone())
+            .collect();
+
+        for key in &stale {
+            entries.pop(key);
+        }
+
+        CleanupStats {
+            evicted: stale.len(),
+            remaining: before - stale.len(),
+        }
+    }
+
+    /// Returns the current number of entries in the rate limiter.
+    #[cfg(test)]
+    pub async fn len(&self) -> usize {
+        self.entries.read().await.len()
+    }
+
+    /// Checks the current count without incrementing.
+    #[cfg(test)]
+    pub async fn peek_counts(&self, key: &K) -> Option<(u32, u32)> {
+        let entries = self.entries.read().await;
+        entries
+            .peek(key)
+            .map(|entry| (entry.minute_count, entry.hour_count))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_allows_within_limits() {
+        let limiter: RateLimiter<u64> = RateLimiter::new(RateLimitConfig {
+            max_per_minute: 10,
+            max_per_hour: 100,
+            max_entries: 100,
+        });
+
+        for _ in 0..10 {
+            assert_eq!(
+                limiter.check_and_increment(&1u64).await,
+                RateLimitResult::Allowed
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_minute_limit() {
+        let limiter: RateLimiter<u64> = RateLimiter::new(RateLimitConfig {
+            max_per_minute: 5,
+            max_per_hour: 100,
+            max_entries: 100,
+        });
+
+        for _ in 0..5 {
+            assert!(limiter.check_and_increment(&1u64).await.is_allowed());
+        }
+
+        assert_eq!(
+            limiter.check_and_increment(&1u64).await,
+            RateLimitResult::ExceededMinuteLimit
+        );
+
+        // Different key should still work
+        assert!(limiter.check_and_increment(&2u64).await.is_allowed());
+    }
+
+    #[tokio::test]
+    async fn test_hour_limit() {
+        let limiter: RateLimiter<u64> = RateLimiter::new(RateLimitConfig {
+            max_per_minute: 100,
+            max_per_hour: 5,
+            max_entries: 100,
+        });
+
+        for _ in 0..5 {
+            assert!(limiter.check_and_increment(&1u64).await.is_allowed());
+        }
+
+        assert_eq!(
+            limiter.check_and_increment(&1u64).await,
+            RateLimitResult::ExceededHourLimit
+        );
+    }
+
+    #[tokio::test]
+    async fn test_minute_window_reset() {
+        tokio::time::pause();
+
+        let limiter: RateLimiter<u64> = RateLimiter::new(RateLimitConfig {
+            max_per_minute: 5,
+            max_per_hour: 100,
+            max_entries: 100,
+        });
+
+        for _ in 0..5 {
+            assert!(limiter.check_and_increment(&1u64).await.is_allowed());
+        }
+        assert!(!limiter.check_and_increment(&1u64).await.is_allowed());
+
+        // Advance past minute window
+        tokio::time::advance(Duration::from_secs(61)).await;
+
+        assert!(limiter.check_and_increment(&1u64).await.is_allowed());
+    }
+
+    #[tokio::test]
+    async fn test_hour_window_reset() {
+        tokio::time::pause();
+
+        let limiter: RateLimiter<u64> = RateLimiter::new(RateLimitConfig {
+            max_per_minute: 100,
+            max_per_hour: 5,
+            max_entries: 100,
+        });
+
+        for _ in 0..5 {
+            assert!(limiter.check_and_increment(&1u64).await.is_allowed());
+        }
+        assert!(!limiter.check_and_increment(&1u64).await.is_allowed());
+
+        // Advance past hour window
+        tokio::time::advance(Duration::from_secs(3601)).await;
+
+        assert!(limiter.check_and_increment(&1u64).await.is_allowed());
+    }
+
+    #[tokio::test]
+    async fn test_independent_keys() {
+        let limiter: RateLimiter<u64> = RateLimiter::new(RateLimitConfig {
+            max_per_minute: 2,
+            max_per_hour: 10,
+            max_entries: 100,
+        });
+
+        // Key 1 hits limit
+        assert!(limiter.check_and_increment(&1u64).await.is_allowed());
+        assert!(limiter.check_and_increment(&1u64).await.is_allowed());
+        assert!(!limiter.check_and_increment(&1u64).await.is_allowed());
+
+        // Key 2 is independent
+        assert!(limiter.check_and_increment(&2u64).await.is_allowed());
+        assert!(limiter.check_and_increment(&2u64).await.is_allowed());
+        assert!(!limiter.check_and_increment(&2u64).await.is_allowed());
+    }
+
+    #[tokio::test]
+    async fn test_cleanup() {
+        tokio::time::pause();
+
+        let limiter: RateLimiter<u64> = RateLimiter::new(RateLimitConfig {
+            max_per_minute: 10,
+            max_per_hour: 100,
+            max_entries: 100,
+        });
+
+        limiter.check_and_increment(&1u64).await;
+        limiter.check_and_increment(&2u64).await;
+        assert_eq!(limiter.len().await, 2);
+
+        // Advance past hour window
+        tokio::time::advance(Duration::from_secs(3601)).await;
+
+        let stats = limiter.cleanup().await;
+        assert_eq!(stats.evicted, 2);
+        assert_eq!(stats.remaining, 0);
+    }
+
+    #[tokio::test]
+    async fn test_lru_eviction() {
+        let limiter: RateLimiter<u64> = RateLimiter::new(RateLimitConfig {
+            max_per_minute: 10,
+            max_per_hour: 100,
+            max_entries: 3,
+        });
+
+        limiter.check_and_increment(&1u64).await;
+        limiter.check_and_increment(&2u64).await;
+        limiter.check_and_increment(&3u64).await;
+        assert_eq!(limiter.len().await, 3);
+
+        // Adding 4th should evict LRU (key 1)
+        limiter.check_and_increment(&4u64).await;
+        assert_eq!(limiter.len().await, 3);
+
+        // Key 1 should have been evicted
+        assert_eq!(limiter.peek_counts(&1u64).await, None);
+    }
+
+    #[tokio::test]
+    async fn test_result_helpers() {
+        assert!(RateLimitResult::Allowed.is_allowed());
+        assert!(!RateLimitResult::ExceededMinuteLimit.is_allowed());
+        assert!(!RateLimitResult::ExceededHourLimit.is_allowed());
+
+        assert_eq!(RateLimitResult::Allowed.limit_reason(), None);
+        assert_eq!(
+            RateLimitResult::ExceededMinuteLimit.limit_reason(),
+            Some("minute")
+        );
+        assert_eq!(
+            RateLimitResult::ExceededHourLimit.limit_reason(),
+            Some("hour")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_with_byte_array_keys() {
+        let limiter: RateLimiter<[u8; 32]> = RateLimiter::new(RateLimitConfig {
+            max_per_minute: 5,
+            max_per_hour: 100,
+            max_entries: 100,
+        });
+
+        let key1 = [1u8; 32];
+        let key2 = [2u8; 32];
+
+        for _ in 0..5 {
+            assert!(limiter.check_and_increment(&key1).await.is_allowed());
+        }
+
+        // Key 1 is rate limited
+        assert!(!limiter.check_and_increment(&key1).await.is_allowed());
+
+        // Key 2 is independent
+        assert!(limiter.check_and_increment(&key2).await.is_allowed());
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented token rate limiting to prevent spam and replay attacks on encrypted tokens and device tokens.
  * Server configuration now includes rate limit thresholds (per-minute and per-hour) and cache management options.
  * Added monitoring metrics for rate-limited tokens, cache size, and eviction counts.

* **Documentation**
  * Updated configuration documentation with new rate-limiting options and default values.
  * Added rate-limiting metrics documentation with label definitions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->