### PR TITLE
Improve MIP-05 compliance and push delivery resilience

### DIFF
--- a/src/crypto/nip59.rs
+++ b/src/crypto/nip59.rs
@@ -6,10 +6,16 @@
 use nostr_sdk::nips::nip59::UnwrappedGift;
 use nostr_sdk::prelude::*;
 
+use crate::crypto::token::ENCRYPTED_TOKEN_SIZE;
 use crate::error::{Error, Result};
 
 /// Kind for MIP-05 notification requests (rumor inside seal).
 pub const KIND_NOTIFICATION_REQUEST: u16 = 446;
+
+const TAG_VERSION: &str = "v";
+const TAG_ENCODING: &str = "encoding";
+const VERSION_MIP05_V1: &str = "mip05-v1";
+const ENCODING_BASE64: &str = "base64";
 
 /// Handler for NIP-59 gift wrap operations.
 #[derive(Clone)]
@@ -38,7 +44,7 @@ impl Nip59Handler {
     /// 3. Verify the seal is kind 13
     /// 4. Decrypt the seal to get the rumor
     /// 5. Verify the rumor is kind 446
-    /// 6. Return the rumor content (encrypted tokens)
+    /// 6. Return the rumor metadata and content
     pub async fn unwrap(&self, event: &Event) -> Result<UnwrappedNotification> {
         // Verify this is a gift wrap event
         if event.kind != Kind::GiftWrap {
@@ -64,13 +70,13 @@ impl Nip59Handler {
         // Extract the sender's public key
         let sender_pubkey = unwrapped.sender;
 
-        // The content contains the encrypted tokens
-        let content = unwrapped.rumor.content.clone();
+        let rumor = unwrapped.rumor;
 
         Ok(UnwrappedNotification {
             sender_pubkey,
-            content,
-            created_at: unwrapped.rumor.created_at,
+            content: rumor.content,
+            tags: rumor.tags,
+            created_at: rumor.created_at,
         })
     }
 }
@@ -81,39 +87,104 @@ impl Nip59Handler {
 pub struct UnwrappedNotification {
     /// Public key of the sender.
     pub sender_pubkey: PublicKey,
-    /// Content containing encrypted tokens (base64-encoded).
+    /// Content containing encrypted tokens as a single base64 blob.
     pub content: String,
+    /// Rumor tags used for versioning and content encoding validation.
+    pub tags: Tags,
     /// When the rumor was created.
     pub created_at: Timestamp,
 }
 
 impl UnwrappedNotification {
+    fn require_tag_value(&self, tag_name: &str, expected_value: &str) -> Result<()> {
+        let mut found_tag = false;
+
+        for tag in self
+            .tags
+            .iter()
+            .filter(|tag| tag.kind() == TagKind::custom(tag_name))
+        {
+            found_tag = true;
+
+            match tag.content() {
+                Some(value) if value == expected_value => continue,
+                Some(value) => {
+                    return Err(Error::InvalidToken(format!(
+                        "Unsupported {tag_name} tag value: {value}"
+                    )));
+                }
+                None => {
+                    return Err(Error::InvalidToken(format!(
+                        "Missing value for required {tag_name} tag"
+                    )));
+                }
+            }
+        }
+
+        if !found_tag {
+            return Err(Error::InvalidToken(format!(
+                "Missing required {tag_name} tag"
+            )));
+        }
+
+        Ok(())
+    }
+
     /// Parse the encrypted tokens from the content.
     ///
-    /// The content is expected to be a JSON array of base64-encoded tokens.
+    /// The content is expected to be a single RFC 4648 standard base64 string
+    /// containing one or more concatenated encrypted tokens.
     pub fn parse_tokens(&self) -> Result<Vec<Vec<u8>>> {
         use base64::prelude::*;
 
-        // Parse JSON array of base64 strings
-        let token_strings: Vec<String> = serde_json::from_str(&self.content)
-            .map_err(|e| Error::InvalidToken(format!("Failed to parse token array: {e}")))?;
+        self.require_tag_value(TAG_VERSION, VERSION_MIP05_V1)?;
+        self.require_tag_value(TAG_ENCODING, ENCODING_BASE64)?;
 
-        // Decode each base64 token
-        let mut tokens = Vec::with_capacity(token_strings.len());
-        for token_str in token_strings {
-            let token_bytes = BASE64_STANDARD
-                .decode(&token_str)
-                .map_err(|e| Error::InvalidToken(format!("Failed to decode token: {e}")))?;
-            tokens.push(token_bytes);
+        let decoded = BASE64_STANDARD
+            .decode(&self.content)
+            .map_err(|e| Error::InvalidToken(format!("Failed to decode token blob: {e}")))?;
+
+        if decoded.is_empty() {
+            return Err(Error::InvalidToken(
+                "Notification request contains no encrypted tokens".to_string(),
+            ));
         }
 
-        Ok(tokens)
+        if decoded.len() % ENCRYPTED_TOKEN_SIZE != 0 {
+            return Err(Error::InvalidToken(format!(
+                "Decoded token blob length {} is not a multiple of {ENCRYPTED_TOKEN_SIZE}",
+                decoded.len()
+            )));
+        }
+
+        Ok(decoded
+            .chunks(ENCRYPTED_TOKEN_SIZE)
+            .map(|chunk| chunk.to_vec())
+            .collect())
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use base64::prelude::*;
+
+    fn valid_tags() -> Tags {
+        Tags::parse([
+            [TAG_VERSION, VERSION_MIP05_V1],
+            [TAG_ENCODING, ENCODING_BASE64],
+        ])
+        .unwrap()
+    }
+
+    fn notification(content: String) -> UnwrappedNotification {
+        UnwrappedNotification {
+            sender_pubkey: Keys::generate().public_key(),
+            content,
+            tags: valid_tags(),
+            created_at: Timestamp::now(),
+        }
+    }
 
     #[test]
     fn test_handler_creation() {
@@ -124,22 +195,12 @@ mod tests {
 
     #[test]
     fn test_parse_tokens() {
-        use base64::prelude::*;
+        let token1 = vec![0x01; ENCRYPTED_TOKEN_SIZE];
+        let token2 = vec![0x02; ENCRYPTED_TOKEN_SIZE];
+        let mut concatenated = token1.clone();
+        concatenated.extend_from_slice(&token2);
 
-        let token1 = vec![0x01, 0x02, 0x03];
-        let token2 = vec![0x04, 0x05, 0x06];
-
-        let content = format!(
-            "[\"{}\", \"{}\"]",
-            BASE64_STANDARD.encode(&token1),
-            BASE64_STANDARD.encode(&token2)
-        );
-
-        let notification = UnwrappedNotification {
-            sender_pubkey: Keys::generate().public_key(),
-            content,
-            created_at: Timestamp::now(),
-        };
+        let notification = notification(BASE64_STANDARD.encode(&concatenated));
 
         let tokens = notification.parse_tokens().unwrap();
         assert_eq!(tokens.len(), 2);
@@ -148,94 +209,11 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_invalid_json() {
+    fn test_parse_rejects_missing_version_tag() {
         let notification = UnwrappedNotification {
             sender_pubkey: Keys::generate().public_key(),
-            content: "not json".to_string(),
-            created_at: Timestamp::now(),
-        };
-
-        assert!(notification.parse_tokens().is_err());
-    }
-
-    #[test]
-    fn test_parse_invalid_base64() {
-        let notification = UnwrappedNotification {
-            sender_pubkey: Keys::generate().public_key(),
-            content: "[\"not valid base64!!!\"]".to_string(),
-            created_at: Timestamp::now(),
-        };
-
-        assert!(notification.parse_tokens().is_err());
-    }
-
-    #[test]
-    fn test_parse_empty_token_array() {
-        let notification = UnwrappedNotification {
-            sender_pubkey: Keys::generate().public_key(),
-            content: "[]".to_string(),
-            created_at: Timestamp::now(),
-        };
-
-        let tokens = notification.parse_tokens().unwrap();
-        assert!(tokens.is_empty());
-    }
-
-    #[test]
-    fn test_parse_single_token() {
-        use base64::prelude::*;
-
-        let token = vec![0xde, 0xad, 0xbe, 0xef];
-        let content = format!("[\"{}\"]", BASE64_STANDARD.encode(&token));
-
-        let notification = UnwrappedNotification {
-            sender_pubkey: Keys::generate().public_key(),
-            content,
-            created_at: Timestamp::now(),
-        };
-
-        let tokens = notification.parse_tokens().unwrap();
-        assert_eq!(tokens.len(), 1);
-        assert_eq!(tokens[0], token);
-    }
-
-    #[test]
-    fn test_parse_many_tokens() {
-        use base64::prelude::*;
-
-        let token_data: Vec<Vec<u8>> = (0..10).map(|i| vec![i; 32]).collect();
-        let encoded: Vec<String> = token_data
-            .iter()
-            .map(|t| BASE64_STANDARD.encode(t))
-            .collect();
-        let content = format!(
-            "[{}]",
-            encoded
-                .iter()
-                .map(|s| format!("\"{}\"", s))
-                .collect::<Vec<_>>()
-                .join(", ")
-        );
-
-        let notification = UnwrappedNotification {
-            sender_pubkey: Keys::generate().public_key(),
-            content,
-            created_at: Timestamp::now(),
-        };
-
-        let tokens = notification.parse_tokens().unwrap();
-        assert_eq!(tokens.len(), 10);
-        for (i, token) in tokens.iter().enumerate() {
-            assert_eq!(token, &vec![i as u8; 32]);
-        }
-    }
-
-    #[test]
-    fn test_parse_tokens_not_array() {
-        // JSON object instead of array
-        let notification = UnwrappedNotification {
-            sender_pubkey: Keys::generate().public_key(),
-            content: r#"{"token": "abc"}"#.to_string(),
+            content: BASE64_STANDARD.encode(vec![0x01; ENCRYPTED_TOKEN_SIZE]),
+            tags: Tags::parse([[TAG_ENCODING, ENCODING_BASE64]]).unwrap(),
             created_at: Timestamp::now(),
         };
 
@@ -245,20 +223,89 @@ mod tests {
             result
                 .unwrap_err()
                 .to_string()
-                .contains("Failed to parse token array")
+                .contains("Missing required v tag")
         );
     }
 
     #[test]
-    fn test_parse_tokens_number_array() {
-        // Array of numbers instead of strings
+    fn test_parse_invalid_base64() {
+        let notification = notification("not valid base64!!!".to_string());
+
+        let result = notification.parse_tokens();
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Failed to decode token blob")
+        );
+    }
+
+    #[test]
+    fn test_parse_empty_token_blob() {
+        let notification = notification(String::new());
+
+        let result = notification.parse_tokens();
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("no encrypted tokens")
+        );
+    }
+
+    #[test]
+    fn test_parse_single_token() {
+        let token = vec![0xde; ENCRYPTED_TOKEN_SIZE];
+        let notification = notification(BASE64_STANDARD.encode(&token));
+
+        let tokens = notification.parse_tokens().unwrap();
+        assert_eq!(tokens.len(), 1);
+        assert_eq!(tokens[0], token);
+    }
+
+    #[test]
+    fn test_parse_many_tokens() {
+        let token_data: Vec<Vec<u8>> = (0..10)
+            .map(|i| vec![i as u8; ENCRYPTED_TOKEN_SIZE])
+            .collect();
+        let concatenated: Vec<u8> = token_data.iter().flatten().copied().collect();
+        let notification = notification(BASE64_STANDARD.encode(&concatenated));
+
+        let tokens = notification.parse_tokens().unwrap();
+        assert_eq!(tokens.len(), 10);
+        for (i, token) in tokens.iter().enumerate() {
+            assert_eq!(token, &vec![i as u8; ENCRYPTED_TOKEN_SIZE]);
+        }
+    }
+
+    #[test]
+    fn test_parse_rejects_invalid_blob_length() {
+        let invalid_len = ENCRYPTED_TOKEN_SIZE - 1;
+        let notification = notification(BASE64_STANDARD.encode(vec![0xAA; invalid_len]));
+
+        let result = notification.parse_tokens();
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("not a multiple"));
+    }
+
+    #[test]
+    fn test_parse_rejects_invalid_encoding_tag() {
         let notification = UnwrappedNotification {
             sender_pubkey: Keys::generate().public_key(),
-            content: "[1, 2, 3]".to_string(),
+            content: BASE64_STANDARD.encode(vec![0x11; ENCRYPTED_TOKEN_SIZE]),
+            tags: Tags::parse([[TAG_VERSION, VERSION_MIP05_V1], [TAG_ENCODING, "hex"]]).unwrap(),
             created_at: Timestamp::now(),
         };
 
         let result = notification.parse_tokens();
         assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Unsupported encoding tag value")
+        );
     }
 }

--- a/src/crypto/token.rs
+++ b/src/crypto/token.rs
@@ -15,7 +15,7 @@ use chacha20poly1305::{
     aead::{Aead, KeyInit},
 };
 use hkdf::Hkdf;
-use secp256k1::{PublicKey, Secp256k1, SecretKey};
+use secp256k1::{Parity, PublicKey, Secp256k1, SecretKey, XOnlyPublicKey};
 use sha2::Sha256;
 use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
@@ -28,16 +28,25 @@ const HKDF_SALT: &[u8] = b"mip05-v1";
 const HKDF_INFO: &[u8] = b"mip05-token-encryption";
 
 /// Expected size of the encrypted token (280 bytes total).
-/// - 33 bytes: compressed ephemeral public key
+/// - 32 bytes: x-only ephemeral public key
 /// - 12 bytes: nonce
-/// - 235 bytes: ciphertext (219 payload + 16 auth tag)
+/// - 236 bytes: ciphertext (220-byte plaintext + 16-byte auth tag)
 pub const ENCRYPTED_TOKEN_SIZE: usize = 280;
 
-/// Size of compressed secp256k1 public key.
-const PUBKEY_SIZE: usize = 33;
+/// Size of x-only secp256k1 public key.
+const PUBKEY_SIZE: usize = 32;
 
 /// Size of ChaCha20-Poly1305 nonce.
 const NONCE_SIZE: usize = 12;
+
+/// Size of decrypted token plaintext.
+const TOKEN_PLAINTEXT_SIZE: usize = 220;
+
+/// Required APNs device token length in bytes.
+const APNS_DEVICE_TOKEN_SIZE: usize = 32;
+
+/// Maximum allowed FCM device token length in bytes.
+const MAX_FCM_DEVICE_TOKEN_SIZE: usize = 200;
 
 /// Platform identifier for APNs (iOS).
 pub const PLATFORM_APNS: u8 = 0x01;
@@ -85,7 +94,7 @@ impl Platform {
 /// in memory.
 #[derive(Debug, Clone, Zeroize, ZeroizeOnDrop)]
 pub struct EncryptedToken {
-    /// Compressed ephemeral public key (33 bytes).
+    /// X-only ephemeral public key (32 bytes).
     pub ephemeral_pubkey: [u8; PUBKEY_SIZE],
     /// ChaCha20-Poly1305 nonce (12 bytes).
     pub nonce: [u8; NONCE_SIZE],
@@ -97,9 +106,9 @@ impl EncryptedToken {
     /// Parse an encrypted token from raw bytes.
     ///
     /// Expected format:
-    /// - Bytes 0-32: Compressed ephemeral public key
-    /// - Bytes 33-44: Nonce
-    /// - Bytes 45-279: Ciphertext with auth tag
+    /// - Bytes 0-31: X-only ephemeral public key
+    /// - Bytes 32-43: Nonce
+    /// - Bytes 44-279: Ciphertext with auth tag
     pub fn from_bytes(data: &[u8]) -> Result<Self> {
         if data.len() != ENCRYPTED_TOKEN_SIZE {
             return Err(Error::InvalidToken(format!(
@@ -141,43 +150,47 @@ pub struct TokenPayload {
 }
 
 impl TokenPayload {
-    /// Parse a decrypted payload, removing PKCS#7 padding.
+    /// Parse a decrypted token plaintext.
     ///
-    /// Payload format:
+    /// Token plaintext format:
     /// - Byte 0: Platform identifier (0x01 = APNs, 0x02 = FCM)
-    /// - Bytes 1-N: Device token
-    /// - Remaining: PKCS#7 padding
+    /// - Bytes 1-2: Device token length (big-endian)
+    /// - Bytes 3..(3+token_length): Device token
+    /// - Remaining: Random padding
     pub fn from_decrypted(data: &[u8]) -> Result<Self> {
-        if data.is_empty() {
-            return Err(Error::InvalidToken("Empty decrypted payload".to_string()));
+        if data.len() != TOKEN_PLAINTEXT_SIZE {
+            return Err(Error::InvalidToken(format!(
+                "Invalid token plaintext size: expected {TOKEN_PLAINTEXT_SIZE}, got {}",
+                data.len()
+            )));
         }
 
-        // Remove PKCS#7 padding
-        let padding_len = *data.last().unwrap() as usize;
-        if padding_len == 0 || padding_len > data.len() {
-            return Err(Error::InvalidToken("Invalid PKCS#7 padding".to_string()));
-        }
+        let platform = Platform::from_byte(data[0])?;
+        let token_length = u16::from_be_bytes([data[1], data[2]]) as usize;
 
-        // Verify padding bytes
-        for &byte in &data[data.len() - padding_len..] {
-            if byte as usize != padding_len {
-                return Err(Error::InvalidToken("Invalid PKCS#7 padding".to_string()));
+        match platform {
+            Platform::Apns if token_length != APNS_DEVICE_TOKEN_SIZE => {
+                return Err(Error::InvalidToken(format!(
+                    "Invalid APNs token length: expected {APNS_DEVICE_TOKEN_SIZE}, got {token_length}"
+                )));
             }
+            Platform::Fcm if !(1..=MAX_FCM_DEVICE_TOKEN_SIZE).contains(&token_length) => {
+                return Err(Error::InvalidToken(format!(
+                    "Invalid FCM token length: expected 1..={MAX_FCM_DEVICE_TOKEN_SIZE}, got {token_length}"
+                )));
+            }
+            _ => {}
         }
 
-        let unpadded = &data[..data.len() - padding_len];
-        if unpadded.is_empty() {
-            return Err(Error::InvalidToken(
-                "Payload empty after removing padding".to_string(),
-            ));
+        let payload_end = 3 + token_length;
+        if payload_end > data.len() {
+            return Err(Error::InvalidToken(format!(
+                "Token length {token_length} exceeds plaintext size {}",
+                data.len()
+            )));
         }
 
-        let platform = Platform::from_byte(unpadded[0])?;
-        let device_token = unpadded[1..].to_vec();
-
-        if device_token.is_empty() {
-            return Err(Error::InvalidToken("Empty device token".to_string()));
-        }
+        let device_token = data[3..payload_end].to_vec();
 
         Ok(Self {
             platform,
@@ -233,9 +246,10 @@ impl TokenDecryptor {
     /// All intermediate cryptographic material (shared secrets, derived keys,
     /// plaintext buffers) is automatically zeroed when this function returns.
     pub fn decrypt(&self, token: &EncryptedToken) -> Result<TokenPayload> {
-        // Parse ephemeral public key
-        let ephemeral_pubkey = PublicKey::from_slice(&token.ephemeral_pubkey)
+        // Parse x-only ephemeral public key and normalize it to even-Y for ECDH.
+        let ephemeral_xonly = XOnlyPublicKey::from_slice(&token.ephemeral_pubkey)
             .map_err(|e| Error::Crypto(format!("Invalid ephemeral public key: {e}")))?;
+        let ephemeral_pubkey = PublicKey::from_x_only_public_key(ephemeral_xonly, Parity::Even);
 
         // Perform ECDH to get shared point (wrapped for zeroization)
         let shared_point: Zeroizing<[u8; 64]> = Zeroizing::new(
@@ -300,6 +314,15 @@ impl TokenDecryptor {
 mod tests {
     use super::*;
 
+    fn build_plaintext(platform: u8, token_length: u16, token_bytes: &[u8]) -> Vec<u8> {
+        let mut plaintext = vec![0u8; TOKEN_PLAINTEXT_SIZE];
+        plaintext[0] = platform;
+        plaintext[1..3].copy_from_slice(&token_length.to_be_bytes());
+        let end = 3 + token_bytes.len();
+        plaintext[3..end].copy_from_slice(token_bytes);
+        plaintext
+    }
+
     #[test]
     fn test_platform_from_byte() {
         assert_eq!(Platform::from_byte(0x01).unwrap(), Platform::Apns);
@@ -330,18 +353,24 @@ mod tests {
 
     #[test]
     fn test_token_payload_parsing() {
-        // Platform byte + device token + PKCS#7 padding (3 bytes of 0x03)
-        let data = vec![0x01, 0xaa, 0xbb, 0xcc, 0x03, 0x03, 0x03];
+        let device_token = [0xAA; APNS_DEVICE_TOKEN_SIZE];
+        let data = build_plaintext(PLATFORM_APNS, APNS_DEVICE_TOKEN_SIZE as u16, &device_token);
         let payload = TokenPayload::from_decrypted(&data).unwrap();
         assert_eq!(payload.platform, Platform::Apns);
-        assert_eq!(payload.device_token, vec![0xaa, 0xbb, 0xcc]);
+        assert_eq!(payload.device_token, device_token);
     }
 
     #[test]
-    fn test_token_payload_invalid_padding() {
-        // Invalid padding (mismatched bytes)
-        let data = vec![0x01, 0xaa, 0xbb, 0x02, 0x03];
-        assert!(TokenPayload::from_decrypted(&data).is_err());
+    fn test_token_payload_invalid_apns_length() {
+        let data = build_plaintext(PLATFORM_APNS, 31, &[0xAA; 31]);
+        let result = TokenPayload::from_decrypted(&data);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Invalid APNs token length")
+        );
     }
 
     #[test]
@@ -391,74 +420,67 @@ mod tests {
         let result = TokenPayload::from_decrypted(&data);
         assert!(result.is_err());
         let err = result.unwrap_err();
-        assert!(err.to_string().contains("Empty decrypted payload"));
+        assert!(err.to_string().contains("Invalid token plaintext size"));
     }
 
     #[test]
     fn test_token_payload_fcm_platform() {
-        // FCM platform byte (0x02) + device token + PKCS#7 padding (2 bytes of 0x02)
-        let data = vec![0x02, 0x64, 0x65, 0x76, 0x69, 0x63, 0x65, 0x02, 0x02];
+        let device_token = b"device";
+        let data = build_plaintext(PLATFORM_FCM, device_token.len() as u16, device_token);
         let payload = TokenPayload::from_decrypted(&data).unwrap();
         assert_eq!(payload.platform, Platform::Fcm);
-        assert_eq!(
-            payload.device_token,
-            vec![0x64, 0x65, 0x76, 0x69, 0x63, 0x65]
-        ); // "device"
+        assert_eq!(payload.device_token, device_token);
     }
 
     #[test]
-    fn test_token_payload_padding_zero() {
-        // Padding of 0 is invalid
-        let data = vec![0x01, 0xaa, 0x00];
+    fn test_token_payload_fcm_length_zero() {
+        let data = build_plaintext(PLATFORM_FCM, 0, &[]);
         let result = TokenPayload::from_decrypted(&data);
         assert!(result.is_err());
         assert!(
             result
                 .unwrap_err()
                 .to_string()
-                .contains("Invalid PKCS#7 padding")
+                .contains("Invalid FCM token length")
         );
     }
 
     #[test]
-    fn test_token_payload_padding_too_large() {
-        // Padding larger than data length is invalid
-        let data = vec![0x01, 0xaa, 0x10]; // 0x10 = 16, but data is only 3 bytes
+    fn test_token_payload_fcm_length_too_large() {
+        let data = build_plaintext(PLATFORM_FCM, 201, &[0x11; 200]);
         let result = TokenPayload::from_decrypted(&data);
         assert!(result.is_err());
         assert!(
             result
                 .unwrap_err()
                 .to_string()
-                .contains("Invalid PKCS#7 padding")
+                .contains("Invalid FCM token length")
         );
     }
 
     #[test]
-    fn test_token_payload_empty_after_padding() {
-        // After removing padding, only the data would be empty (all padding)
-        let data = vec![0x03, 0x03, 0x03]; // 3 bytes of 0x03 padding = empty payload
+    fn test_token_payload_wrong_size() {
+        let data = vec![0u8; TOKEN_PLAINTEXT_SIZE - 1];
         let result = TokenPayload::from_decrypted(&data);
         assert!(result.is_err());
         assert!(
             result
                 .unwrap_err()
                 .to_string()
-                .contains("Payload empty after removing padding")
+                .contains("Invalid token plaintext size")
         );
     }
 
     #[test]
     fn test_token_payload_empty_device_token() {
-        // Platform byte + 1 byte of padding (no device token)
-        let data = vec![0x01, 0x01]; // Platform byte 0x01, then 1 byte of 0x01 padding
+        let data = build_plaintext(PLATFORM_FCM, 0, &[]);
         let result = TokenPayload::from_decrypted(&data);
         assert!(result.is_err());
         assert!(
             result
                 .unwrap_err()
                 .to_string()
-                .contains("Empty device token")
+                .contains("Invalid FCM token length")
         );
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -29,6 +29,10 @@ pub enum Error {
     #[error("Invalid token: {0}")]
     InvalidToken(String),
 
+    /// Push dispatch or queueing error.
+    #[error("Push dispatch error: {0}")]
+    Dispatch(String),
+
     /// IO error.
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
@@ -89,6 +93,12 @@ mod tests {
     fn test_error_display_invalid_token() {
         let err = Error::InvalidToken("malformed token data".to_string());
         assert_eq!(err.to_string(), "Invalid token: malformed token data");
+    }
+
+    #[test]
+    fn test_error_display_dispatch() {
+        let err = Error::Dispatch("queue full".to_string());
+        assert_eq!(err.to_string(), "Push dispatch error: queue full");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use clap::Parser;
 use nostr_sdk::prelude::*;
+use tokio::sync::broadcast::error::RecvError;
 use tracing::{debug, error, info, warn};
 use tracing_subscriber::{EnvFilter, fmt, prelude::*};
 
@@ -51,6 +52,19 @@ struct Args {
 enum Command {
     /// Generate a new Nostr key pair for the server
     GenerateKeys,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NotificationReceiveAction {
+    Continue,
+    Shutdown,
+}
+
+fn classify_notification_receive_error(error: &RecvError) -> NotificationReceiveAction {
+    match error {
+        RecvError::Lagged(_) => NotificationReceiveAction::Continue,
+        RecvError::Closed => NotificationReceiveAction::Shutdown,
+    }
 }
 
 #[tokio::main]
@@ -255,8 +269,15 @@ async fn main() -> Result<()> {
                             }
                         }
                         Err(e) => {
-                            error!(error = %e, "Notification channel error");
-                            break;
+                            match classify_notification_receive_error(&e) {
+                                NotificationReceiveAction::Continue => {
+                                    warn!(error = %e, "Lagged relay notifications, continuing");
+                                }
+                                NotificationReceiveAction::Shutdown => {
+                                    error!(error = %e, "Notification channel closed");
+                                    break;
+                                }
+                            }
                         }
                     }
                 }
@@ -366,4 +387,23 @@ fn init_logging(config: &config::LoggingConfig) -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn notification_receive_lag_is_recoverable() {
+        let action = classify_notification_receive_error(&RecvError::Lagged(3));
+
+        assert_eq!(action, NotificationReceiveAction::Continue);
+    }
+
+    #[test]
+    fn notification_receive_close_is_terminal() {
+        let action = classify_notification_receive_error(&RecvError::Closed);
+
+        assert_eq!(action, NotificationReceiveAction::Shutdown);
+    }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -70,9 +70,6 @@ pub struct Metrics {
     /// Current number of items in the push queue.
     pub push_queue_size: IntGauge,
 
-    /// Total number of notifications dropped due to full queue.
-    pub push_queue_dropped_total: IntCounter,
-
     /// Number of available semaphore permits for concurrent pushes.
     pub push_semaphore_available: IntGauge,
 
@@ -220,12 +217,6 @@ impl Metrics {
         ))?;
         registry.register(Box::new(push_queue_size.clone()))?;
 
-        let push_queue_dropped_total = IntCounter::with_opts(Opts::new(
-            "transponder_push_queue_dropped_total",
-            "Total number of notifications dropped due to full queue",
-        ))?;
-        registry.register(Box::new(push_queue_dropped_total.clone()))?;
-
         let push_semaphore_available = IntGauge::with_opts(Opts::new(
             "transponder_push_semaphore_available",
             "Number of available permits for concurrent push requests",
@@ -322,7 +313,6 @@ impl Metrics {
             push_success_total,
             push_failed_total,
             push_queue_size,
-            push_queue_dropped_total,
             push_semaphore_available,
             push_retries_total,
             push_request_duration_seconds,
@@ -448,11 +438,6 @@ impl Metrics {
         self.push_queue_size.set(size as i64);
     }
 
-    /// Record a dropped notification due to full queue.
-    pub fn record_push_queue_dropped(&self) {
-        self.push_queue_dropped_total.inc();
-    }
-
     /// Update available semaphore permits.
     pub fn set_push_semaphore_available(&self, available: usize) {
         self.push_semaphore_available.set(available as i64);
@@ -536,7 +521,6 @@ mod tests {
         metrics.record_push_success("apns");
         metrics.record_push_failed("fcm", "invalid_token");
         metrics.set_push_queue_size(100);
-        metrics.record_push_queue_dropped();
         metrics.set_push_semaphore_available(95);
 
         let families = metrics.registry.gather();

--- a/src/nostr/events.rs
+++ b/src/nostr/events.rs
@@ -282,10 +282,7 @@ impl EventProcessor {
         }
 
         // Dispatch notifications
-        let count = payloads.len();
-        self.push_dispatcher.dispatch(payloads).await;
-
-        Ok(count)
+        self.push_dispatcher.dispatch(payloads).await
     }
 
     /// Hash arbitrary bytes to a fixed-size key for rate limiting.

--- a/src/nostr/events.rs
+++ b/src/nostr/events.rs
@@ -431,7 +431,7 @@ mod tests {
     async fn test_process_valid_gift_wrap_event() {
         let server_keys = Keys::generate();
         let sender_keys = Keys::generate();
-        let device_token = "aabbccdd11223344aabbccdd11223344";
+        let device_token = "aabbccdd11223344aabbccdd11223344aabbccdd11223344aabbccdd11223344";
 
         let event =
             scenarios::single_apns_notification(&server_keys, &sender_keys, device_token).await;
@@ -451,7 +451,7 @@ mod tests {
         let event = scenarios::single_apns_notification(
             &server_keys,
             &sender_keys,
-            "deadbeef12345678deadbeef12345678",
+            "deadbeef12345678deadbeef12345678deadbeef12345678deadbeef12345678",
         )
         .await;
 
@@ -476,14 +476,14 @@ mod tests {
         let event1 = scenarios::single_apns_notification(
             &server_keys,
             &sender_keys,
-            "aaaa111122223333aaaa111122223333",
+            "aaaa111122223333aaaa111122223333aaaa111122223333aaaa111122223333",
         )
         .await;
 
         let event2 = scenarios::single_apns_notification(
             &server_keys,
             &sender_keys,
-            "bbbb444455556666bbbb444455556666",
+            "bbbb444455556666bbbb444455556666bbbb444455556666bbbb444455556666",
         )
         .await;
 
@@ -505,7 +505,7 @@ mod tests {
         let event = scenarios::single_apns_notification(
             &wrong_server_keys,
             &sender_keys,
-            "deadbeef12345678deadbeef12345678",
+            "deadbeef12345678deadbeef12345678deadbeef12345678deadbeef12345678",
         )
         .await;
 
@@ -517,7 +517,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_process_empty_token_list() {
+    async fn test_process_empty_token_blob() {
         let server_keys = Keys::generate();
         let sender_keys = Keys::generate();
 
@@ -527,7 +527,7 @@ mod tests {
         let result = processor.process(&event).await;
 
         assert!(result.is_ok());
-        assert!(result.unwrap());
+        assert!(!result.unwrap());
     }
 
     #[tokio::test]
@@ -796,7 +796,7 @@ mod tests {
         );
 
         // Same device token, but different encrypted blobs (re-encrypted each time)
-        let device_token = "aabbccdd11223344aabbccdd11223344";
+        let device_token = "aabbccdd11223344aabbccdd11223344aabbccdd11223344aabbccdd11223344";
 
         // First notification should succeed
         let event1 =
@@ -822,7 +822,7 @@ mod tests {
         assert!(result3.unwrap());
 
         // A different device should still work
-        let other_device = "11111111222222223333333344444444";
+        let other_device = "1111111122222222333333334444444411111111222222223333333344444444";
         let event4 =
             scenarios::single_apns_notification(&server_keys, &sender_keys, other_device).await;
         let result4 = processor.process(&event4).await;
@@ -835,7 +835,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_encrypted_token_rate_limiting() {
-        use crate::test_vectors::{GiftWrapBuilder, TestToken, TokenEncryptor};
+        use crate::test_vectors::{
+            GiftWrapBuilder, NotificationContentBuilder, TestToken, TokenEncryptor,
+        };
 
         let server_keys = Keys::generate();
         let sender_keys = Keys::generate();
@@ -854,11 +856,14 @@ mod tests {
 
         // Encrypt a token once and reuse the same encrypted blob
         let encryptor = TokenEncryptor::from_keys(&server_keys);
-        let test_token = TestToken::apns("deadbeef12345678deadbeef12345678");
+        let test_token =
+            TestToken::apns("deadbeef12345678deadbeef12345678deadbeef12345678deadbeef12345678");
         let encrypted_b64 = encryptor.encrypt_base64(&test_token);
 
         // Create events with the exact same encrypted token
-        let content = serde_json::to_string(&vec![&encrypted_b64]).unwrap();
+        let content = NotificationContentBuilder::new(&server_keys)
+            .with_raw_token(encrypted_b64.clone())
+            .build();
 
         let event1 = GiftWrapBuilder::new(server_keys.clone(), sender_keys.clone())
             .build(&content)
@@ -892,7 +897,9 @@ mod tests {
         // A different encrypted token (same device) should work since we rate limit
         // encrypted tokens first
         let encrypted_b64_2 = encryptor.encrypt_base64(&test_token);
-        let content2 = serde_json::to_string(&vec![&encrypted_b64_2]).unwrap();
+        let content2 = NotificationContentBuilder::new(&server_keys)
+            .with_raw_token(encrypted_b64_2)
+            .build();
         let event4 = GiftWrapBuilder::new(server_keys.clone(), sender_keys.clone())
             .build(&content2)
             .await;
@@ -903,7 +910,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_rate_limit_window_reset() {
-        use crate::test_vectors::{GiftWrapBuilder, TestToken, TokenEncryptor};
+        use crate::test_vectors::{
+            GiftWrapBuilder, NotificationContentBuilder, TestToken, TokenEncryptor,
+        };
 
         tokio::time::pause();
 
@@ -922,9 +931,12 @@ mod tests {
         );
 
         let encryptor = TokenEncryptor::from_keys(&server_keys);
-        let test_token = TestToken::apns("aabbccdd11223344aabbccdd11223344");
+        let test_token =
+            TestToken::apns("aabbccdd11223344aabbccdd11223344aabbccdd11223344aabbccdd11223344");
         let encrypted_b64 = encryptor.encrypt_base64(&test_token);
-        let content = serde_json::to_string(&vec![&encrypted_b64]).unwrap();
+        let content = NotificationContentBuilder::new(&server_keys)
+            .with_raw_token(encrypted_b64)
+            .build();
 
         // First request succeeds
         let event1 = GiftWrapBuilder::new(server_keys.clone(), sender_keys.clone())

--- a/src/push/apns.rs
+++ b/src/push/apns.rs
@@ -219,6 +219,16 @@ impl ApnsClient {
         .await
     }
 
+    fn build_request(&self, url: &str, auth_token: &str) -> reqwest::RequestBuilder {
+        self.http_client
+            .post(url)
+            .header("apns-push-type", "background")
+            .header("apns-priority", "5")
+            .header("apns-topic", &self.config.bundle_id)
+            .header("authorization", format!("bearer {auth_token}"))
+            .json(&ApnsPayload::default())
+    }
+
     /// Send a single push notification attempt without retry.
     ///
     /// Returns a `SendAttemptResult` indicating success, retriable error, or permanent error.
@@ -226,26 +236,28 @@ impl ApnsClient {
         let start = Instant::now();
         let url = format!("{}/3/device/{}", self.config.base_url(), device_token);
 
-        let payload = ApnsPayload::default();
-
-        let mut request = self
-            .http_client
-            .post(&url)
-            .header("apns-push-type", "background")
-            .header("apns-priority", "5")
-            .header("apns-topic", &self.config.bundle_id)
-            .json(&payload);
-
         // Add authorization header
         let token = match self.get_token().await {
             Ok(t) => t,
             Err(e) => return SendAttemptResult::Permanent(e),
         };
-        request = request.header("authorization", format!("bearer {token}"));
 
-        let response = match request.send().await {
+        let transport_retry = RetryConfig::default();
+        let response = match retry::with_transport_retry(
+            &transport_retry,
+            "APNs",
+            || async {
+                self.build_request(&url, &token)
+                    .send()
+                    .await
+                    .map_err(Error::from)
+            },
+            self.metrics.as_ref(),
+        )
+        .await
+        {
             Ok(r) => r,
-            Err(e) => return SendAttemptResult::Permanent(Error::from(e)),
+            Err(e) => return SendAttemptResult::Permanent(e),
         };
 
         let status = response.status();

--- a/src/push/dispatcher.rs
+++ b/src/push/dispatcher.rs
@@ -20,6 +20,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use tokio::sync::Semaphore;
 use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
 use tracing::{debug, trace, warn};
 use zeroize::Zeroizing;
 
@@ -68,6 +69,7 @@ pub struct PushDispatcher {
     semaphore: Arc<Semaphore>,
     sender: mpsc::Sender<PushMessage>,
     shutting_down: Arc<AtomicBool>,
+    worker_handles: tokio::sync::Mutex<Vec<JoinHandle<()>>>,
     metrics: Option<Metrics>,
 }
 
@@ -100,12 +102,11 @@ impl PushDispatcher {
         }
 
         // Spawn worker tasks
-        Self::spawn_workers(
+        let worker_handles = Self::spawn_workers(
             receiver,
             apns_client.clone(),
             fcm_client.clone(),
             semaphore.clone(),
-            shutting_down.clone(),
             metrics.clone(),
         );
 
@@ -115,6 +116,7 @@ impl PushDispatcher {
             semaphore,
             sender,
             shutting_down,
+            worker_handles: tokio::sync::Mutex::new(worker_handles),
             metrics,
         }
     }
@@ -125,28 +127,21 @@ impl PushDispatcher {
         apns_client: Option<Arc<ApnsClient>>,
         fcm_client: Option<Arc<FcmClient>>,
         semaphore: Arc<Semaphore>,
-        shutting_down: Arc<AtomicBool>,
         metrics: Option<Metrics>,
-    ) {
+    ) -> Vec<JoinHandle<()>> {
         // Wrap receiver in Arc<Mutex> so workers can share it
         let receiver = Arc::new(tokio::sync::Mutex::new(receiver));
+        let mut worker_handles = Vec::with_capacity(NUM_WORKERS);
 
         for worker_id in 0..NUM_WORKERS {
             let receiver = receiver.clone();
             let apns_client = apns_client.clone();
             let fcm_client = fcm_client.clone();
             let semaphore = semaphore.clone();
-            let shutting_down = shutting_down.clone();
             let metrics = metrics.clone();
 
-            tokio::spawn(async move {
+            worker_handles.push(tokio::spawn(async move {
                 loop {
-                    // Check shutdown flag before waiting for next message
-                    if shutting_down.load(Ordering::SeqCst) {
-                        debug!(worker_id, "Worker detected shutdown flag, exiting");
-                        break;
-                    }
-
                     // Get next message from the shared queue
                     let msg = {
                         let mut rx = receiver.lock().await;
@@ -155,17 +150,6 @@ impl PushDispatcher {
 
                     match msg {
                         Some(PushMessage::Send { platform, token }) => {
-                            // Check shutdown flag again before processing
-                            // This handles the case where shutdown was triggered while waiting
-                            if shutting_down.load(Ordering::SeqCst) {
-                                debug!(
-                                    worker_id,
-                                    "Worker detected shutdown during processing, exiting"
-                                );
-                                // Token is automatically zeroed when dropped here
-                                break;
-                            }
-
                             // Acquire semaphore permit before sending
                             let permit = match semaphore.acquire().await {
                                 Ok(p) => p,
@@ -262,8 +246,10 @@ impl PushDispatcher {
                         }
                     }
                 }
-            });
+            }));
         }
+
+        worker_handles
     }
 
     /// Dispatch push notifications for all payloads.
@@ -388,31 +374,38 @@ impl PushDispatcher {
 
     /// Wait for all in-flight push notifications to complete.
     ///
-    /// This is used during graceful shutdown. It sets the shutdown flag,
-    /// attempts to send shutdown signals, then waits for all permits to be
-    /// available (indicating all pushes complete).
-    ///
-    /// Workers check the `shutting_down` flag in their loop, so they will
-    /// exit even if shutdown messages are dropped due to a full queue.
+    /// This is used during graceful shutdown. It stops accepting new dispatches,
+    /// enqueues one shutdown message per worker behind any queued notifications,
+    /// and then waits for all worker tasks to exit. This guarantees queued work
+    /// is drained before shutdown completes.
     pub async fn wait_for_completion(&self) {
-        // Mark as shutting down to prevent new dispatches and signal workers
+        // Mark as shutting down to prevent new dispatches.
         self.shutting_down.store(true, Ordering::SeqCst);
 
-        // Send shutdown signals to all workers (best effort - workers also check the flag)
+        // Enqueue shutdown signals after any already-queued notifications.
         for _ in 0..NUM_WORKERS {
-            // Use try_send since we don't want to block if queue is full.
-            // Workers will exit via the shutting_down flag check even if this fails.
-            let _ = self.sender.try_send(PushMessage::Shutdown);
-        }
-
-        // Wait for all permits to be available (all in-flight pushes complete)
-        let mut permits = Vec::with_capacity(MAX_CONCURRENT_PUSHES);
-        for _ in 0..MAX_CONCURRENT_PUSHES {
-            if let Ok(permit) = self.semaphore.acquire().await {
-                permits.push(permit);
+            if self.sender.send(PushMessage::Shutdown).await.is_err() {
+                break;
             }
         }
-        debug!("All in-flight push notifications completed");
+
+        let worker_handles = {
+            let mut handles = self.worker_handles.lock().await;
+            std::mem::take(&mut *handles)
+        };
+
+        for handle in worker_handles {
+            if let Err(error) = handle.await {
+                warn!(error = %error, "Push worker exited unexpectedly during shutdown");
+            }
+        }
+
+        if let Some(ref m) = self.metrics {
+            m.set_push_queue_size(0);
+            m.set_push_semaphore_available(self.semaphore.available_permits());
+        }
+
+        debug!("All queued push notifications drained");
     }
 
     /// Returns the current queue capacity available.
@@ -785,6 +778,58 @@ mod tests {
         // The queue should be bounded
         assert!(dispatcher.queue_capacity() <= MAX_PENDING_QUEUE_SIZE);
         assert_eq!(dispatcher.max_queue_size(), MAX_PENDING_QUEUE_SIZE);
+    }
+
+    #[tokio::test]
+    async fn test_wait_for_completion_drains_backlog_before_returning() {
+        use crate::config::ApnsConfig;
+        use crate::push::ApnsClient;
+
+        let apns_config = ApnsConfig {
+            enabled: true,
+            key_id: "KEY123".to_string(),
+            team_id: "TEAM456".to_string(),
+            private_key_path: String::new(),
+            environment: "sandbox".to_string(),
+            bundle_id: "com.example.app".to_string(),
+        };
+        let dispatcher = Arc::new(PushDispatcher::new(
+            Some(ApnsClient::mock(apns_config, true)),
+            None,
+        ));
+
+        let permits = dispatcher
+            .semaphore
+            .acquire_many(MAX_CONCURRENT_PUSHES as u32)
+            .await
+            .unwrap();
+
+        let payloads = vec![
+            TokenPayload {
+                platform: Platform::Apns,
+                device_token: vec![0xaa, 0xbb, 0xcc],
+            };
+            NUM_WORKERS + 2
+        ];
+        assert_eq!(
+            dispatcher.dispatch(payloads).await.unwrap(),
+            NUM_WORKERS + 2
+        );
+
+        let shutdown_dispatcher = dispatcher.clone();
+        let shutdown_handle = tokio::spawn(async move {
+            shutdown_dispatcher.wait_for_completion().await;
+        });
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        drop(permits);
+
+        tokio::time::timeout(Duration::from_secs(1), shutdown_handle)
+            .await
+            .expect("shutdown should complete")
+            .expect("shutdown task should not panic");
+
+        assert_eq!(dispatcher.queue_capacity(), MAX_PENDING_QUEUE_SIZE);
     }
 
     #[tokio::test]

--- a/src/push/dispatcher.rs
+++ b/src/push/dispatcher.rs
@@ -39,7 +39,10 @@ const MAX_CONCURRENT_PUSHES: usize = 100;
 const MAX_PENDING_QUEUE_SIZE: usize = 10_000;
 
 /// Number of worker tasks processing the queue.
-const NUM_WORKERS: usize = 4;
+///
+/// Match the worker pool to the semaphore limit so the dispatcher can actually
+/// reach the configured maximum outbound concurrency.
+const NUM_WORKERS: usize = MAX_CONCURRENT_PUSHES;
 
 /// Internal message for the push queue.
 ///
@@ -830,6 +833,11 @@ mod tests {
             .expect("shutdown task should not panic");
 
         assert_eq!(dispatcher.queue_capacity(), MAX_PENDING_QUEUE_SIZE);
+    }
+
+    #[test]
+    fn test_worker_count_matches_concurrency_limit() {
+        assert_eq!(NUM_WORKERS, MAX_CONCURRENT_PUSHES);
     }
 
     #[tokio::test]

--- a/src/push/dispatcher.rs
+++ b/src/push/dispatcher.rs
@@ -6,9 +6,9 @@
 //! # Bounded Queue Pattern
 //!
 //! To prevent unbounded task spawning (a potential DoS vector), the dispatcher
-//! uses a bounded channel. When the queue is full, new notifications are dropped
-//! and logged as warnings. This provides backpressure and protects against OOM
-//! conditions during traffic spikes.
+//! uses a bounded channel. When the queue is full, new notification batches are
+//! rejected before admission. This provides backpressure and protects against
+//! OOM conditions during traffic spikes.
 //!
 //! # Security
 //!
@@ -35,7 +35,7 @@ const MAX_CONCURRENT_PUSHES: usize = 100;
 /// Maximum number of pending notifications in the queue.
 ///
 /// This bounds the memory used by waiting tasks. When this limit is reached,
-/// new notifications will be dropped to protect against DoS attacks.
+/// new notification batches are rejected to protect against DoS attacks.
 const MAX_PENDING_QUEUE_SIZE: usize = 10_000;
 
 /// Number of worker tasks processing the queue.
@@ -72,6 +72,7 @@ pub struct PushDispatcher {
     semaphore: Arc<Semaphore>,
     sender: mpsc::Sender<PushMessage>,
     shutting_down: Arc<AtomicBool>,
+    admission_lock: tokio::sync::Mutex<()>,
     worker_handles: tokio::sync::Mutex<Vec<JoinHandle<()>>>,
     metrics: Option<Metrics>,
 }
@@ -107,6 +108,7 @@ impl PushDispatcher {
         // Spawn worker tasks
         let worker_handles = Self::spawn_workers(
             receiver,
+            sender.clone(),
             apns_client.clone(),
             fcm_client.clone(),
             semaphore.clone(),
@@ -119,14 +121,22 @@ impl PushDispatcher {
             semaphore,
             sender,
             shutting_down,
+            admission_lock: tokio::sync::Mutex::new(()),
             worker_handles: tokio::sync::Mutex::new(worker_handles),
             metrics,
+        }
+    }
+
+    fn update_queue_size_metric(metrics: &Option<Metrics>, sender: &mpsc::Sender<PushMessage>) {
+        if let Some(metrics) = metrics {
+            metrics.set_push_queue_size(MAX_PENDING_QUEUE_SIZE - sender.capacity());
         }
     }
 
     /// Spawn worker tasks that process the push queue.
     fn spawn_workers(
         receiver: mpsc::Receiver<PushMessage>,
+        sender: mpsc::Sender<PushMessage>,
         apns_client: Option<Arc<ApnsClient>>,
         fcm_client: Option<Arc<FcmClient>>,
         semaphore: Arc<Semaphore>,
@@ -138,6 +148,7 @@ impl PushDispatcher {
 
         for worker_id in 0..NUM_WORKERS {
             let receiver = receiver.clone();
+            let sender = sender.clone();
             let apns_client = apns_client.clone();
             let fcm_client = fcm_client.clone();
             let semaphore = semaphore.clone();
@@ -151,10 +162,14 @@ impl PushDispatcher {
                         rx.recv().await
                     };
 
+                    if msg.is_some() {
+                        Self::update_queue_size_metric(&metrics, &sender);
+                    }
+
                     match msg {
                         Some(PushMessage::Send { platform, token }) => {
-                            // Acquire semaphore permit before sending
-                            let permit = match semaphore.acquire().await {
+                            // Acquire semaphore permit before spawning the send task.
+                            let permit = match semaphore.clone().acquire_owned().await {
                                 Ok(p) => p,
                                 Err(_) => {
                                     debug!(worker_id, "Semaphore closed, worker exiting");
@@ -168,75 +183,85 @@ impl PushDispatcher {
                                 m.set_push_semaphore_available(semaphore.available_permits());
                             }
 
-                            let platform_str = match platform {
-                                Platform::Apns => "apns",
-                                Platform::Fcm => "fcm",
-                            };
+                            let apns_client = apns_client.clone();
+                            let fcm_client = fcm_client.clone();
+                            let metrics = metrics.clone();
+                            let semaphore = semaphore.clone();
 
-                            match platform {
-                                Platform::Apns => {
-                                    if let Some(ref client) = apns_client {
-                                        match client.send(token.as_str()).await {
-                                            Ok(true) => {
-                                                trace!("APNs notification sent");
-                                                if let Some(ref m) = metrics {
-                                                    m.record_push_success(platform_str);
+                            tokio::spawn(async move {
+                                let platform_str = match platform {
+                                    Platform::Apns => "apns",
+                                    Platform::Fcm => "fcm",
+                                };
+
+                                match platform {
+                                    Platform::Apns => {
+                                        if let Some(client) = apns_client {
+                                            match client.send(token.as_str()).await {
+                                                Ok(true) => {
+                                                    trace!("APNs notification sent");
+                                                    if let Some(ref m) = metrics {
+                                                        m.record_push_success(platform_str);
+                                                    }
                                                 }
-                                            }
-                                            Ok(false) => {
-                                                trace!("APNs notification failed (invalid token)");
-                                                if let Some(ref m) = metrics {
-                                                    m.record_push_failed(
-                                                        platform_str,
-                                                        "invalid_token",
+                                                Ok(false) => {
+                                                    trace!(
+                                                        "APNs notification failed (invalid token)"
                                                     );
+                                                    if let Some(ref m) = metrics {
+                                                        m.record_push_failed(
+                                                            platform_str,
+                                                            "invalid_token",
+                                                        );
+                                                    }
+                                                }
+                                                Err(e) => {
+                                                    debug!(error = %e, "APNs send error");
+                                                    if let Some(ref m) = metrics {
+                                                        m.record_push_failed(platform_str, "error");
+                                                    }
                                                 }
                                             }
-                                            Err(e) => {
-                                                debug!(error = %e, "APNs send error");
-                                                if let Some(ref m) = metrics {
-                                                    m.record_push_failed(platform_str, "error");
+                                        }
+                                    }
+                                    Platform::Fcm => {
+                                        if let Some(client) = fcm_client {
+                                            match client.send(token.as_str()).await {
+                                                Ok(true) => {
+                                                    trace!("FCM notification sent");
+                                                    if let Some(ref m) = metrics {
+                                                        m.record_push_success(platform_str);
+                                                    }
+                                                }
+                                                Ok(false) => {
+                                                    trace!(
+                                                        "FCM notification failed (invalid token)"
+                                                    );
+                                                    if let Some(ref m) = metrics {
+                                                        m.record_push_failed(
+                                                            platform_str,
+                                                            "invalid_token",
+                                                        );
+                                                    }
+                                                }
+                                                Err(e) => {
+                                                    debug!(error = %e, "FCM send error");
+                                                    if let Some(ref m) = metrics {
+                                                        m.record_push_failed(platform_str, "error");
+                                                    }
                                                 }
                                             }
                                         }
                                     }
                                 }
-                                Platform::Fcm => {
-                                    if let Some(ref client) = fcm_client {
-                                        match client.send(token.as_str()).await {
-                                            Ok(true) => {
-                                                trace!("FCM notification sent");
-                                                if let Some(ref m) = metrics {
-                                                    m.record_push_success(platform_str);
-                                                }
-                                            }
-                                            Ok(false) => {
-                                                trace!("FCM notification failed (invalid token)");
-                                                if let Some(ref m) = metrics {
-                                                    m.record_push_failed(
-                                                        platform_str,
-                                                        "invalid_token",
-                                                    );
-                                                }
-                                            }
-                                            Err(e) => {
-                                                debug!(error = %e, "FCM send error");
-                                                if let Some(ref m) = metrics {
-                                                    m.record_push_failed(platform_str, "error");
-                                                }
-                                            }
-                                        }
-                                    }
+                                // Token is automatically zeroed when dropped here.
+
+                                drop(permit);
+
+                                if let Some(ref m) = metrics {
+                                    m.set_push_semaphore_available(semaphore.available_permits());
                                 }
-                            }
-                            // Token is automatically zeroed when dropped here
-
-                            drop(permit);
-
-                            // Update semaphore metric after releasing permit
-                            if let Some(ref m) = metrics {
-                                m.set_push_semaphore_available(semaphore.available_permits());
-                            }
+                            });
                         }
                         Some(PushMessage::Shutdown) => {
                             debug!(worker_id, "Worker received shutdown signal");
@@ -262,6 +287,8 @@ impl PushDispatcher {
     /// callers can safely treat a successful return as "all notifications were
     /// admitted locally". Invalid tokens are silently ignored per MIP-05 spec.
     pub async fn dispatch(&self, payloads: Vec<TokenPayload>) -> Result<usize> {
+        let _admission_guard = self.admission_lock.lock().await;
+
         if self.shutting_down.load(Ordering::SeqCst) {
             debug!("Dispatcher shutting down, ignoring dispatch request");
             return Err(Error::Dispatch("Dispatcher is shutting down".to_string()));
@@ -343,10 +370,8 @@ impl PushDispatcher {
             }
         }
 
-        if let Some(ref m) = self.metrics {
-            // Update queue size after the full batch is admitted.
-            m.set_push_queue_size(MAX_PENDING_QUEUE_SIZE - self.sender.capacity());
-        }
+        // Update queue size after the full batch is admitted.
+        Self::update_queue_size_metric(&self.metrics, &self.sender);
 
         Ok(message_count)
     }
@@ -382,13 +407,17 @@ impl PushDispatcher {
     /// and then waits for all worker tasks to exit. This guarantees queued work
     /// is drained before shutdown completes.
     pub async fn wait_for_completion(&self) {
-        // Mark as shutting down to prevent new dispatches.
-        self.shutting_down.store(true, Ordering::SeqCst);
+        {
+            let _admission_guard = self.admission_lock.lock().await;
 
-        // Enqueue shutdown signals after any already-queued notifications.
-        for _ in 0..NUM_WORKERS {
-            if self.sender.send(PushMessage::Shutdown).await.is_err() {
-                break;
+            // Mark as shutting down to prevent new dispatches.
+            self.shutting_down.store(true, Ordering::SeqCst);
+
+            // Enqueue shutdown signals after any already-queued notifications.
+            for _ in 0..NUM_WORKERS {
+                if self.sender.send(PushMessage::Shutdown).await.is_err() {
+                    break;
+                }
             }
         }
 
@@ -402,6 +431,16 @@ impl PushDispatcher {
                 warn!(error = %error, "Push worker exited unexpectedly during shutdown");
             }
         }
+
+        // Wait for all spawned send tasks to finish and release their permits.
+        let mut permits = Vec::with_capacity(MAX_CONCURRENT_PUSHES);
+        for _ in 0..MAX_CONCURRENT_PUSHES {
+            match self.semaphore.acquire().await {
+                Ok(permit) => permits.push(permit),
+                Err(_) => break,
+            }
+        }
+        drop(permits);
 
         if let Some(ref m) = self.metrics {
             m.set_push_queue_size(0);
@@ -432,6 +471,21 @@ impl PushDispatcher {
 mod tests {
     use super::*;
     use std::time::Duration;
+
+    fn queue_size_metric_value(metrics: &crate::metrics::Metrics) -> i64 {
+        metrics
+            .gather()
+            .into_iter()
+            .find(|family| family.name() == "transponder_push_queue_size")
+            .and_then(|family| {
+                family
+                    .get_metric()
+                    .first()
+                    .and_then(|metric| metric.get_gauge().value)
+            })
+            .map(|value| value as i64)
+            .unwrap_or_default()
+    }
 
     #[tokio::test]
     async fn test_dispatcher_no_clients() {
@@ -665,6 +719,51 @@ mod tests {
 
         assert!(apns_dispatched, "APNs dispatch metric missing");
         assert!(fcm_dispatched, "FCM dispatch metric missing");
+    }
+
+    #[tokio::test]
+    async fn test_queue_metric_updates_after_worker_dequeue() {
+        use crate::config::ApnsConfig;
+        use crate::metrics::Metrics;
+        use crate::push::ApnsClient;
+
+        let apns_config = ApnsConfig {
+            enabled: true,
+            key_id: "KEY123".to_string(),
+            team_id: "TEAM456".to_string(),
+            private_key_path: String::new(),
+            environment: "sandbox".to_string(),
+            bundle_id: "com.example.app".to_string(),
+        };
+
+        let metrics = Metrics::default();
+        let dispatcher = PushDispatcher::with_metrics(
+            Some(ApnsClient::mock(apns_config, true)),
+            None,
+            Some(metrics.clone()),
+        );
+
+        let permits = dispatcher
+            .semaphore
+            .acquire_many(MAX_CONCURRENT_PUSHES as u32)
+            .await
+            .unwrap();
+
+        let payloads = vec![
+            TokenPayload {
+                platform: Platform::Apns,
+                device_token: vec![0xaa, 0xbb, 0xcc],
+            };
+            2
+        ];
+
+        assert_eq!(dispatcher.dispatch(payloads).await.unwrap(), 2);
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(queue_size_metric_value(&metrics), 0);
+
+        drop(permits);
+        dispatcher.wait_for_completion().await;
     }
 
     #[tokio::test]

--- a/src/push/dispatcher.rs
+++ b/src/push/dispatcher.rs
@@ -16,7 +16,7 @@
 //! from memory when no longer needed, preventing sensitive data from lingering.
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 use tokio::sync::Semaphore;
 use tokio::sync::mpsc;
@@ -71,6 +71,7 @@ pub struct PushDispatcher {
     fcm_client: Option<Arc<FcmClient>>,
     semaphore: Arc<Semaphore>,
     sender: mpsc::Sender<PushMessage>,
+    queue_depth: Arc<AtomicUsize>,
     shutting_down: Arc<AtomicBool>,
     admission_lock: tokio::sync::Mutex<()>,
     worker_handles: tokio::sync::Mutex<Vec<JoinHandle<()>>>,
@@ -98,6 +99,7 @@ impl PushDispatcher {
         let fcm_client = fcm_client.map(Arc::new);
         let semaphore = Arc::new(Semaphore::new(MAX_CONCURRENT_PUSHES));
         let (sender, receiver) = mpsc::channel(MAX_PENDING_QUEUE_SIZE);
+        let queue_depth = Arc::new(AtomicUsize::new(0));
         let shutting_down = Arc::new(AtomicBool::new(false));
 
         // Initialize semaphore metric
@@ -108,7 +110,7 @@ impl PushDispatcher {
         // Spawn worker tasks
         let worker_handles = Self::spawn_workers(
             receiver,
-            sender.clone(),
+            queue_depth.clone(),
             apns_client.clone(),
             fcm_client.clone(),
             semaphore.clone(),
@@ -120,6 +122,7 @@ impl PushDispatcher {
             fcm_client,
             semaphore,
             sender,
+            queue_depth,
             shutting_down,
             admission_lock: tokio::sync::Mutex::new(()),
             worker_handles: tokio::sync::Mutex::new(worker_handles),
@@ -127,16 +130,26 @@ impl PushDispatcher {
         }
     }
 
-    fn update_queue_size_metric(metrics: &Option<Metrics>, sender: &mpsc::Sender<PushMessage>) {
+    fn update_queue_size_metric(metrics: &Option<Metrics>, queue_depth: &AtomicUsize) {
         if let Some(metrics) = metrics {
-            metrics.set_push_queue_size(MAX_PENDING_QUEUE_SIZE - sender.capacity());
+            metrics.set_push_queue_size(queue_depth.load(Ordering::SeqCst));
         }
+    }
+
+    fn increment_queue_depth(queue_depth: &AtomicUsize, count: usize) {
+        queue_depth.fetch_add(count, Ordering::SeqCst);
+    }
+
+    fn decrement_queue_depth(queue_depth: &AtomicUsize) {
+        let _ = queue_depth.fetch_update(Ordering::SeqCst, Ordering::SeqCst, |current| {
+            current.checked_sub(1)
+        });
     }
 
     /// Spawn worker tasks that process the push queue.
     fn spawn_workers(
         receiver: mpsc::Receiver<PushMessage>,
-        sender: mpsc::Sender<PushMessage>,
+        queue_depth: Arc<AtomicUsize>,
         apns_client: Option<Arc<ApnsClient>>,
         fcm_client: Option<Arc<FcmClient>>,
         semaphore: Arc<Semaphore>,
@@ -148,7 +161,7 @@ impl PushDispatcher {
 
         for worker_id in 0..NUM_WORKERS {
             let receiver = receiver.clone();
-            let sender = sender.clone();
+            let queue_depth = queue_depth.clone();
             let apns_client = apns_client.clone();
             let fcm_client = fcm_client.clone();
             let semaphore = semaphore.clone();
@@ -162,12 +175,11 @@ impl PushDispatcher {
                         rx.recv().await
                     };
 
-                    if msg.is_some() {
-                        Self::update_queue_size_metric(&metrics, &sender);
-                    }
-
                     match msg {
                         Some(PushMessage::Send { platform, token }) => {
+                            Self::decrement_queue_depth(&queue_depth);
+                            Self::update_queue_size_metric(&metrics, &queue_depth);
+
                             // Acquire semaphore permit before spawning the send task.
                             let permit = match semaphore.clone().acquire_owned().await {
                                 Ok(p) => p,
@@ -370,8 +382,9 @@ impl PushDispatcher {
             }
         }
 
+        Self::increment_queue_depth(&self.queue_depth, message_count);
         // Update queue size after the full batch is admitted.
-        Self::update_queue_size_metric(&self.metrics, &self.sender);
+        Self::update_queue_size_metric(&self.metrics, &self.queue_depth);
 
         Ok(message_count)
     }
@@ -442,6 +455,7 @@ impl PushDispatcher {
         }
         drop(permits);
 
+        self.queue_depth.store(0, Ordering::SeqCst);
         if let Some(ref m) = self.metrics {
             m.set_push_queue_size(0);
             m.set_push_semaphore_available(self.semaphore.available_permits());

--- a/src/push/dispatcher.rs
+++ b/src/push/dispatcher.rs
@@ -24,6 +24,7 @@ use tracing::{debug, trace, warn};
 use zeroize::Zeroizing;
 
 use crate::crypto::{Platform, TokenPayload};
+use crate::error::{Error, Result};
 use crate::metrics::Metrics;
 use crate::push::{ApnsClient, FcmClient};
 
@@ -53,6 +54,11 @@ enum PushMessage {
     },
     /// Shutdown signal for workers.
     Shutdown,
+}
+
+struct QueuedPushMessage {
+    platform: Platform,
+    token: Zeroizing<String>,
 }
 
 /// Push notification dispatcher.
@@ -262,14 +268,17 @@ impl PushDispatcher {
 
     /// Dispatch push notifications for all payloads.
     ///
-    /// This queues notifications for processing by worker tasks. If the queue
-    /// is full, notifications are dropped to prevent unbounded memory growth.
-    /// Invalid tokens are silently ignored per MIP-05 spec.
-    pub async fn dispatch(&self, payloads: Vec<TokenPayload>) {
+    /// This queues notifications for processing by worker tasks. The batch is
+    /// only accepted if enough queue capacity exists for all notifications, so
+    /// callers can safely treat a successful return as "all notifications were
+    /// admitted locally". Invalid tokens are silently ignored per MIP-05 spec.
+    pub async fn dispatch(&self, payloads: Vec<TokenPayload>) -> Result<usize> {
         if self.shutting_down.load(Ordering::SeqCst) {
             debug!("Dispatcher shutting down, ignoring dispatch request");
-            return;
+            return Err(Error::Dispatch("Dispatcher is shutting down".to_string()));
         }
+
+        let mut messages = Vec::with_capacity(payloads.len());
 
         for payload in payloads {
             // Extract token as Zeroizing<String> for automatic cleanup
@@ -298,36 +307,59 @@ impl PushDispatcher {
             // Note: payload (TokenPayload) is automatically zeroed when dropped here
             // due to its ZeroizeOnDrop implementation
 
-            let platform_str = match platform {
+            messages.push(QueuedPushMessage { platform, token });
+        }
+
+        if messages.is_empty() {
+            return Ok(0);
+        }
+
+        let message_count = messages.len();
+        let mut permits =
+            self.sender
+                .try_reserve_many(message_count)
+                .map_err(|error| match error {
+                    mpsc::error::TrySendError::Full(_) => {
+                        warn!(
+                            requested = message_count,
+                            available = self.sender.capacity(),
+                            "Push queue full, rejecting notification batch"
+                        );
+                        Error::Dispatch(format!(
+                            "Push queue full: unable to queue {message_count} notifications"
+                        ))
+                    }
+                    mpsc::error::TrySendError::Closed(_) => {
+                        warn!("Push queue closed, rejecting notification batch");
+                        Error::Dispatch("Push queue closed".to_string())
+                    }
+                })?;
+
+        for message in messages {
+            let platform_str = match message.platform {
                 Platform::Apns => "apns",
                 Platform::Fcm => "fcm",
             };
 
-            // Try to send to the bounded queue
-            match self.sender.try_send(PushMessage::Send { platform, token }) {
-                Ok(()) => {
-                    // Successfully queued - record metric
-                    if let Some(ref m) = self.metrics {
-                        m.record_push_dispatched(platform_str);
-                        // Update queue size (approximate - capacity minus available)
-                        // tokio::mpsc::Sender::capacity() returns available permits
-                        m.set_push_queue_size(MAX_PENDING_QUEUE_SIZE - self.sender.capacity());
-                    }
-                }
-                Err(mpsc::error::TrySendError::Full(_)) => {
-                    // Token is automatically zeroed when dropped here
-                    warn!("Push queue full, dropping notification (DoS protection)");
-                    if let Some(ref m) = self.metrics {
-                        m.record_push_queue_dropped();
-                    }
-                }
-                Err(mpsc::error::TrySendError::Closed(_)) => {
-                    // Token is automatically zeroed when dropped here
-                    warn!("Push queue closed, dropping notification");
-                    break;
-                }
+            let permit = permits
+                .next()
+                .expect("reserved permits should match queued message count");
+            permit.send(PushMessage::Send {
+                platform: message.platform,
+                token: message.token,
+            });
+
+            if let Some(ref m) = self.metrics {
+                m.record_push_dispatched(platform_str);
             }
         }
+
+        if let Some(ref m) = self.metrics {
+            // Update queue size after the full batch is admitted.
+            m.set_push_queue_size(MAX_PENDING_QUEUE_SIZE - self.sender.capacity());
+        }
+
+        Ok(message_count)
     }
 
     /// Check if APNs is configured and ready.
@@ -418,7 +450,7 @@ mod tests {
         let dispatcher = PushDispatcher::new(None, None);
 
         // Should not panic with empty payloads
-        dispatcher.dispatch(vec![]).await;
+        assert_eq!(dispatcher.dispatch(vec![]).await.unwrap(), 0);
     }
 
     #[tokio::test]
@@ -437,7 +469,7 @@ mod tests {
         ];
 
         // Should not panic - just skips notifications
-        dispatcher.dispatch(payloads).await;
+        assert_eq!(dispatcher.dispatch(payloads).await.unwrap(), 0);
     }
 
     #[tokio::test]
@@ -512,7 +544,7 @@ mod tests {
             device_token: vec![0xaa, 0xbb, 0xcc],
         }];
 
-        dispatcher.dispatch(payloads).await;
+        assert_eq!(dispatcher.dispatch(payloads).await.unwrap(), 0);
         // Should not panic, just skip the notification
     }
 
@@ -539,7 +571,7 @@ mod tests {
             device_token: b"fcm-token-123".to_vec(),
         }];
 
-        dispatcher.dispatch(payloads).await;
+        assert_eq!(dispatcher.dispatch(payloads).await.unwrap(), 0);
         // Should not panic, just skip the notification
     }
 
@@ -562,7 +594,7 @@ mod tests {
             device_token: vec![0xff, 0xfe, 0x00, 0x01], // Invalid UTF-8
         }];
 
-        dispatcher.dispatch(payloads).await;
+        assert_eq!(dispatcher.dispatch(payloads).await.unwrap(), 0);
         // Should not panic, just skip the notification
     }
 
@@ -608,7 +640,7 @@ mod tests {
             },
         ];
 
-        dispatcher.dispatch(payloads).await;
+        assert_eq!(dispatcher.dispatch(payloads).await.unwrap(), 2);
         // Tasks are spawned - give them time to start
         tokio::time::sleep(Duration::from_millis(50)).await;
 
@@ -729,8 +761,8 @@ mod tests {
             device_token: vec![0xaa, 0xbb, 0xcc],
         }];
 
-        dispatcher.dispatch(payloads).await;
-        // Should not panic, just ignore
+        let error = dispatcher.dispatch(payloads).await.unwrap_err();
+        assert!(matches!(error, Error::Dispatch(_)));
     }
 
     #[tokio::test]
@@ -753,5 +785,34 @@ mod tests {
         // The queue should be bounded
         assert!(dispatcher.queue_capacity() <= MAX_PENDING_QUEUE_SIZE);
         assert_eq!(dispatcher.max_queue_size(), MAX_PENDING_QUEUE_SIZE);
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_rejects_batch_larger_than_queue() {
+        use crate::config::ApnsConfig;
+        use crate::push::ApnsClient;
+
+        let apns_config = ApnsConfig {
+            enabled: true,
+            key_id: "KEY123".to_string(),
+            team_id: "TEAM456".to_string(),
+            private_key_path: String::new(),
+            environment: "sandbox".to_string(),
+            bundle_id: "com.example.app".to_string(),
+        };
+        let apns_client = ApnsClient::mock(apns_config, true);
+        let dispatcher = PushDispatcher::new(Some(apns_client), None);
+
+        let payloads = vec![
+            TokenPayload {
+                platform: Platform::Apns,
+                device_token: vec![0xaa, 0xbb, 0xcc],
+            };
+            MAX_PENDING_QUEUE_SIZE + 1
+        ];
+
+        let error = dispatcher.dispatch(payloads).await.unwrap_err();
+
+        assert!(matches!(error, Error::Dispatch(message) if message.contains("Push queue full")));
     }
 }

--- a/src/push/fcm.rs
+++ b/src/push/fcm.rs
@@ -279,6 +279,31 @@ impl FcmClient {
         .await
     }
 
+    fn build_request(
+        &self,
+        url: &str,
+        access_token: &str,
+        device_token: &str,
+    ) -> reqwest::RequestBuilder {
+        let mut data = std::collections::HashMap::new();
+        data.insert("content_available".to_string(), "true".to_string());
+
+        let request = FcmRequest {
+            message: FcmMessage {
+                token: device_token.to_string(),
+                android: Some(AndroidConfig {
+                    priority: "high".to_string(),
+                }),
+                data: Some(data),
+            },
+        };
+
+        self.http_client
+            .post(url)
+            .header("authorization", format!("Bearer {access_token}"))
+            .json(&request)
+    }
+
     /// Send a single push notification attempt without retry.
     ///
     /// Returns a `SendAttemptResult` indicating success, retriable error, or permanent error.
@@ -295,29 +320,22 @@ impl FcmClient {
             Err(e) => return SendAttemptResult::Permanent(e),
         };
 
-        let mut data = std::collections::HashMap::new();
-        data.insert("content_available".to_string(), "true".to_string());
-
-        let request = FcmRequest {
-            message: FcmMessage {
-                token: device_token.to_string(),
-                android: Some(AndroidConfig {
-                    priority: "high".to_string(),
-                }),
-                data: Some(data),
+        let transport_retry = RetryConfig::default();
+        let response = match retry::with_transport_retry(
+            &transport_retry,
+            "FCM",
+            || async {
+                self.build_request(&url, &access_token, device_token)
+                    .send()
+                    .await
+                    .map_err(Error::from)
             },
-        };
-
-        let response = match self
-            .http_client
-            .post(&url)
-            .header("authorization", format!("Bearer {access_token}"))
-            .json(&request)
-            .send()
-            .await
+            self.metrics.as_ref(),
+        )
+        .await
         {
             Ok(r) => r,
-            Err(e) => return SendAttemptResult::Permanent(Error::from(e)),
+            Err(e) => return SendAttemptResult::Permanent(e),
         };
 
         let status = response.status();

--- a/src/push/fcm.rs
+++ b/src/push/fcm.rs
@@ -320,7 +320,10 @@ impl FcmClient {
             Err(e) => return SendAttemptResult::Permanent(e),
         };
 
-        let transport_retry = RetryConfig::default();
+        let transport_retry = RetryConfig {
+            max_retries: 1,
+            ..RetryConfig::default()
+        };
         let response = match retry::with_transport_retry(
             &transport_retry,
             "FCM",

--- a/src/push/retry.rs
+++ b/src/push/retry.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 use tokio::time::sleep;
 use tracing::warn;
 
+use crate::error::Error;
 use crate::metrics::Metrics;
 
 /// Default maximum number of retry attempts.
@@ -115,6 +116,60 @@ where
     }
 }
 
+/// Execute an async transport operation with exponential backoff retry.
+///
+/// Only `Error::Http` failures are retried. The last transport error is
+/// returned once the retry budget is exhausted.
+#[must_use = "retry result indicates success/failure and should not be ignored"]
+pub async fn with_transport_retry<T, F, Fut>(
+    config: &RetryConfig,
+    service_name: &str,
+    mut operation: F,
+    metrics: Option<&Metrics>,
+) -> crate::error::Result<T>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = crate::error::Result<T>>,
+{
+    let mut retries = 0;
+    let mut backoff = config.initial_backoff;
+
+    loop {
+        match operation().await {
+            Ok(result) => return Ok(result),
+            Err(Error::Http(error)) if retries < config.max_retries => {
+                retries += 1;
+
+                if let Some(metrics) = metrics {
+                    metrics.record_push_retry(service_name.to_lowercase().as_str());
+                }
+
+                warn!(
+                    service = service_name,
+                    error = %error,
+                    retry = retries,
+                    max_retries = config.max_retries,
+                    backoff_ms = backoff.as_millis() as u64,
+                    "Retrying push transport error"
+                );
+
+                sleep(backoff).await;
+                backoff = (backoff * 2).min(MAX_BACKOFF);
+            }
+            Err(Error::Http(error)) => {
+                warn!(
+                    service = service_name,
+                    error = %error,
+                    retries = retries,
+                    "Max retries exceeded for push transport error"
+                );
+                return Err(Error::Http(error));
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
 /// Parse a Retry-After header value into a Duration.
 ///
 /// Supports both delay-seconds format (e.g., "120") and HTTP-date format.
@@ -136,6 +191,7 @@ pub fn parse_retry_after(header_value: Option<&str>) -> Option<Duration> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use reqwest::Client;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicU32, Ordering};
 
@@ -378,5 +434,70 @@ mod tests {
         // Verify metrics were recorded - gather metrics and check they're non-empty
         let families = metrics.registry.gather();
         assert!(!families.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_with_transport_retry_success_after_retries() {
+        let config = RetryConfig {
+            max_retries: 3,
+            initial_backoff: Duration::from_millis(1),
+        };
+        let attempt_count = Arc::new(AtomicU32::new(0));
+        let attempt_count_clone = attempt_count.clone();
+        let client = Client::new();
+
+        let result: crate::error::Result<bool> = with_transport_retry(
+            &config,
+            "test",
+            || {
+                let count = attempt_count_clone.clone();
+                let client = client.clone();
+                async move {
+                    let attempts = count.fetch_add(1, Ordering::SeqCst);
+                    if attempts < 2 {
+                        let error = client.get("http://127.0.0.1:9").send().await.unwrap_err();
+                        Err(Error::from(error))
+                    } else {
+                        Ok(true)
+                    }
+                }
+            },
+            None,
+        )
+        .await;
+
+        assert!(result.is_ok());
+        assert!(result.unwrap());
+        assert_eq!(attempt_count.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn test_with_transport_retry_exhausts_retries() {
+        let config = RetryConfig {
+            max_retries: 2,
+            initial_backoff: Duration::from_millis(1),
+        };
+        let attempt_count = Arc::new(AtomicU32::new(0));
+        let attempt_count_clone = attempt_count.clone();
+        let client = Client::new();
+
+        let result: crate::error::Result<bool> = with_transport_retry(
+            &config,
+            "test",
+            || {
+                let count = attempt_count_clone.clone();
+                let client = client.clone();
+                async move {
+                    count.fetch_add(1, Ordering::SeqCst);
+                    let error = client.get("http://127.0.0.1:9").send().await.unwrap_err();
+                    Err(Error::from(error))
+                }
+            },
+            None,
+        )
+        .await;
+
+        assert!(matches!(result, Err(Error::Http(_))));
+        assert_eq!(attempt_count.load(Ordering::SeqCst), 3);
     }
 }

--- a/src/test_vectors.rs
+++ b/src/test_vectors.rs
@@ -9,7 +9,7 @@
 //! event processing pipeline from relay receipt to push dispatch.
 
 use ::hkdf::Hkdf;
-use ::secp256k1::{PublicKey, Secp256k1, SecretKey};
+use ::secp256k1::{Parity, PublicKey, Secp256k1, SecretKey, XOnlyPublicKey};
 use base64::prelude::*;
 use chacha20poly1305::{
     ChaCha20Poly1305, Nonce,
@@ -28,6 +28,14 @@ const HKDF_INFO: &[u8] = b"mip05-token-encryption";
 
 /// Kind for MIP-05 notification requests.
 pub const KIND_NOTIFICATION_REQUEST: u16 = 446;
+
+const TOKEN_PLAINTEXT_SIZE: usize = 220;
+const APNS_DEVICE_TOKEN_SIZE: usize = 32;
+const MAX_FCM_DEVICE_TOKEN_SIZE: usize = 200;
+const TAG_VERSION: &str = "v";
+const TAG_ENCODING: &str = "encoding";
+const VERSION_MIP05_V1: &str = "mip05-v1";
+const ENCODING_BASE64: &str = "base64";
 
 /// A test token that can be encrypted for the server.
 #[derive(Debug, Clone)]
@@ -81,26 +89,30 @@ impl TestToken {
         }
     }
 
-    /// Get the plaintext payload with PKCS#7 padding.
+    /// Get the fixed-size token plaintext used by MIP-05.
     ///
-    /// Format: platform_byte || device_token || pkcs7_padding
-    /// Padded to 219 bytes (the expected plaintext size for MIP-05).
-    fn to_padded_payload(&self) -> Vec<u8> {
-        const PAYLOAD_SIZE: usize = 219; // Expected plaintext size
+    /// Format: platform || token_length || device_token || random_padding
+    fn to_plaintext(&self) -> Vec<u8> {
+        match self.platform {
+            PLATFORM_APNS => assert_eq!(
+                self.device_token.len(),
+                APNS_DEVICE_TOKEN_SIZE,
+                "APNs token must be 32 bytes"
+            ),
+            PLATFORM_FCM => assert!(
+                (1..=MAX_FCM_DEVICE_TOKEN_SIZE).contains(&self.device_token.len()),
+                "FCM token must be 1..=200 bytes"
+            ),
+            _ => panic!("unsupported test platform"),
+        }
 
-        let mut payload = Vec::with_capacity(PAYLOAD_SIZE);
-        payload.push(self.platform);
-        payload.extend_from_slice(&self.device_token);
-
-        // Add PKCS#7 padding
-        let padding_len = PAYLOAD_SIZE - payload.len();
-        assert!(
-            padding_len > 0 && padding_len <= 255,
-            "Token too large for payload"
-        );
-        payload.resize(PAYLOAD_SIZE, padding_len as u8);
-
-        payload
+        let token_length = self.device_token.len();
+        let mut plaintext = vec![0u8; TOKEN_PLAINTEXT_SIZE];
+        plaintext[0] = self.platform;
+        plaintext[1..3].copy_from_slice(&(token_length as u16).to_be_bytes());
+        plaintext[3..(3 + token_length)].copy_from_slice(&self.device_token);
+        getrandom::fill(&mut plaintext[(3 + token_length)..]).expect("random bytes");
+        plaintext
     }
 }
 
@@ -127,12 +139,9 @@ impl TokenEncryptor {
     /// Create from a server's nostr Keys.
     #[must_use]
     pub fn from_keys(keys: &Keys) -> Self {
-        let pubkey_bytes = keys.public_key().to_bytes();
-        // Convert x-only pubkey to compressed pubkey (assume even y)
-        let mut compressed = [0u8; 33];
-        compressed[0] = 0x02; // Even y-coordinate prefix
-        compressed[1..].copy_from_slice(&pubkey_bytes);
-        let server_pubkey = PublicKey::from_slice(&compressed).expect("valid pubkey");
+        let xonly =
+            XOnlyPublicKey::from_slice(&keys.public_key().to_bytes()).expect("valid pubkey");
+        let server_pubkey = PublicKey::from_x_only_public_key(xonly, Parity::Even);
         Self::new(server_pubkey)
     }
 
@@ -146,6 +155,7 @@ impl TokenEncryptor {
         let ephemeral_secret =
             SecretKey::from_slice(&ephemeral_secret_bytes).expect("valid secret key");
         let ephemeral_pubkey = PublicKey::from_secret_key(&self.secp, &ephemeral_secret);
+        let ephemeral_xonly = XOnlyPublicKey::from(ephemeral_pubkey);
 
         // Perform ECDH to get shared secret
         let shared_point =
@@ -165,16 +175,16 @@ impl TokenEncryptor {
 
         // Encrypt using ChaCha20-Poly1305
         let cipher = ChaCha20Poly1305::new_from_slice(&encryption_key).expect("valid key size");
-        let plaintext = token.to_padded_payload();
+        let plaintext = token.to_plaintext();
         let ciphertext = cipher
             .encrypt(nonce, plaintext.as_ref())
             .expect("encryption should not fail");
 
         // Assemble encrypted token: ephemeral_pubkey || nonce || ciphertext
         let mut encrypted = Vec::with_capacity(ENCRYPTED_TOKEN_SIZE);
-        encrypted.extend_from_slice(&ephemeral_pubkey.serialize()); // 33 bytes
+        encrypted.extend_from_slice(&ephemeral_xonly.serialize()); // 32 bytes
         encrypted.extend_from_slice(&nonce_bytes); // 12 bytes
-        encrypted.extend_from_slice(&ciphertext); // 235 bytes (219 + 16 tag)
+        encrypted.extend_from_slice(&ciphertext); // 236 bytes (220 + 16 tag)
 
         assert_eq!(encrypted.len(), ENCRYPTED_TOKEN_SIZE);
         encrypted
@@ -188,10 +198,10 @@ impl TokenEncryptor {
 
 /// Builder for creating kind 446 notification request content.
 ///
-/// The content is a JSON array of base64-encoded encrypted tokens.
+/// The content is one base64 string of concatenated encrypted tokens.
 pub struct NotificationContentBuilder {
     encryptor: TokenEncryptor,
-    tokens: Vec<String>,
+    tokens: Vec<Vec<u8>>,
 }
 
 #[allow(dead_code)]
@@ -209,7 +219,7 @@ impl NotificationContentBuilder {
     #[must_use]
     pub fn with_apns_token(mut self, device_token_hex: &str) -> Self {
         let token = TestToken::apns(device_token_hex);
-        self.tokens.push(self.encryptor.encrypt_base64(&token));
+        self.tokens.push(self.encryptor.encrypt(&token));
         self
     }
 
@@ -217,7 +227,7 @@ impl NotificationContentBuilder {
     #[must_use]
     pub fn with_random_apns_token(mut self) -> Self {
         let token = TestToken::apns_random();
-        self.tokens.push(self.encryptor.encrypt_base64(&token));
+        self.tokens.push(self.encryptor.encrypt(&token));
         self
     }
 
@@ -225,7 +235,7 @@ impl NotificationContentBuilder {
     #[must_use]
     pub fn with_fcm_token(mut self, device_token: &str) -> Self {
         let token = TestToken::fcm(device_token);
-        self.tokens.push(self.encryptor.encrypt_base64(&token));
+        self.tokens.push(self.encryptor.encrypt(&token));
         self
     }
 
@@ -233,21 +243,30 @@ impl NotificationContentBuilder {
     #[must_use]
     pub fn with_random_fcm_token(mut self) -> Self {
         let token = TestToken::fcm_random();
-        self.tokens.push(self.encryptor.encrypt_base64(&token));
+        self.tokens.push(self.encryptor.encrypt(&token));
         self
     }
 
     /// Add a pre-encrypted token (base64 encoded).
     #[must_use]
     pub fn with_raw_token(mut self, base64_token: String) -> Self {
-        self.tokens.push(base64_token);
+        let token = BASE64_STANDARD
+            .decode(base64_token)
+            .expect("pre-encrypted token should be valid base64");
+        assert_eq!(
+            token.len(),
+            ENCRYPTED_TOKEN_SIZE,
+            "token should be 280 bytes"
+        );
+        self.tokens.push(token);
         self
     }
 
-    /// Build the JSON content string.
+    /// Build the base64 content string.
     #[must_use]
     pub fn build(self) -> String {
-        serde_json::to_string(&self.tokens).expect("serialization should not fail")
+        let concatenated: Vec<u8> = self.tokens.into_iter().flatten().collect();
+        BASE64_STANDARD.encode(concatenated)
     }
 }
 
@@ -280,10 +299,14 @@ impl GiftWrapBuilder {
     /// Build a gift-wrapped notification request event.
     ///
     /// # Arguments
-    /// * `content` - The JSON content (array of base64-encoded encrypted tokens)
+    /// * `content` - The base64 content (concatenated encrypted tokens)
     pub async fn build(&self, content: &str) -> Event {
         // Create the kind 446 rumor (unsigned event)
-        let rumor_builder = EventBuilder::new(Kind::Custom(KIND_NOTIFICATION_REQUEST), content);
+        let rumor_builder = EventBuilder::new(Kind::Custom(KIND_NOTIFICATION_REQUEST), content)
+            .tags([
+                Tag::parse([TAG_VERSION, VERSION_MIP05_V1]).expect("valid version tag"),
+                Tag::parse([TAG_ENCODING, ENCODING_BASE64]).expect("valid encoding tag"),
+            ]);
 
         // Build the unsigned event (rumor)
         let rumor = rumor_builder.build(self.sender_keys.public_key());
@@ -303,9 +326,13 @@ impl GiftWrapBuilder {
     /// Build a gift-wrapped notification request with the given tokens.
     pub async fn build_with_tokens(&self, tokens: Vec<TestToken>) -> Event {
         let encryptor = TokenEncryptor::from_keys(&self.server_keys);
-        let token_strings: Vec<String> =
-            tokens.iter().map(|t| encryptor.encrypt_base64(t)).collect();
-        let content = serde_json::to_string(&token_strings).expect("serialization");
+        let content = tokens
+            .into_iter()
+            .fold(
+                NotificationContentBuilder::new(&self.server_keys),
+                |builder, token| builder.with_raw_token(encryptor.encrypt_base64(&token)),
+            )
+            .build();
         self.build(&content).await
     }
 }
@@ -358,9 +385,9 @@ pub mod scenarios {
             .await
     }
 
-    /// Create a notification with an empty token array.
+    /// Create a notification with an empty token blob.
     pub async fn empty_notification(server_keys: &Keys, sender_keys: &Keys) -> Event {
-        let content = "[]";
+        let content = "";
 
         GiftWrapBuilder::new(server_keys.clone(), sender_keys.clone())
             .build(content)
@@ -383,7 +410,8 @@ mod tests {
         let encryptor = TokenEncryptor::from_keys(&server_keys);
 
         // Create and encrypt a test token
-        let test_token = TestToken::apns("deadbeef1234567890abcdef");
+        let test_token =
+            TestToken::apns("deadbeef1234567890abcdefdeadbeef1234567890abcdefdeadbeef12345678");
         let encrypted = encryptor.encrypt(&test_token);
 
         // Verify size
@@ -419,19 +447,12 @@ mod tests {
         let server_keys = Keys::generate();
 
         let content = NotificationContentBuilder::new(&server_keys)
-            .with_apns_token("aabbccdd")
+            .with_apns_token("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff")
             .with_fcm_token("fcm-token")
             .build();
 
-        // Should be valid JSON array
-        let parsed: Vec<String> = serde_json::from_str(&content).unwrap();
-        assert_eq!(parsed.len(), 2);
-
-        // Each token should be valid base64
-        for token_b64 in &parsed {
-            let decoded = BASE64_STANDARD.decode(token_b64).unwrap();
-            assert_eq!(decoded.len(), ENCRYPTED_TOKEN_SIZE);
-        }
+        let decoded = BASE64_STANDARD.decode(&content).unwrap();
+        assert_eq!(decoded.len(), ENCRYPTED_TOKEN_SIZE * 2);
     }
 
     #[tokio::test]
@@ -464,7 +485,7 @@ mod tests {
 
         // Create notification content
         let content = NotificationContentBuilder::new(&server_keys)
-            .with_apns_token("deadbeef")
+            .with_apns_token("deadbeef1234567890abcdefdeadbeef1234567890abcdefdeadbeef12345678")
             .build();
 
         // Create gift wrap
@@ -491,7 +512,7 @@ mod tests {
 
         let server_keys = Keys::generate();
         let sender_keys = Keys::generate();
-        let device_token_hex = "0123456789abcdef0123456789abcdef";
+        let device_token_hex = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
         // Create gift-wrapped notification
         let gift_wrap =


### PR DESCRIPTION
## Summary
- align Transponder with the current MIP-05 PR #61 rumor and token formats, including required `v` and `encoding` tag validation
- keep relay ingestion alive after lagged broadcast notifications instead of stopping the event loop
- make push queue admission explicit, drain queued notifications on shutdown, and scale worker throughput to the configured concurrency limit
- retry transient APNs and FCM transport failures and remove the obsolete queue-drop metric

## Testing
- cargo fmt
- cargo test --quiet
- cargo clippy -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transport retry with exponential backoff for push sends.
  * Batch-based dispatch atomically accepts/rejects whole batches and returns admitted counts.
  * Centralized APNs/FCM request builders; queue-depth tracking and stronger shutdown/drain guarantees.

* **Bug Fixes**
  * Better error classification for receive errors; explicit dispatch error reporting.

* **Chores**
  * Notification content now uses a single base64 blob with version/encoding tags.
  * Token format and device-token length validation updated; removed old padding handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->