### PR TITLE
Add event pipeline observability metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ Label values: `type` = `encrypted_token` or `device_token`; `reason` = `minute` 
 | `transponder_push_queue_capacity` | Gauge | - | Maximum number of notifications the push queue can hold |
 | `transponder_push_semaphore_available` | Gauge | - | Available concurrent push permits |
 | `transponder_push_concurrency_limit` | Gauge | - | Maximum number of concurrent outbound push requests |
-| `transponder_push_queue_rejected_total` | Counter | - | Notifications rejected before admission because the push queue was full, closed, or shutting down |
+| `transponder_push_queue_rejected_total` | Counter | - | Notifications rejected before admission because the push queue was full, the dispatcher was shutting down, or the queue channel was closed |
 | `transponder_push_dispatch_admission_duration_seconds` | Histogram | `outcome` | Time spent admitting notifications into the push dispatcher |
 | `transponder_push_retries_total` | Counter | `platform` | Push retry attempts |
 | `transponder_push_request_duration_seconds` | Histogram | `platform` | Push request duration |

--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ Transponder exposes Prometheus metrics at `/metrics` on the health server port (
 | `transponder_gift_wrap_unwrap_duration_seconds` | Histogram | `outcome` | Duration of NIP-59 gift-wrap unwraps |
 | `transponder_notification_parse_duration_seconds` | Histogram | `outcome` | Duration of notification tag validation, base64 decode, and token splitting |
 | `transponder_tokens_per_event` | Histogram | - | Number of encrypted tokens carried by each parsed event |
-| `transponder_notification_content_size_bytes` | Histogram | - | Decoded size in bytes of kind 446 notification content |
+| `transponder_notification_content_size_bytes` | Histogram | - | Size in bytes of the base64-decoded encrypted token blob from kind 446 notification content |
 | `transponder_dedup_cache_size` | Gauge | - | Current deduplication cache size |
 | `transponder_dedup_cache_evictions_total` | Counter | - | Total dedup cache evictions |
 | `transponder_tokens_decrypted_total` | Counter | - | Total tokens successfully decrypted |

--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ Transponder exposes Prometheus metrics at `/metrics` on the health server port (
 | `transponder_gift_wrap_unwrap_duration_seconds` | Histogram | `outcome` | Duration of NIP-59 gift-wrap unwraps |
 | `transponder_notification_parse_duration_seconds` | Histogram | `outcome` | Duration of notification tag validation, base64 decode, and token splitting |
 | `transponder_tokens_per_event` | Histogram | - | Number of encrypted tokens carried by each parsed event |
-| `transponder_notification_content_size_bytes` | Histogram | - | Size of kind 446 notification content before base64 decoding |
+| `transponder_notification_content_size_bytes` | Histogram | - | Decoded size in bytes of kind 446 notification content |
 | `transponder_dedup_cache_size` | Gauge | - | Current deduplication cache size |
 | `transponder_dedup_cache_evictions_total` | Counter | - | Total dedup cache evictions |
 | `transponder_tokens_decrypted_total` | Counter | - | Total tokens successfully decrypted |
@@ -362,7 +362,11 @@ Transponder exposes Prometheus metrics at `/metrics` on the health server port (
 | `transponder_rate_limit_cache_size` | Gauge | `type` | Current rate limit cache size |
 | `transponder_rate_limit_evictions_total` | Counter | `type` | Rate limit cache evictions |
 
-Label values: `type` = `encrypted_token` or `device_token`; `reason` = `minute` or `hour`; `outcome` = `success`, `failed`, `processed`, or `duplicate`
+Label values: `type` = `encrypted_token` or `device_token`; `reason` = `minute` or `hour`
+
+`outcome` values vary by metric group:
+- Event processing: `processed`, `duplicate`, `failed`
+- Gift-wrap unwrap, notification parse, token decrypt, and push admission: `success`, `failed`
 
 #### Push Notifications
 

--- a/README.md
+++ b/README.md
@@ -335,16 +335,24 @@ Transponder exposes Prometheus metrics at `/metrics` on the health server port (
 
 #### Event Processing
 
-| Metric | Type | Description |
-|--------|------|-------------|
-| `transponder_events_received_total` | Counter | Total events received from relays |
-| `transponder_events_processed_total` | Counter | Total events successfully processed |
-| `transponder_events_deduplicated_total` | Counter | Total events skipped (already processed) |
-| `transponder_events_failed_total` | Counter | Total events that failed processing |
-| `transponder_dedup_cache_size` | Gauge | Current deduplication cache size |
-| `transponder_dedup_cache_evictions_total` | Counter | Total dedup cache evictions |
-| `transponder_tokens_decrypted_total` | Counter | Total tokens successfully decrypted |
-| `transponder_tokens_decryption_failed_total` | Counter | Total token decryption failures |
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `transponder_events_received_total` | Counter | - | Total events received from relays |
+| `transponder_events_processed_total` | Counter | - | Total events successfully processed |
+| `transponder_events_deduplicated_total` | Counter | - | Total events skipped (already processed) |
+| `transponder_events_failed_total` | Counter | - | Total events that failed processing |
+| `transponder_events_in_flight` | Gauge | - | Current number of events actively being processed |
+| `transponder_event_processing_duration_seconds` | Histogram | `outcome` | End-to-end duration of event processing |
+| `transponder_gift_wrap_unwrap_duration_seconds` | Histogram | `outcome` | Duration of NIP-59 gift-wrap unwraps |
+| `transponder_notification_parse_duration_seconds` | Histogram | `outcome` | Duration of notification tag validation, base64 decode, and token splitting |
+| `transponder_tokens_per_event` | Histogram | - | Number of encrypted tokens carried by each parsed event |
+| `transponder_notification_content_size_bytes` | Histogram | - | Size of kind 446 notification content before base64 decoding |
+| `transponder_dedup_cache_size` | Gauge | - | Current deduplication cache size |
+| `transponder_dedup_cache_evictions_total` | Counter | - | Total dedup cache evictions |
+| `transponder_tokens_decrypted_total` | Counter | - | Total tokens successfully decrypted |
+| `transponder_tokens_decryption_failed_total` | Counter | - | Total token decryption failures |
+| `transponder_token_decrypt_duration_seconds` | Histogram | `outcome` | Duration of individual token decrypt operations |
+| `transponder_notifications_admitted_per_event` | Histogram | - | Number of notifications admitted to the push dispatcher per event |
 
 #### Token Rate Limiting
 
@@ -354,7 +362,7 @@ Transponder exposes Prometheus metrics at `/metrics` on the health server port (
 | `transponder_rate_limit_cache_size` | Gauge | `type` | Current rate limit cache size |
 | `transponder_rate_limit_evictions_total` | Counter | `type` | Rate limit cache evictions |
 
-Label values: `type` = `encrypted_token` or `device_token`; `reason` = `minute` or `hour`
+Label values: `type` = `encrypted_token` or `device_token`; `reason` = `minute` or `hour`; `outcome` = `success`, `failed`, `processed`, or `duplicate`
 
 #### Push Notifications
 
@@ -364,8 +372,11 @@ Label values: `type` = `encrypted_token` or `device_token`; `reason` = `minute` 
 | `transponder_push_success_total` | Counter | `platform` | Successful push notifications |
 | `transponder_push_failed_total` | Counter | `platform`, `reason` | Failed push notifications |
 | `transponder_push_queue_size` | Gauge | - | Current push queue size |
-| `transponder_push_queue_dropped_total` | Counter | - | Notifications dropped (queue full) |
+| `transponder_push_queue_capacity` | Gauge | - | Maximum number of notifications the push queue can hold |
 | `transponder_push_semaphore_available` | Gauge | - | Available concurrent push permits |
+| `transponder_push_concurrency_limit` | Gauge | - | Maximum number of concurrent outbound push requests |
+| `transponder_push_queue_rejected_total` | Counter | - | Notifications rejected before admission because the push queue was full, closed, or shutting down |
+| `transponder_push_dispatch_admission_duration_seconds` | Histogram | `outcome` | Time spent admitting notifications into the push dispatcher |
 | `transponder_push_retries_total` | Counter | `platform` | Push retry attempts |
 | `transponder_push_request_duration_seconds` | Histogram | `platform` | Push request duration |
 | `transponder_push_response_status_total` | Counter | `platform`, `status` | Push responses by HTTP status |
@@ -377,6 +388,8 @@ Label values: `type` = `encrypted_token` or `device_token`; `reason` = `minute` 
 |--------|------|--------|-------------|
 | `transponder_relays_connected` | Gauge | `type` | Currently connected relays |
 | `transponder_relays_configured` | Gauge | `type` | Configured relays |
+| `transponder_relay_notifications_lagged_total` | Counter | - | Number of times the relay notification receiver reported lag |
+| `transponder_relay_notifications_dropped_total` | Counter | - | Total relay notifications dropped because the receiver lagged |
 
 #### Server Info
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -284,6 +284,7 @@ async fn main() -> Result<()> {
     let mut event_shutdown = shutdown.subscribe();
     let event_processor_clone = event_processor.clone();
     let relay_client_clone = relay_client.clone();
+    let event_metrics = metrics.clone();
 
     let event_handle = tokio::spawn(async move {
         let mut notifications = relay_client_clone.notifications();
@@ -304,6 +305,12 @@ async fn main() -> Result<()> {
                             }
                         }
                         Err(e) => {
+                            if let RecvError::Lagged(skipped) = &e
+                                && let Some(ref m) = event_metrics {
+                                m.record_relay_notifications_lagged();
+                                m.record_relay_notifications_dropped(*skipped);
+                            }
+
                             match classify_notification_receive_error(&e) {
                                 NotificationReceiveAction::Continue => {
                                     warn!(error = %e, "Lagged relay notifications, continuing");

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,6 +75,15 @@ fn classify_notification_receive_error(error: &RecvError) -> NotificationReceive
     }
 }
 
+fn record_notification_receive_metrics(metrics: Option<&Metrics>, error: &RecvError) {
+    if let RecvError::Lagged(skipped) = error
+        && let Some(metrics) = metrics
+    {
+        metrics.record_relay_notifications_lagged();
+        metrics.record_relay_notifications_dropped(*skipped);
+    }
+}
+
 #[cfg(feature = "tor")]
 const TOR_FEATURE_ENABLED: bool = true;
 #[cfg(not(feature = "tor"))]
@@ -305,11 +314,7 @@ async fn main() -> Result<()> {
                             }
                         }
                         Err(e) => {
-                            if let RecvError::Lagged(skipped) = &e
-                                && let Some(ref m) = event_metrics {
-                                m.record_relay_notifications_lagged();
-                                m.record_relay_notifications_dropped(*skipped);
-                            }
+                            record_notification_receive_metrics(event_metrics.as_ref(), &e);
 
                             match classify_notification_receive_error(&e) {
                                 NotificationReceiveAction::Continue => {
@@ -494,6 +499,26 @@ mod tests {
         let action = classify_notification_receive_error(&RecvError::Closed);
 
         assert_eq!(action, NotificationReceiveAction::Shutdown);
+    }
+
+    #[test]
+    fn notification_receive_lag_records_metrics() {
+        let metrics = Metrics::new().unwrap();
+
+        record_notification_receive_metrics(Some(&metrics), &RecvError::Lagged(3));
+
+        assert_eq!(metrics.relay_notifications_lagged_total.get(), 1);
+        assert_eq!(metrics.relay_notifications_dropped_total.get(), 3);
+    }
+
+    #[test]
+    fn notification_receive_close_does_not_record_metrics() {
+        let metrics = Metrics::new().unwrap();
+
+        record_notification_receive_metrics(Some(&metrics), &RecvError::Closed);
+
+        assert_eq!(metrics.relay_notifications_lagged_total.get(), 0);
+        assert_eq!(metrics.relay_notifications_dropped_total.get(), 0);
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,8 @@ mod server;
 mod shutdown;
 
 #[cfg(test)]
+mod test_metrics;
+#[cfg(test)]
 mod test_vectors;
 
 use config::AppConfig;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -50,7 +50,8 @@ pub struct Metrics {
     /// Number of encrypted tokens carried by each parsed event.
     pub tokens_per_event: Histogram,
 
-    /// Decoded size in bytes of kind 446 notification content.
+    /// Size in bytes of the base64-decoded encrypted token blob from kind 446
+    /// notification content.
     pub notification_content_size_bytes: Histogram,
 
     /// Current size of the deduplication cache.
@@ -287,7 +288,7 @@ impl Metrics {
         let notification_content_size_bytes = Histogram::with_opts(
             HistogramOpts::new(
                 "transponder_notification_content_size_bytes",
-                "Decoded size in bytes of kind 446 notification content",
+                "Size in bytes of the base64-decoded encrypted token blob from kind 446 notification content",
             )
             .buckets(NOTIFICATION_CONTENT_SIZE_BUCKETS.to_vec()),
         )?;
@@ -647,7 +648,7 @@ impl Metrics {
         self.tokens_per_event.observe(count as f64);
     }
 
-    /// Observe decoded notification content size in bytes.
+    /// Observe the size in bytes of the base64-decoded encrypted token blob.
     pub fn observe_notification_content_size_bytes(&self, size: usize) {
         self.notification_content_size_bytes.observe(size as f64);
     }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -103,7 +103,7 @@ pub struct Metrics {
     /// Maximum number of concurrent outbound push requests.
     pub push_concurrency_limit: IntGauge,
 
-    /// Total number of push queue admissions rejected due to capacity or shutdown.
+    /// Total number of notifications rejected due to push queue capacity or shutdown.
     pub push_queue_rejected_total: IntCounter,
 
     /// Duration of push dispatcher admission by outcome.
@@ -141,6 +141,31 @@ pub struct Metrics {
 
     /// Server version information.
     pub server_info: IntGaugeVec,
+}
+
+/// Fixed set of outcome label values used by histogram metrics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutcomeLabel {
+    /// Operation completed successfully.
+    Success,
+    /// Operation failed.
+    Failed,
+    /// Event was processed successfully.
+    Processed,
+    /// Event was skipped because it was already seen.
+    Duplicate,
+}
+
+impl OutcomeLabel {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Success => "success",
+            Self::Failed => "failed",
+            Self::Processed => "processed",
+            Self::Duplicate => "duplicate",
+        }
+    }
 }
 
 fn event_duration_buckets() -> Vec<f64> {
@@ -380,7 +405,7 @@ impl Metrics {
 
         let push_queue_rejected_total = IntCounter::with_opts(Opts::new(
             "transponder_push_queue_rejected_total",
-            "Total number of push queue admissions rejected due to capacity or shutdown",
+            "Total number of notifications rejected due to push queue capacity or shutdown",
         ))?;
         registry.register(Box::new(push_queue_rejected_total.clone()))?;
 
@@ -574,23 +599,23 @@ impl Metrics {
     }
 
     /// Observe end-to-end event processing duration.
-    pub fn observe_event_processing_duration(&self, outcome: &str, duration_secs: f64) {
+    pub fn observe_event_processing_duration(&self, outcome: OutcomeLabel, duration_secs: f64) {
         self.event_processing_duration_seconds
-            .with_label_values(&[outcome])
+            .with_label_values(&[outcome.as_str()])
             .observe(duration_secs);
     }
 
     /// Observe gift-wrap unwrap duration.
-    pub fn observe_gift_wrap_unwrap_duration(&self, outcome: &str, duration_secs: f64) {
+    pub fn observe_gift_wrap_unwrap_duration(&self, outcome: OutcomeLabel, duration_secs: f64) {
         self.gift_wrap_unwrap_duration_seconds
-            .with_label_values(&[outcome])
+            .with_label_values(&[outcome.as_str()])
             .observe(duration_secs);
     }
 
     /// Observe notification parse duration.
-    pub fn observe_notification_parse_duration(&self, outcome: &str, duration_secs: f64) {
+    pub fn observe_notification_parse_duration(&self, outcome: OutcomeLabel, duration_secs: f64) {
         self.notification_parse_duration_seconds
-            .with_label_values(&[outcome])
+            .with_label_values(&[outcome.as_str()])
             .observe(duration_secs);
     }
 
@@ -653,9 +678,9 @@ impl Metrics {
     }
 
     /// Observe per-token decryption duration.
-    pub fn observe_token_decrypt_duration(&self, outcome: &str, duration_secs: f64) {
+    pub fn observe_token_decrypt_duration(&self, outcome: OutcomeLabel, duration_secs: f64) {
         self.token_decrypt_duration_seconds
-            .with_label_values(&[outcome])
+            .with_label_values(&[outcome.as_str()])
             .observe(duration_secs);
     }
 
@@ -704,14 +729,18 @@ impl Metrics {
     }
 
     /// Record a push queue rejection.
-    pub fn record_push_queue_rejected(&self) {
-        self.push_queue_rejected_total.inc();
+    pub fn record_push_queue_rejected(&self, count: u64) {
+        self.push_queue_rejected_total.inc_by(count);
     }
 
     /// Observe push dispatcher admission duration.
-    pub fn observe_push_dispatch_admission_duration(&self, outcome: &str, duration_secs: f64) {
+    pub fn observe_push_dispatch_admission_duration(
+        &self,
+        outcome: OutcomeLabel,
+        duration_secs: f64,
+    ) {
         self.push_dispatch_admission_duration_seconds
-            .with_label_values(&[outcome])
+            .with_label_values(&[outcome.as_str()])
             .observe(duration_secs);
     }
 
@@ -773,6 +802,60 @@ impl Default for Metrics {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use prometheus::proto::{Metric, MetricFamily};
+
+    fn metric_matches_labels(metric: &Metric, labels: &[(&str, &str)]) -> bool {
+        labels.iter().all(|(name, value)| {
+            metric
+                .get_label()
+                .iter()
+                .any(|label| label.name() == *name && label.value() == *value)
+        })
+    }
+
+    fn family(metrics: &Metrics, name: &str) -> MetricFamily {
+        metrics
+            .gather()
+            .into_iter()
+            .find(|family| family.name() == name)
+            .unwrap_or_else(|| panic!("metric family {name} not found"))
+    }
+
+    fn counter_value(metrics: &Metrics, name: &str, labels: &[(&str, &str)]) -> f64 {
+        family(metrics, name)
+            .get_metric()
+            .iter()
+            .find(|metric| metric_matches_labels(metric, labels))
+            .and_then(|metric| metric.get_counter().value)
+            .unwrap_or_default()
+    }
+
+    fn gauge_value(metrics: &Metrics, name: &str, labels: &[(&str, &str)]) -> f64 {
+        family(metrics, name)
+            .get_metric()
+            .iter()
+            .find(|metric| metric_matches_labels(metric, labels))
+            .and_then(|metric| metric.get_gauge().value)
+            .unwrap_or_default()
+    }
+
+    fn histogram_sample_count(metrics: &Metrics, name: &str, labels: &[(&str, &str)]) -> u64 {
+        family(metrics, name)
+            .get_metric()
+            .iter()
+            .find(|metric| metric_matches_labels(metric, labels))
+            .and_then(|metric| metric.get_histogram().sample_count)
+            .unwrap_or_default()
+    }
+
+    fn histogram_sample_sum(metrics: &Metrics, name: &str, labels: &[(&str, &str)]) -> f64 {
+        family(metrics, name)
+            .get_metric()
+            .iter()
+            .find(|metric| metric_matches_labels(metric, labels))
+            .and_then(|metric| metric.get_histogram().sample_sum)
+            .unwrap_or_default()
+    }
 
     #[test]
     fn test_metrics_creation() {
@@ -789,16 +872,73 @@ mod tests {
         metrics.record_event_deduplicated();
         metrics.record_event_failed();
         metrics.inc_events_in_flight();
-        metrics.observe_event_processing_duration("processed", 0.01);
-        metrics.observe_gift_wrap_unwrap_duration("success", 0.005);
-        metrics.observe_notification_parse_duration("success", 0.001);
+        metrics.observe_event_processing_duration(OutcomeLabel::Processed, 0.01);
+        metrics.observe_gift_wrap_unwrap_duration(OutcomeLabel::Success, 0.005);
+        metrics.observe_notification_parse_duration(OutcomeLabel::Success, 0.001);
         metrics.observe_tokens_per_event(3);
         metrics.observe_notification_content_size_bytes(512);
         metrics.dec_events_in_flight();
 
-        // Metrics should be incremented
-        let families = metrics.registry.gather();
-        assert!(!families.is_empty());
+        assert_eq!(
+            counter_value(&metrics, "transponder_events_received_total", &[]),
+            1.0
+        );
+        assert_eq!(
+            counter_value(&metrics, "transponder_events_processed_total", &[]),
+            1.0
+        );
+        assert_eq!(
+            counter_value(&metrics, "transponder_events_deduplicated_total", &[]),
+            1.0
+        );
+        assert_eq!(
+            counter_value(&metrics, "transponder_events_failed_total", &[]),
+            1.0
+        );
+        assert_eq!(
+            gauge_value(&metrics, "transponder_events_in_flight", &[]),
+            0.0
+        );
+        assert_eq!(
+            histogram_sample_count(
+                &metrics,
+                "transponder_event_processing_duration_seconds",
+                &[("outcome", OutcomeLabel::Processed.as_str())],
+            ),
+            1
+        );
+        assert_eq!(
+            histogram_sample_count(
+                &metrics,
+                "transponder_gift_wrap_unwrap_duration_seconds",
+                &[("outcome", OutcomeLabel::Success.as_str())],
+            ),
+            1
+        );
+        assert_eq!(
+            histogram_sample_count(
+                &metrics,
+                "transponder_notification_parse_duration_seconds",
+                &[("outcome", OutcomeLabel::Success.as_str())],
+            ),
+            1
+        );
+        assert_eq!(
+            histogram_sample_count(&metrics, "transponder_tokens_per_event", &[]),
+            1
+        );
+        assert_eq!(
+            histogram_sample_sum(&metrics, "transponder_tokens_per_event", &[]),
+            3.0
+        );
+        assert_eq!(
+            histogram_sample_count(&metrics, "transponder_notification_content_size_bytes", &[]),
+            1
+        );
+        assert_eq!(
+            histogram_sample_sum(&metrics, "transponder_notification_content_size_bytes", &[]),
+            512.0
+        );
     }
 
     #[test]
@@ -813,12 +953,86 @@ mod tests {
         metrics.set_push_queue_capacity(10_000);
         metrics.set_push_semaphore_available(95);
         metrics.set_push_concurrency_limit(100);
-        metrics.record_push_queue_rejected();
-        metrics.observe_push_dispatch_admission_duration("success", 0.001);
+        metrics.record_push_queue_rejected(2);
+        metrics.observe_push_dispatch_admission_duration(OutcomeLabel::Success, 0.001);
         metrics.observe_notifications_admitted_per_event(2);
 
-        let families = metrics.registry.gather();
-        assert!(!families.is_empty());
+        assert_eq!(
+            counter_value(
+                &metrics,
+                "transponder_push_dispatched_total",
+                &[("platform", "apns")]
+            ),
+            1.0
+        );
+        assert_eq!(
+            counter_value(
+                &metrics,
+                "transponder_push_dispatched_total",
+                &[("platform", "fcm")]
+            ),
+            1.0
+        );
+        assert_eq!(
+            counter_value(
+                &metrics,
+                "transponder_push_success_total",
+                &[("platform", "apns")]
+            ),
+            1.0
+        );
+        assert_eq!(
+            counter_value(
+                &metrics,
+                "transponder_push_failed_total",
+                &[("platform", "fcm"), ("reason", "invalid_token")],
+            ),
+            1.0
+        );
+        assert_eq!(
+            gauge_value(&metrics, "transponder_push_queue_size", &[]),
+            100.0
+        );
+        assert_eq!(
+            gauge_value(&metrics, "transponder_push_queue_capacity", &[]),
+            10_000.0
+        );
+        assert_eq!(
+            gauge_value(&metrics, "transponder_push_semaphore_available", &[]),
+            95.0
+        );
+        assert_eq!(
+            gauge_value(&metrics, "transponder_push_concurrency_limit", &[]),
+            100.0
+        );
+        assert_eq!(
+            counter_value(&metrics, "transponder_push_queue_rejected_total", &[]),
+            2.0
+        );
+        assert_eq!(
+            histogram_sample_count(
+                &metrics,
+                "transponder_push_dispatch_admission_duration_seconds",
+                &[("outcome", OutcomeLabel::Success.as_str())],
+            ),
+            1
+        );
+        assert_eq!(
+            histogram_sample_count(
+                &metrics,
+                "transponder_notifications_admitted_per_event",
+                &[]
+            ),
+            1
+        );
+        assert_eq!(
+            histogram_sample_sum(
+                &metrics,
+                "transponder_notifications_admitted_per_event",
+                &[]
+            ),
+            2.0
+        );
     }
 
     #[test]
@@ -830,8 +1044,38 @@ mod tests {
         metrics.record_push_retry("fcm");
         metrics.record_auth_token_refresh("apns_jwt");
 
-        let families = metrics.registry.gather();
-        assert!(!families.is_empty());
+        assert_eq!(
+            histogram_sample_count(
+                &metrics,
+                "transponder_push_request_duration_seconds",
+                &[("platform", "apns")],
+            ),
+            1
+        );
+        assert_eq!(
+            counter_value(
+                &metrics,
+                "transponder_push_response_status_total",
+                &[("platform", "apns"), ("status", "200")],
+            ),
+            1.0
+        );
+        assert_eq!(
+            counter_value(
+                &metrics,
+                "transponder_push_retries_total",
+                &[("platform", "fcm")]
+            ),
+            1.0
+        );
+        assert_eq!(
+            counter_value(
+                &metrics,
+                "transponder_auth_token_refreshes_total",
+                &[("service", "apns_jwt")],
+            ),
+            1.0
+        );
     }
 
     #[test]
@@ -844,8 +1088,54 @@ mod tests {
         metrics.record_relay_notifications_lagged();
         metrics.record_relay_notifications_dropped(4);
 
-        let families = metrics.registry.gather();
-        assert!(!families.is_empty());
+        assert_eq!(
+            gauge_value(
+                &metrics,
+                "transponder_relays_configured",
+                &[("type", "clearnet")]
+            ),
+            3.0
+        );
+        assert_eq!(
+            gauge_value(
+                &metrics,
+                "transponder_relays_configured",
+                &[("type", "onion")]
+            ),
+            2.0
+        );
+        assert_eq!(
+            gauge_value(
+                &metrics,
+                "transponder_relays_connected",
+                &[("type", "clearnet")]
+            ),
+            2.0
+        );
+        assert_eq!(
+            gauge_value(
+                &metrics,
+                "transponder_relays_connected",
+                &[("type", "onion")]
+            ),
+            1.0
+        );
+        assert_eq!(
+            counter_value(
+                &metrics,
+                "transponder_relay_notifications_lagged_total",
+                &[]
+            ),
+            1.0
+        );
+        assert_eq!(
+            counter_value(
+                &metrics,
+                "transponder_relay_notifications_dropped_total",
+                &[]
+            ),
+            4.0
+        );
     }
 
     #[test]
@@ -854,8 +1144,11 @@ mod tests {
 
         metrics.init_server_info("0.1.0");
 
-        let families = metrics.registry.gather();
-        assert!(!families.is_empty());
+        assert!(gauge_value(&metrics, "transponder_server_start_time_seconds", &[]) > 0.0);
+        assert_eq!(
+            gauge_value(&metrics, "transponder_server_info", &[("version", "0.1.0")]),
+            1.0
+        );
     }
 
     #[test]
@@ -865,8 +1158,14 @@ mod tests {
         metrics.set_dedup_cache_size(50000);
         metrics.record_dedup_evictions(100);
 
-        let families = metrics.registry.gather();
-        assert!(!families.is_empty());
+        assert_eq!(
+            gauge_value(&metrics, "transponder_dedup_cache_size", &[]),
+            50_000.0
+        );
+        assert_eq!(
+            counter_value(&metrics, "transponder_dedup_cache_evictions_total", &[]),
+            100.0
+        );
     }
 
     #[test]
@@ -875,11 +1174,33 @@ mod tests {
 
         metrics.record_token_decrypted();
         metrics.record_token_decryption_failed();
-        metrics.observe_token_decrypt_duration("success", 0.0005);
-        metrics.observe_token_decrypt_duration("failed", 0.0007);
+        metrics.observe_token_decrypt_duration(OutcomeLabel::Success, 0.0005);
+        metrics.observe_token_decrypt_duration(OutcomeLabel::Failed, 0.0007);
 
-        let families = metrics.registry.gather();
-        assert!(!families.is_empty());
+        assert_eq!(
+            counter_value(&metrics, "transponder_tokens_decrypted_total", &[]),
+            1.0
+        );
+        assert_eq!(
+            counter_value(&metrics, "transponder_tokens_decryption_failed_total", &[]),
+            1.0
+        );
+        assert_eq!(
+            histogram_sample_count(
+                &metrics,
+                "transponder_token_decrypt_duration_seconds",
+                &[("outcome", OutcomeLabel::Success.as_str())],
+            ),
+            1
+        );
+        assert_eq!(
+            histogram_sample_count(
+                &metrics,
+                "transponder_token_decrypt_duration_seconds",
+                &[("outcome", OutcomeLabel::Failed.as_str())],
+            ),
+            1
+        );
     }
 
     #[test]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -12,8 +12,8 @@
 //! - Only aggregate counts and operational statistics
 
 use prometheus::{
-    Gauge, HistogramOpts, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, Opts,
-    Registry,
+    Gauge, Histogram, HistogramOpts, HistogramVec, IntCounter, IntCounterVec, IntGauge,
+    IntGaugeVec, Opts, Registry,
 };
 
 /// All metrics for the Transponder server.
@@ -34,6 +34,24 @@ pub struct Metrics {
 
     /// Total number of events that failed processing.
     pub events_failed_total: IntCounter,
+
+    /// Current number of events actively being processed.
+    pub events_in_flight: IntGauge,
+
+    /// End-to-end duration of event processing by outcome.
+    pub event_processing_duration_seconds: HistogramVec,
+
+    /// Duration of gift-wrap unwrap operations by outcome.
+    pub gift_wrap_unwrap_duration_seconds: HistogramVec,
+
+    /// Duration of notification parsing operations by outcome.
+    pub notification_parse_duration_seconds: HistogramVec,
+
+    /// Number of encrypted tokens carried by each parsed event.
+    pub tokens_per_event: Histogram,
+
+    /// Size of kind 446 notification content before base64 decoding.
+    pub notification_content_size_bytes: Histogram,
 
     /// Current size of the deduplication cache.
     pub dedup_cache_size: IntGauge,
@@ -57,6 +75,12 @@ pub struct Metrics {
     /// Total number of token decryption failures.
     pub tokens_decryption_failed_total: IntCounter,
 
+    /// Duration of individual token decrypt operations by outcome.
+    pub token_decrypt_duration_seconds: HistogramVec,
+
+    /// Number of notifications admitted to the push dispatcher per event.
+    pub notifications_admitted_per_event: Histogram,
+
     // === Push Dispatcher Metrics ===
     /// Total number of notifications dispatched to push services.
     pub push_dispatched_total: IntCounterVec,
@@ -70,8 +94,20 @@ pub struct Metrics {
     /// Current number of items in the push queue.
     pub push_queue_size: IntGauge,
 
+    /// Maximum number of items the push queue can hold.
+    pub push_queue_capacity: IntGauge,
+
     /// Number of available semaphore permits for concurrent pushes.
     pub push_semaphore_available: IntGauge,
+
+    /// Maximum number of concurrent outbound push requests.
+    pub push_concurrency_limit: IntGauge,
+
+    /// Total number of push queue admissions rejected due to capacity or shutdown.
+    pub push_queue_rejected_total: IntCounter,
+
+    /// Duration of push dispatcher admission by outcome.
+    pub push_dispatch_admission_duration_seconds: HistogramVec,
 
     /// Total number of push retries attempted.
     pub push_retries_total: IntCounterVec,
@@ -93,12 +129,46 @@ pub struct Metrics {
     /// Total number of configured relays.
     pub relays_configured: IntGaugeVec,
 
+    /// Total number of lagged relay notification events encountered.
+    pub relay_notifications_lagged_total: IntCounter,
+
+    /// Total number of relay notifications dropped because the receiver lagged.
+    pub relay_notifications_dropped_total: IntCounter,
+
     // === Server Metrics ===
     /// Timestamp when the server started (Unix seconds).
     pub server_start_time_seconds: Gauge,
 
     /// Server version information.
     pub server_info: IntGaugeVec,
+}
+
+fn event_duration_buckets() -> Vec<f64> {
+    vec![
+        0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0,
+    ]
+}
+
+fn parse_duration_buckets() -> Vec<f64> {
+    vec![
+        0.0001, 0.00025, 0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1,
+    ]
+}
+
+fn token_decrypt_duration_buckets() -> Vec<f64> {
+    vec![
+        0.00005, 0.0001, 0.00025, 0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05,
+    ]
+}
+
+fn per_event_count_buckets() -> Vec<f64> {
+    vec![1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0]
+}
+
+fn notification_content_size_buckets() -> Vec<f64> {
+    vec![
+        128.0, 256.0, 512.0, 1024.0, 2048.0, 4096.0, 8192.0, 16384.0, 32768.0,
+    ]
 }
 
 impl Metrics {
@@ -130,6 +200,60 @@ impl Metrics {
             "Total number of events that failed processing",
         ))?;
         registry.register(Box::new(events_failed_total.clone()))?;
+
+        let events_in_flight = IntGauge::with_opts(Opts::new(
+            "transponder_events_in_flight",
+            "Current number of events actively being processed",
+        ))?;
+        registry.register(Box::new(events_in_flight.clone()))?;
+
+        let event_processing_duration_seconds = HistogramVec::new(
+            HistogramOpts::new(
+                "transponder_event_processing_duration_seconds",
+                "End-to-end duration of event processing by outcome",
+            )
+            .buckets(event_duration_buckets()),
+            &["outcome"],
+        )?;
+        registry.register(Box::new(event_processing_duration_seconds.clone()))?;
+
+        let gift_wrap_unwrap_duration_seconds = HistogramVec::new(
+            HistogramOpts::new(
+                "transponder_gift_wrap_unwrap_duration_seconds",
+                "Duration of gift-wrap unwrap operations by outcome",
+            )
+            .buckets(event_duration_buckets()),
+            &["outcome"],
+        )?;
+        registry.register(Box::new(gift_wrap_unwrap_duration_seconds.clone()))?;
+
+        let notification_parse_duration_seconds = HistogramVec::new(
+            HistogramOpts::new(
+                "transponder_notification_parse_duration_seconds",
+                "Duration of notification parsing operations by outcome",
+            )
+            .buckets(parse_duration_buckets()),
+            &["outcome"],
+        )?;
+        registry.register(Box::new(notification_parse_duration_seconds.clone()))?;
+
+        let tokens_per_event = Histogram::with_opts(
+            HistogramOpts::new(
+                "transponder_tokens_per_event",
+                "Number of encrypted tokens carried by each parsed event",
+            )
+            .buckets(per_event_count_buckets()),
+        )?;
+        registry.register(Box::new(tokens_per_event.clone()))?;
+
+        let notification_content_size_bytes = Histogram::with_opts(
+            HistogramOpts::new(
+                "transponder_notification_content_size_bytes",
+                "Size of kind 446 notification content before base64 decoding",
+            )
+            .buckets(notification_content_size_buckets()),
+        )?;
+        registry.register(Box::new(notification_content_size_bytes.clone()))?;
 
         let dedup_cache_size = IntGauge::with_opts(Opts::new(
             "transponder_dedup_cache_size",
@@ -183,6 +307,25 @@ impl Metrics {
         ))?;
         registry.register(Box::new(tokens_decryption_failed_total.clone()))?;
 
+        let token_decrypt_duration_seconds = HistogramVec::new(
+            HistogramOpts::new(
+                "transponder_token_decrypt_duration_seconds",
+                "Duration of individual token decrypt operations by outcome",
+            )
+            .buckets(token_decrypt_duration_buckets()),
+            &["outcome"],
+        )?;
+        registry.register(Box::new(token_decrypt_duration_seconds.clone()))?;
+
+        let notifications_admitted_per_event = Histogram::with_opts(
+            HistogramOpts::new(
+                "transponder_notifications_admitted_per_event",
+                "Number of notifications admitted to the push dispatcher per event",
+            )
+            .buckets(per_event_count_buckets()),
+        )?;
+        registry.register(Box::new(notifications_admitted_per_event.clone()))?;
+
         // === Push Dispatcher Metrics ===
         let push_dispatched_total = IntCounterVec::new(
             Opts::new(
@@ -217,11 +360,39 @@ impl Metrics {
         ))?;
         registry.register(Box::new(push_queue_size.clone()))?;
 
+        let push_queue_capacity = IntGauge::with_opts(Opts::new(
+            "transponder_push_queue_capacity",
+            "Maximum number of notifications the push queue can hold",
+        ))?;
+        registry.register(Box::new(push_queue_capacity.clone()))?;
+
         let push_semaphore_available = IntGauge::with_opts(Opts::new(
             "transponder_push_semaphore_available",
             "Number of available permits for concurrent push requests",
         ))?;
         registry.register(Box::new(push_semaphore_available.clone()))?;
+
+        let push_concurrency_limit = IntGauge::with_opts(Opts::new(
+            "transponder_push_concurrency_limit",
+            "Maximum number of concurrent outbound push requests",
+        ))?;
+        registry.register(Box::new(push_concurrency_limit.clone()))?;
+
+        let push_queue_rejected_total = IntCounter::with_opts(Opts::new(
+            "transponder_push_queue_rejected_total",
+            "Total number of push queue admissions rejected due to capacity or shutdown",
+        ))?;
+        registry.register(Box::new(push_queue_rejected_total.clone()))?;
+
+        let push_dispatch_admission_duration_seconds = HistogramVec::new(
+            HistogramOpts::new(
+                "transponder_push_dispatch_admission_duration_seconds",
+                "Duration of push dispatcher admission by outcome",
+            )
+            .buckets(parse_duration_buckets()),
+            &["outcome"],
+        )?;
+        registry.register(Box::new(push_dispatch_admission_duration_seconds.clone()))?;
 
         let push_retries_total = IntCounterVec::new(
             Opts::new(
@@ -280,6 +451,18 @@ impl Metrics {
         )?;
         registry.register(Box::new(relays_configured.clone()))?;
 
+        let relay_notifications_lagged_total = IntCounter::with_opts(Opts::new(
+            "transponder_relay_notifications_lagged_total",
+            "Total number of lagged relay notification events encountered",
+        ))?;
+        registry.register(Box::new(relay_notifications_lagged_total.clone()))?;
+
+        let relay_notifications_dropped_total = IntCounter::with_opts(Opts::new(
+            "transponder_relay_notifications_dropped_total",
+            "Total number of relay notifications dropped because the receiver lagged",
+        ))?;
+        registry.register(Box::new(relay_notifications_dropped_total.clone()))?;
+
         // === Server Metrics ===
         let server_start_time_seconds = Gauge::with_opts(Opts::new(
             "transponder_server_start_time_seconds",
@@ -302,6 +485,12 @@ impl Metrics {
             events_processed_total,
             events_deduplicated_total,
             events_failed_total,
+            events_in_flight,
+            event_processing_duration_seconds,
+            gift_wrap_unwrap_duration_seconds,
+            notification_parse_duration_seconds,
+            tokens_per_event,
+            notification_content_size_bytes,
             dedup_cache_size,
             dedup_cache_evictions_total,
             tokens_rate_limited_total,
@@ -309,17 +498,25 @@ impl Metrics {
             rate_limit_evictions_total,
             tokens_decrypted_total,
             tokens_decryption_failed_total,
+            token_decrypt_duration_seconds,
+            notifications_admitted_per_event,
             push_dispatched_total,
             push_success_total,
             push_failed_total,
             push_queue_size,
+            push_queue_capacity,
             push_semaphore_available,
+            push_concurrency_limit,
+            push_queue_rejected_total,
+            push_dispatch_admission_duration_seconds,
             push_retries_total,
             push_request_duration_seconds,
             push_response_status_total,
             auth_token_refreshes_total,
             relays_connected,
             relays_configured,
+            relay_notifications_lagged_total,
+            relay_notifications_dropped_total,
             server_start_time_seconds,
             server_info,
         })
@@ -364,6 +561,47 @@ impl Metrics {
     /// Record a failed event.
     pub fn record_event_failed(&self) {
         self.events_failed_total.inc();
+    }
+
+    /// Increment the number of in-flight events.
+    pub fn inc_events_in_flight(&self) {
+        self.events_in_flight.inc();
+    }
+
+    /// Decrement the number of in-flight events.
+    pub fn dec_events_in_flight(&self) {
+        self.events_in_flight.dec();
+    }
+
+    /// Observe end-to-end event processing duration.
+    pub fn observe_event_processing_duration(&self, outcome: &str, duration_secs: f64) {
+        self.event_processing_duration_seconds
+            .with_label_values(&[outcome])
+            .observe(duration_secs);
+    }
+
+    /// Observe gift-wrap unwrap duration.
+    pub fn observe_gift_wrap_unwrap_duration(&self, outcome: &str, duration_secs: f64) {
+        self.gift_wrap_unwrap_duration_seconds
+            .with_label_values(&[outcome])
+            .observe(duration_secs);
+    }
+
+    /// Observe notification parse duration.
+    pub fn observe_notification_parse_duration(&self, outcome: &str, duration_secs: f64) {
+        self.notification_parse_duration_seconds
+            .with_label_values(&[outcome])
+            .observe(duration_secs);
+    }
+
+    /// Observe encrypted token count per event.
+    pub fn observe_tokens_per_event(&self, count: usize) {
+        self.tokens_per_event.observe(count as f64);
+    }
+
+    /// Observe inner notification content size in bytes.
+    pub fn observe_notification_content_size_bytes(&self, size: usize) {
+        self.notification_content_size_bytes.observe(size as f64);
     }
 
     /// Update dedup cache size.
@@ -414,6 +652,18 @@ impl Metrics {
         self.tokens_decryption_failed_total.inc();
     }
 
+    /// Observe per-token decryption duration.
+    pub fn observe_token_decrypt_duration(&self, outcome: &str, duration_secs: f64) {
+        self.token_decrypt_duration_seconds
+            .with_label_values(&[outcome])
+            .observe(duration_secs);
+    }
+
+    /// Observe the number of notifications admitted to the push dispatcher per event.
+    pub fn observe_notifications_admitted_per_event(&self, count: usize) {
+        self.notifications_admitted_per_event.observe(count as f64);
+    }
+
     /// Record a notification dispatched to push queue.
     pub fn record_push_dispatched(&self, platform: &str) {
         self.push_dispatched_total
@@ -438,9 +688,31 @@ impl Metrics {
         self.push_queue_size.set(size as i64);
     }
 
+    /// Update the push queue capacity.
+    pub fn set_push_queue_capacity(&self, size: usize) {
+        self.push_queue_capacity.set(size as i64);
+    }
+
     /// Update available semaphore permits.
     pub fn set_push_semaphore_available(&self, available: usize) {
         self.push_semaphore_available.set(available as i64);
+    }
+
+    /// Update the push concurrency limit.
+    pub fn set_push_concurrency_limit(&self, limit: usize) {
+        self.push_concurrency_limit.set(limit as i64);
+    }
+
+    /// Record a push queue rejection.
+    pub fn record_push_queue_rejected(&self) {
+        self.push_queue_rejected_total.inc();
+    }
+
+    /// Observe push dispatcher admission duration.
+    pub fn observe_push_dispatch_admission_duration(&self, outcome: &str, duration_secs: f64) {
+        self.push_dispatch_admission_duration_seconds
+            .with_label_values(&[outcome])
+            .observe(duration_secs);
     }
 
     /// Record a push retry attempt.
@@ -476,6 +748,16 @@ impl Metrics {
             .set(count as i64);
     }
 
+    /// Record a lagged relay notification event.
+    pub fn record_relay_notifications_lagged(&self) {
+        self.relay_notifications_lagged_total.inc();
+    }
+
+    /// Record relay notifications dropped due to receiver lag.
+    pub fn record_relay_notifications_dropped(&self, count: u64) {
+        self.relay_notifications_dropped_total.inc_by(count);
+    }
+
     /// Gather all metrics for export.
     pub fn gather(&self) -> Vec<prometheus::proto::MetricFamily> {
         self.registry.gather()
@@ -506,6 +788,13 @@ mod tests {
         metrics.record_event_processed();
         metrics.record_event_deduplicated();
         metrics.record_event_failed();
+        metrics.inc_events_in_flight();
+        metrics.observe_event_processing_duration("processed", 0.01);
+        metrics.observe_gift_wrap_unwrap_duration("success", 0.005);
+        metrics.observe_notification_parse_duration("success", 0.001);
+        metrics.observe_tokens_per_event(3);
+        metrics.observe_notification_content_size_bytes(512);
+        metrics.dec_events_in_flight();
 
         // Metrics should be incremented
         let families = metrics.registry.gather();
@@ -521,7 +810,12 @@ mod tests {
         metrics.record_push_success("apns");
         metrics.record_push_failed("fcm", "invalid_token");
         metrics.set_push_queue_size(100);
+        metrics.set_push_queue_capacity(10_000);
         metrics.set_push_semaphore_available(95);
+        metrics.set_push_concurrency_limit(100);
+        metrics.record_push_queue_rejected();
+        metrics.observe_push_dispatch_admission_duration("success", 0.001);
+        metrics.observe_notifications_admitted_per_event(2);
 
         let families = metrics.registry.gather();
         assert!(!families.is_empty());
@@ -547,6 +841,8 @@ mod tests {
         metrics.set_relay_counts(3, 2);
         metrics.set_relays_connected("clearnet", 2);
         metrics.set_relays_connected("onion", 1);
+        metrics.record_relay_notifications_lagged();
+        metrics.record_relay_notifications_dropped(4);
 
         let families = metrics.registry.gather();
         assert!(!families.is_empty());
@@ -579,6 +875,8 @@ mod tests {
 
         metrics.record_token_decrypted();
         metrics.record_token_decryption_failed();
+        metrics.observe_token_decrypt_duration("success", 0.0005);
+        metrics.observe_token_decrypt_duration("failed", 0.0007);
 
         let families = metrics.registry.gather();
         assert!(!families.is_empty());

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -103,7 +103,8 @@ pub struct Metrics {
     /// Maximum number of concurrent outbound push requests.
     pub push_concurrency_limit: IntGauge,
 
-    /// Total number of notifications rejected due to push queue capacity or shutdown.
+    /// Total number of notifications rejected because the push queue was full,
+    /// the dispatcher was shutting down, or the queue channel was closed.
     pub push_queue_rejected_total: IntCounter,
 
     /// Duration of push dispatcher admission by outcome.
@@ -417,7 +418,7 @@ impl Metrics {
 
         let push_queue_rejected_total = IntCounter::with_opts(Opts::new(
             "transponder_push_queue_rejected_total",
-            "Total number of notifications rejected due to push queue capacity or shutdown",
+            "Total number of notifications rejected because the push queue was full, the dispatcher was shutting down, or the queue channel was closed",
         ))?;
         registry.register(Box::new(push_queue_rejected_total.clone()))?;
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -168,32 +168,28 @@ impl OutcomeLabel {
     }
 }
 
-fn event_duration_buckets() -> Vec<f64> {
-    vec![
-        0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0,
-    ]
+const EVENT_DURATION_BUCKETS: [f64; 12] = [
+    0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0,
+];
+const PARSE_DURATION_BUCKETS: [f64; 10] = [
+    0.0001, 0.00025, 0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1,
+];
+const TOKEN_DECRYPT_DURATION_BUCKETS: [f64; 10] = [
+    0.00005, 0.0001, 0.00025, 0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05,
+];
+const PER_EVENT_COUNT_BUCKETS: [f64; 9] = [1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0];
+const NOTIFICATION_CONTENT_SIZE_BUCKETS: [f64; 9] = [
+    128.0, 256.0, 512.0, 1024.0, 2048.0, 4096.0, 8192.0, 16384.0, 32768.0,
+];
+
+fn observe_outcome(histogram: &HistogramVec, outcome: OutcomeLabel, value: f64) {
+    histogram
+        .with_label_values(&[outcome.as_str()])
+        .observe(value);
 }
 
-fn parse_duration_buckets() -> Vec<f64> {
-    vec![
-        0.0001, 0.00025, 0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1,
-    ]
-}
-
-fn token_decrypt_duration_buckets() -> Vec<f64> {
-    vec![
-        0.00005, 0.0001, 0.00025, 0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05,
-    ]
-}
-
-fn per_event_count_buckets() -> Vec<f64> {
-    vec![1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0]
-}
-
-fn notification_content_size_buckets() -> Vec<f64> {
-    vec![
-        128.0, 256.0, 512.0, 1024.0, 2048.0, 4096.0, 8192.0, 16384.0, 32768.0,
-    ]
+fn set_usize_gauge(gauge: &IntGauge, value: usize) {
+    gauge.set(value as i64);
 }
 
 impl Metrics {
@@ -237,7 +233,7 @@ impl Metrics {
                 "transponder_event_processing_duration_seconds",
                 "End-to-end duration of event processing by outcome",
             )
-            .buckets(event_duration_buckets()),
+            .buckets(EVENT_DURATION_BUCKETS.to_vec()),
             &["outcome"],
         )?;
         registry.register(Box::new(event_processing_duration_seconds.clone()))?;
@@ -247,7 +243,7 @@ impl Metrics {
                 "transponder_gift_wrap_unwrap_duration_seconds",
                 "Duration of gift-wrap unwrap operations by outcome",
             )
-            .buckets(event_duration_buckets()),
+            .buckets(EVENT_DURATION_BUCKETS.to_vec()),
             &["outcome"],
         )?;
         registry.register(Box::new(gift_wrap_unwrap_duration_seconds.clone()))?;
@@ -257,7 +253,7 @@ impl Metrics {
                 "transponder_notification_parse_duration_seconds",
                 "Duration of notification parsing operations by outcome",
             )
-            .buckets(parse_duration_buckets()),
+            .buckets(PARSE_DURATION_BUCKETS.to_vec()),
             &["outcome"],
         )?;
         registry.register(Box::new(notification_parse_duration_seconds.clone()))?;
@@ -267,7 +263,7 @@ impl Metrics {
                 "transponder_tokens_per_event",
                 "Number of encrypted tokens carried by each parsed event",
             )
-            .buckets(per_event_count_buckets()),
+            .buckets(PER_EVENT_COUNT_BUCKETS.to_vec()),
         )?;
         registry.register(Box::new(tokens_per_event.clone()))?;
 
@@ -276,7 +272,7 @@ impl Metrics {
                 "transponder_notification_content_size_bytes",
                 "Size of kind 446 notification content before base64 decoding",
             )
-            .buckets(notification_content_size_buckets()),
+            .buckets(NOTIFICATION_CONTENT_SIZE_BUCKETS.to_vec()),
         )?;
         registry.register(Box::new(notification_content_size_bytes.clone()))?;
 
@@ -337,7 +333,7 @@ impl Metrics {
                 "transponder_token_decrypt_duration_seconds",
                 "Duration of individual token decrypt operations by outcome",
             )
-            .buckets(token_decrypt_duration_buckets()),
+            .buckets(TOKEN_DECRYPT_DURATION_BUCKETS.to_vec()),
             &["outcome"],
         )?;
         registry.register(Box::new(token_decrypt_duration_seconds.clone()))?;
@@ -347,7 +343,7 @@ impl Metrics {
                 "transponder_notifications_admitted_per_event",
                 "Number of notifications admitted to the push dispatcher per event",
             )
-            .buckets(per_event_count_buckets()),
+            .buckets(PER_EVENT_COUNT_BUCKETS.to_vec()),
         )?;
         registry.register(Box::new(notifications_admitted_per_event.clone()))?;
 
@@ -414,7 +410,7 @@ impl Metrics {
                 "transponder_push_dispatch_admission_duration_seconds",
                 "Duration of push dispatcher admission by outcome",
             )
-            .buckets(parse_duration_buckets()),
+            .buckets(PARSE_DURATION_BUCKETS.to_vec()),
             &["outcome"],
         )?;
         registry.register(Box::new(push_dispatch_admission_duration_seconds.clone()))?;
@@ -600,23 +596,29 @@ impl Metrics {
 
     /// Observe end-to-end event processing duration.
     pub fn observe_event_processing_duration(&self, outcome: OutcomeLabel, duration_secs: f64) {
-        self.event_processing_duration_seconds
-            .with_label_values(&[outcome.as_str()])
-            .observe(duration_secs);
+        observe_outcome(
+            &self.event_processing_duration_seconds,
+            outcome,
+            duration_secs,
+        );
     }
 
     /// Observe gift-wrap unwrap duration.
     pub fn observe_gift_wrap_unwrap_duration(&self, outcome: OutcomeLabel, duration_secs: f64) {
-        self.gift_wrap_unwrap_duration_seconds
-            .with_label_values(&[outcome.as_str()])
-            .observe(duration_secs);
+        observe_outcome(
+            &self.gift_wrap_unwrap_duration_seconds,
+            outcome,
+            duration_secs,
+        );
     }
 
     /// Observe notification parse duration.
     pub fn observe_notification_parse_duration(&self, outcome: OutcomeLabel, duration_secs: f64) {
-        self.notification_parse_duration_seconds
-            .with_label_values(&[outcome.as_str()])
-            .observe(duration_secs);
+        observe_outcome(
+            &self.notification_parse_duration_seconds,
+            outcome,
+            duration_secs,
+        );
     }
 
     /// Observe encrypted token count per event.
@@ -631,7 +633,7 @@ impl Metrics {
 
     /// Update dedup cache size.
     pub fn set_dedup_cache_size(&self, size: usize) {
-        self.dedup_cache_size.set(size as i64);
+        set_usize_gauge(&self.dedup_cache_size, size);
     }
 
     /// Record dedup cache evictions.
@@ -679,9 +681,7 @@ impl Metrics {
 
     /// Observe per-token decryption duration.
     pub fn observe_token_decrypt_duration(&self, outcome: OutcomeLabel, duration_secs: f64) {
-        self.token_decrypt_duration_seconds
-            .with_label_values(&[outcome.as_str()])
-            .observe(duration_secs);
+        observe_outcome(&self.token_decrypt_duration_seconds, outcome, duration_secs);
     }
 
     /// Observe the number of notifications admitted to the push dispatcher per event.
@@ -710,22 +710,22 @@ impl Metrics {
 
     /// Update the push queue size.
     pub fn set_push_queue_size(&self, size: usize) {
-        self.push_queue_size.set(size as i64);
+        set_usize_gauge(&self.push_queue_size, size);
     }
 
     /// Update the push queue capacity.
     pub fn set_push_queue_capacity(&self, size: usize) {
-        self.push_queue_capacity.set(size as i64);
+        set_usize_gauge(&self.push_queue_capacity, size);
     }
 
     /// Update available semaphore permits.
     pub fn set_push_semaphore_available(&self, available: usize) {
-        self.push_semaphore_available.set(available as i64);
+        set_usize_gauge(&self.push_semaphore_available, available);
     }
 
     /// Update the push concurrency limit.
     pub fn set_push_concurrency_limit(&self, limit: usize) {
-        self.push_concurrency_limit.set(limit as i64);
+        set_usize_gauge(&self.push_concurrency_limit, limit);
     }
 
     /// Record a push queue rejection.
@@ -739,9 +739,11 @@ impl Metrics {
         outcome: OutcomeLabel,
         duration_secs: f64,
     ) {
-        self.push_dispatch_admission_duration_seconds
-            .with_label_values(&[outcome.as_str()])
-            .observe(duration_secs);
+        observe_outcome(
+            &self.push_dispatch_admission_duration_seconds,
+            outcome,
+            duration_secs,
+        );
     }
 
     /// Record a push retry attempt.
@@ -802,60 +804,9 @@ impl Default for Metrics {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use prometheus::proto::{Metric, MetricFamily};
-
-    fn metric_matches_labels(metric: &Metric, labels: &[(&str, &str)]) -> bool {
-        labels.iter().all(|(name, value)| {
-            metric
-                .get_label()
-                .iter()
-                .any(|label| label.name() == *name && label.value() == *value)
-        })
-    }
-
-    fn family(metrics: &Metrics, name: &str) -> MetricFamily {
-        metrics
-            .gather()
-            .into_iter()
-            .find(|family| family.name() == name)
-            .unwrap_or_else(|| panic!("metric family {name} not found"))
-    }
-
-    fn counter_value(metrics: &Metrics, name: &str, labels: &[(&str, &str)]) -> f64 {
-        family(metrics, name)
-            .get_metric()
-            .iter()
-            .find(|metric| metric_matches_labels(metric, labels))
-            .and_then(|metric| metric.get_counter().value)
-            .unwrap_or_default()
-    }
-
-    fn gauge_value(metrics: &Metrics, name: &str, labels: &[(&str, &str)]) -> f64 {
-        family(metrics, name)
-            .get_metric()
-            .iter()
-            .find(|metric| metric_matches_labels(metric, labels))
-            .and_then(|metric| metric.get_gauge().value)
-            .unwrap_or_default()
-    }
-
-    fn histogram_sample_count(metrics: &Metrics, name: &str, labels: &[(&str, &str)]) -> u64 {
-        family(metrics, name)
-            .get_metric()
-            .iter()
-            .find(|metric| metric_matches_labels(metric, labels))
-            .and_then(|metric| metric.get_histogram().sample_count)
-            .unwrap_or_default()
-    }
-
-    fn histogram_sample_sum(metrics: &Metrics, name: &str, labels: &[(&str, &str)]) -> f64 {
-        family(metrics, name)
-            .get_metric()
-            .iter()
-            .find(|metric| metric_matches_labels(metric, labels))
-            .and_then(|metric| metric.get_histogram().sample_sum)
-            .unwrap_or_default()
-    }
+    use crate::test_metrics::{
+        counter_value, gauge_value, histogram_sample_count, histogram_sample_sum,
+    };
 
     #[test]
     fn test_metrics_creation() {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -50,7 +50,7 @@ pub struct Metrics {
     /// Number of encrypted tokens carried by each parsed event.
     pub tokens_per_event: Histogram,
 
-    /// Size of kind 446 notification content before base64 decoding.
+    /// Decoded size in bytes of kind 446 notification content.
     pub notification_content_size_bytes: Histogram,
 
     /// Current size of the deduplication cache.
@@ -143,12 +143,10 @@ pub struct Metrics {
     pub server_info: IntGaugeVec,
 }
 
-/// Fixed set of outcome label values used by histogram metrics.
+/// Fixed set of outcome label values used by the event-level processing histogram.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum OutcomeLabel {
-    /// Operation completed successfully.
-    Success,
-    /// Operation failed.
+pub enum EventOutcome {
+    /// Event processing failed.
     Failed,
     /// Event was processed successfully.
     Processed,
@@ -156,14 +154,32 @@ pub enum OutcomeLabel {
     Duplicate,
 }
 
-impl OutcomeLabel {
+impl EventOutcome {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Failed => "failed",
+            Self::Processed => "processed",
+            Self::Duplicate => "duplicate",
+        }
+    }
+}
+
+/// Fixed set of outcome label values used by sub-operation histograms.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OperationOutcome {
+    /// Operation completed successfully.
+    Success,
+    /// Operation failed.
+    Failed,
+}
+
+impl OperationOutcome {
     #[must_use]
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::Success => "success",
             Self::Failed => "failed",
-            Self::Processed => "processed",
-            Self::Duplicate => "duplicate",
         }
     }
 }
@@ -177,15 +193,15 @@ const PARSE_DURATION_BUCKETS: [f64; 10] = [
 const TOKEN_DECRYPT_DURATION_BUCKETS: [f64; 10] = [
     0.00005, 0.0001, 0.00025, 0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05,
 ];
+const PUSH_ADMISSION_DURATION_BUCKETS: [f64; 8] =
+    [0.00005, 0.0001, 0.00025, 0.0005, 0.001, 0.0025, 0.005, 0.01];
 const PER_EVENT_COUNT_BUCKETS: [f64; 9] = [1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0];
 const NOTIFICATION_CONTENT_SIZE_BUCKETS: [f64; 9] = [
     128.0, 256.0, 512.0, 1024.0, 2048.0, 4096.0, 8192.0, 16384.0, 32768.0,
 ];
 
-fn observe_outcome(histogram: &HistogramVec, outcome: OutcomeLabel, value: f64) {
-    histogram
-        .with_label_values(&[outcome.as_str()])
-        .observe(value);
+fn observe_label_value(histogram: &HistogramVec, label: &str, value: f64) {
+    histogram.with_label_values(&[label]).observe(value);
 }
 
 fn set_usize_gauge(gauge: &IntGauge, value: usize) {
@@ -270,7 +286,7 @@ impl Metrics {
         let notification_content_size_bytes = Histogram::with_opts(
             HistogramOpts::new(
                 "transponder_notification_content_size_bytes",
-                "Size of kind 446 notification content before base64 decoding",
+                "Decoded size in bytes of kind 446 notification content",
             )
             .buckets(NOTIFICATION_CONTENT_SIZE_BUCKETS.to_vec()),
         )?;
@@ -410,7 +426,7 @@ impl Metrics {
                 "transponder_push_dispatch_admission_duration_seconds",
                 "Duration of push dispatcher admission by outcome",
             )
-            .buckets(PARSE_DURATION_BUCKETS.to_vec()),
+            .buckets(PUSH_ADMISSION_DURATION_BUCKETS.to_vec()),
             &["outcome"],
         )?;
         registry.register(Box::new(push_dispatch_admission_duration_seconds.clone()))?;
@@ -595,28 +611,32 @@ impl Metrics {
     }
 
     /// Observe end-to-end event processing duration.
-    pub fn observe_event_processing_duration(&self, outcome: OutcomeLabel, duration_secs: f64) {
-        observe_outcome(
+    pub fn observe_event_processing_duration(&self, outcome: EventOutcome, duration_secs: f64) {
+        observe_label_value(
             &self.event_processing_duration_seconds,
-            outcome,
+            outcome.as_str(),
             duration_secs,
         );
     }
 
     /// Observe gift-wrap unwrap duration.
-    pub fn observe_gift_wrap_unwrap_duration(&self, outcome: OutcomeLabel, duration_secs: f64) {
-        observe_outcome(
+    pub fn observe_gift_wrap_unwrap_duration(&self, outcome: OperationOutcome, duration_secs: f64) {
+        observe_label_value(
             &self.gift_wrap_unwrap_duration_seconds,
-            outcome,
+            outcome.as_str(),
             duration_secs,
         );
     }
 
     /// Observe notification parse duration.
-    pub fn observe_notification_parse_duration(&self, outcome: OutcomeLabel, duration_secs: f64) {
-        observe_outcome(
+    pub fn observe_notification_parse_duration(
+        &self,
+        outcome: OperationOutcome,
+        duration_secs: f64,
+    ) {
+        observe_label_value(
             &self.notification_parse_duration_seconds,
-            outcome,
+            outcome.as_str(),
             duration_secs,
         );
     }
@@ -626,7 +646,7 @@ impl Metrics {
         self.tokens_per_event.observe(count as f64);
     }
 
-    /// Observe inner notification content size in bytes.
+    /// Observe decoded notification content size in bytes.
     pub fn observe_notification_content_size_bytes(&self, size: usize) {
         self.notification_content_size_bytes.observe(size as f64);
     }
@@ -680,8 +700,12 @@ impl Metrics {
     }
 
     /// Observe per-token decryption duration.
-    pub fn observe_token_decrypt_duration(&self, outcome: OutcomeLabel, duration_secs: f64) {
-        observe_outcome(&self.token_decrypt_duration_seconds, outcome, duration_secs);
+    pub fn observe_token_decrypt_duration(&self, outcome: OperationOutcome, duration_secs: f64) {
+        observe_label_value(
+            &self.token_decrypt_duration_seconds,
+            outcome.as_str(),
+            duration_secs,
+        );
     }
 
     /// Observe the number of notifications admitted to the push dispatcher per event.
@@ -736,12 +760,12 @@ impl Metrics {
     /// Observe push dispatcher admission duration.
     pub fn observe_push_dispatch_admission_duration(
         &self,
-        outcome: OutcomeLabel,
+        outcome: OperationOutcome,
         duration_secs: f64,
     ) {
-        observe_outcome(
+        observe_label_value(
             &self.push_dispatch_admission_duration_seconds,
-            outcome,
+            outcome.as_str(),
             duration_secs,
         );
     }
@@ -823,9 +847,9 @@ mod tests {
         metrics.record_event_deduplicated();
         metrics.record_event_failed();
         metrics.inc_events_in_flight();
-        metrics.observe_event_processing_duration(OutcomeLabel::Processed, 0.01);
-        metrics.observe_gift_wrap_unwrap_duration(OutcomeLabel::Success, 0.005);
-        metrics.observe_notification_parse_duration(OutcomeLabel::Success, 0.001);
+        metrics.observe_event_processing_duration(EventOutcome::Processed, 0.01);
+        metrics.observe_gift_wrap_unwrap_duration(OperationOutcome::Success, 0.005);
+        metrics.observe_notification_parse_duration(OperationOutcome::Success, 0.001);
         metrics.observe_tokens_per_event(3);
         metrics.observe_notification_content_size_bytes(512);
         metrics.dec_events_in_flight();
@@ -854,7 +878,7 @@ mod tests {
             histogram_sample_count(
                 &metrics,
                 "transponder_event_processing_duration_seconds",
-                &[("outcome", OutcomeLabel::Processed.as_str())],
+                &[("outcome", EventOutcome::Processed.as_str())],
             ),
             1
         );
@@ -862,7 +886,7 @@ mod tests {
             histogram_sample_count(
                 &metrics,
                 "transponder_gift_wrap_unwrap_duration_seconds",
-                &[("outcome", OutcomeLabel::Success.as_str())],
+                &[("outcome", OperationOutcome::Success.as_str())],
             ),
             1
         );
@@ -870,7 +894,7 @@ mod tests {
             histogram_sample_count(
                 &metrics,
                 "transponder_notification_parse_duration_seconds",
-                &[("outcome", OutcomeLabel::Success.as_str())],
+                &[("outcome", OperationOutcome::Success.as_str())],
             ),
             1
         );
@@ -905,7 +929,7 @@ mod tests {
         metrics.set_push_semaphore_available(95);
         metrics.set_push_concurrency_limit(100);
         metrics.record_push_queue_rejected(2);
-        metrics.observe_push_dispatch_admission_duration(OutcomeLabel::Success, 0.001);
+        metrics.observe_push_dispatch_admission_duration(OperationOutcome::Success, 0.001);
         metrics.observe_notifications_admitted_per_event(2);
 
         assert_eq!(
@@ -964,7 +988,7 @@ mod tests {
             histogram_sample_count(
                 &metrics,
                 "transponder_push_dispatch_admission_duration_seconds",
-                &[("outcome", OutcomeLabel::Success.as_str())],
+                &[("outcome", OperationOutcome::Success.as_str())],
             ),
             1
         );
@@ -1125,8 +1149,8 @@ mod tests {
 
         metrics.record_token_decrypted();
         metrics.record_token_decryption_failed();
-        metrics.observe_token_decrypt_duration(OutcomeLabel::Success, 0.0005);
-        metrics.observe_token_decrypt_duration(OutcomeLabel::Failed, 0.0007);
+        metrics.observe_token_decrypt_duration(OperationOutcome::Success, 0.0005);
+        metrics.observe_token_decrypt_duration(OperationOutcome::Failed, 0.0007);
 
         assert_eq!(
             counter_value(&metrics, "transponder_tokens_decrypted_total", &[]),
@@ -1140,7 +1164,7 @@ mod tests {
             histogram_sample_count(
                 &metrics,
                 "transponder_token_decrypt_duration_seconds",
-                &[("outcome", OutcomeLabel::Success.as_str())],
+                &[("outcome", OperationOutcome::Success.as_str())],
             ),
             1
         );
@@ -1148,7 +1172,7 @@ mod tests {
             histogram_sample_count(
                 &metrics,
                 "transponder_token_decrypt_duration_seconds",
-                &[("outcome", OutcomeLabel::Failed.as_str())],
+                &[("outcome", OperationOutcome::Failed.as_str())],
             ),
             1
         );

--- a/src/nostr/events.rs
+++ b/src/nostr/events.rs
@@ -16,7 +16,7 @@ use tracing::{debug, trace, warn};
 
 use crate::crypto::{Nip59Handler, TokenDecryptor, TokenPayload};
 use crate::error::Result;
-use crate::metrics::{Metrics, OutcomeLabel};
+use crate::metrics::{EventOutcome, Metrics, OperationOutcome};
 use crate::push::PushDispatcher;
 use crate::rate_limiter::{
     DEFAULT_MAX_SIZE, DEFAULT_RATE_LIMIT_PER_HOUR, DEFAULT_RATE_LIMIT_PER_MINUTE, RateLimitConfig,
@@ -52,6 +52,18 @@ impl Drop for InFlightEventGuard<'_> {
         if let Some(m) = self.metrics {
             m.dec_events_in_flight();
         }
+    }
+}
+
+struct StageTimer(StdInstant);
+
+impl StageTimer {
+    fn start() -> Self {
+        Self(StdInstant::now())
+    }
+
+    fn elapsed_secs(&self) -> f64 {
+        self.0.elapsed().as_secs_f64()
     }
 }
 
@@ -174,7 +186,7 @@ impl EventProcessor {
     /// deduplicated (already seen), or an error if processing failed.
     pub async fn process(&self, event: &Event) -> Result<bool> {
         let _in_flight = InFlightEventGuard::new(self.metrics.as_ref());
-        let started_at = StdInstant::now();
+        let started_at = StageTimer::start();
 
         // Record event received
         if let Some(ref m) = self.metrics {
@@ -187,8 +199,8 @@ impl EventProcessor {
             if let Some(ref m) = self.metrics {
                 m.record_event_deduplicated();
                 m.observe_event_processing_duration(
-                    OutcomeLabel::Duplicate,
-                    started_at.elapsed().as_secs_f64(),
+                    EventOutcome::Duplicate,
+                    started_at.elapsed_secs(),
                 );
             }
             return Ok(false);
@@ -210,8 +222,8 @@ impl EventProcessor {
                 if let Some(ref m) = self.metrics {
                     m.record_event_processed();
                     m.observe_event_processing_duration(
-                        OutcomeLabel::Processed,
-                        started_at.elapsed().as_secs_f64(),
+                        EventOutcome::Processed,
+                        started_at.elapsed_secs(),
                     );
                 }
                 Ok(true)
@@ -226,8 +238,8 @@ impl EventProcessor {
                 if let Some(ref m) = self.metrics {
                     m.record_event_failed();
                     m.observe_event_processing_duration(
-                        OutcomeLabel::Failed,
-                        started_at.elapsed().as_secs_f64(),
+                        EventOutcome::Failed,
+                        started_at.elapsed_secs(),
                     );
                 }
                 Ok(false)
@@ -238,13 +250,13 @@ impl EventProcessor {
     /// Inner processing logic for an event.
     async fn process_inner(&self, event: &Event) -> Result<usize> {
         // Unwrap the gift wrap to get the notification request
-        let unwrap_started_at = StdInstant::now();
+        let unwrap_started_at = StageTimer::start();
         let notification = match self.nip59_handler.unwrap(event).await {
             Ok(notification) => {
                 if let Some(ref m) = self.metrics {
                     m.observe_gift_wrap_unwrap_duration(
-                        OutcomeLabel::Success,
-                        unwrap_started_at.elapsed().as_secs_f64(),
+                        OperationOutcome::Success,
+                        unwrap_started_at.elapsed_secs(),
                     );
                 }
                 notification
@@ -252,8 +264,8 @@ impl EventProcessor {
             Err(e) => {
                 if let Some(ref m) = self.metrics {
                     m.observe_gift_wrap_unwrap_duration(
-                        OutcomeLabel::Failed,
-                        unwrap_started_at.elapsed().as_secs_f64(),
+                        OperationOutcome::Failed,
+                        unwrap_started_at.elapsed_secs(),
                     );
                 }
                 return Err(e);
@@ -265,28 +277,27 @@ impl EventProcessor {
             "Unwrapped notification request"
         );
 
-        if let Some(ref m) = self.metrics {
-            m.observe_notification_content_size_bytes(notification.content.len());
-        }
-
         // Parse the encrypted tokens from the content
-        let parse_started_at = StdInstant::now();
+        let parse_started_at = StageTimer::start();
         let token_bytes = match notification.parse_tokens() {
             Ok(token_bytes) => {
                 if let Some(ref m) = self.metrics {
                     m.observe_notification_parse_duration(
-                        OutcomeLabel::Success,
-                        parse_started_at.elapsed().as_secs_f64(),
+                        OperationOutcome::Success,
+                        parse_started_at.elapsed_secs(),
                     );
                     m.observe_tokens_per_event(token_bytes.len());
+                    m.observe_notification_content_size_bytes(
+                        token_bytes.iter().map(Vec::len).sum(),
+                    );
                 }
                 token_bytes
             }
             Err(e) => {
                 if let Some(ref m) = self.metrics {
                     m.observe_notification_parse_duration(
-                        OutcomeLabel::Failed,
-                        parse_started_at.elapsed().as_secs_f64(),
+                        OperationOutcome::Failed,
+                        parse_started_at.elapsed_secs(),
                     );
                 }
                 return Err(e);
@@ -323,14 +334,14 @@ impl EventProcessor {
             }
 
             // Decrypt the token
-            let decrypt_started_at = StdInstant::now();
+            let decrypt_started_at = StageTimer::start();
             let payload = match self.token_decryptor.decrypt_bytes(&bytes) {
                 Ok(p) => {
                     if let Some(ref m) = self.metrics {
                         m.record_token_decrypted();
                         m.observe_token_decrypt_duration(
-                            OutcomeLabel::Success,
-                            decrypt_started_at.elapsed().as_secs_f64(),
+                            OperationOutcome::Success,
+                            decrypt_started_at.elapsed_secs(),
                         );
                     }
                     p
@@ -341,8 +352,8 @@ impl EventProcessor {
                     if let Some(ref m) = self.metrics {
                         m.record_token_decryption_failed();
                         m.observe_token_decrypt_duration(
-                            OutcomeLabel::Failed,
-                            decrypt_started_at.elapsed().as_secs_f64(),
+                            OperationOutcome::Failed,
+                            decrypt_started_at.elapsed_secs(),
                         );
                     }
                     continue;
@@ -370,17 +381,20 @@ impl EventProcessor {
         }
 
         if payloads.is_empty() {
+            if let Some(ref m) = self.metrics {
+                m.observe_notifications_admitted_per_event(0);
+            }
             return Ok(0);
         }
 
         // Dispatch notifications
-        let dispatch_started_at = StdInstant::now();
+        let dispatch_started_at = StageTimer::start();
         match self.push_dispatcher.dispatch(payloads).await {
             Ok(count) => {
                 if let Some(ref m) = self.metrics {
                     m.observe_push_dispatch_admission_duration(
-                        OutcomeLabel::Success,
-                        dispatch_started_at.elapsed().as_secs_f64(),
+                        OperationOutcome::Success,
+                        dispatch_started_at.elapsed_secs(),
                     );
                     m.observe_notifications_admitted_per_event(count);
                 }
@@ -389,8 +403,8 @@ impl EventProcessor {
             Err(e) => {
                 if let Some(ref m) = self.metrics {
                     m.observe_push_dispatch_admission_duration(
-                        OutcomeLabel::Failed,
-                        dispatch_started_at.elapsed().as_secs_f64(),
+                        OperationOutcome::Failed,
+                        dispatch_started_at.elapsed_secs(),
                     );
                 }
                 Err(e)
@@ -515,10 +529,12 @@ impl EventProcessor {
 mod tests {
     use super::*;
     use crate::config::ApnsConfig;
-    use crate::metrics::{Metrics, OutcomeLabel};
+    use crate::crypto::token::ENCRYPTED_TOKEN_SIZE;
+    use crate::metrics::{EventOutcome, Metrics, OperationOutcome};
     use crate::push::{ApnsClient, PushDispatcher};
     use crate::test_metrics::{
-        counter_value, gauge_value as metric_gauge_value, histogram_sample_count as histogram_count,
+        counter_value, gauge_value as metric_gauge_value,
+        histogram_sample_count as histogram_count, histogram_sample_sum,
     };
     use crate::test_vectors::scenarios;
 
@@ -547,6 +563,13 @@ mod tests {
     }
 
     fn create_processor_with_metrics(server_keys: &Keys) -> (EventProcessor, Metrics) {
+        create_processor_with_metrics_and_rate_limits(server_keys, TokenRateLimitConfig::default())
+    }
+
+    fn create_processor_with_metrics_and_rate_limits(
+        server_keys: &Keys,
+        rate_limit_config: TokenRateLimitConfig,
+    ) -> (EventProcessor, Metrics) {
         let nip59_handler = Nip59Handler::new(server_keys.clone());
         let secp_secret_key =
             secp256k1::SecretKey::from_slice(&server_keys.secret_key().to_secret_bytes())
@@ -572,7 +595,7 @@ mod tests {
                 token_decryptor,
                 push_dispatcher,
                 DEFAULT_MAX_DEDUP_CACHE_SIZE,
-                TokenRateLimitConfig::default(),
+                rate_limit_config,
                 Some(metrics.clone()),
             ),
             metrics,
@@ -622,7 +645,7 @@ mod tests {
             histogram_count(
                 &metrics,
                 "transponder_event_processing_duration_seconds",
-                &[("outcome", OutcomeLabel::Processed.as_str())],
+                &[("outcome", EventOutcome::Processed.as_str())],
             ),
             1
         );
@@ -630,7 +653,7 @@ mod tests {
             histogram_count(
                 &metrics,
                 "transponder_gift_wrap_unwrap_duration_seconds",
-                &[("outcome", OutcomeLabel::Success.as_str())],
+                &[("outcome", OperationOutcome::Success.as_str())],
             ),
             1
         );
@@ -638,7 +661,7 @@ mod tests {
             histogram_count(
                 &metrics,
                 "transponder_notification_parse_duration_seconds",
-                &[("outcome", OutcomeLabel::Success.as_str())],
+                &[("outcome", OperationOutcome::Success.as_str())],
             ),
             1
         );
@@ -646,7 +669,7 @@ mod tests {
             histogram_count(
                 &metrics,
                 "transponder_token_decrypt_duration_seconds",
-                &[("outcome", OutcomeLabel::Success.as_str())],
+                &[("outcome", OperationOutcome::Success.as_str())],
             ),
             1
         );
@@ -654,7 +677,7 @@ mod tests {
             histogram_count(
                 &metrics,
                 "transponder_push_dispatch_admission_duration_seconds",
-                &[("outcome", OutcomeLabel::Success.as_str())],
+                &[("outcome", OperationOutcome::Success.as_str())],
             ),
             1
         );
@@ -669,6 +692,10 @@ mod tests {
                 &[]
             ),
             1
+        );
+        assert_eq!(
+            histogram_sample_sum(&metrics, "transponder_notification_content_size_bytes", &[]),
+            ENCRYPTED_TOKEN_SIZE as f64
         );
     }
 
@@ -727,7 +754,7 @@ mod tests {
             histogram_count(
                 &metrics,
                 "transponder_event_processing_duration_seconds",
-                &[("outcome", OutcomeLabel::Duplicate.as_str())],
+                &[("outcome", EventOutcome::Duplicate.as_str())],
             ),
             1
         );
@@ -808,7 +835,7 @@ mod tests {
             histogram_count(
                 &metrics,
                 "transponder_event_processing_duration_seconds",
-                &[("outcome", OutcomeLabel::Failed.as_str())],
+                &[("outcome", EventOutcome::Failed.as_str())],
             ),
             1
         );
@@ -816,7 +843,7 @@ mod tests {
             histogram_count(
                 &metrics,
                 "transponder_gift_wrap_unwrap_duration_seconds",
-                &[("outcome", OutcomeLabel::Failed.as_str())],
+                &[("outcome", OperationOutcome::Failed.as_str())],
             ),
             1
         );
@@ -856,7 +883,7 @@ mod tests {
             histogram_count(
                 &metrics,
                 "transponder_notification_parse_duration_seconds",
-                &[("outcome", OutcomeLabel::Failed.as_str())],
+                &[("outcome", OperationOutcome::Failed.as_str())],
             ),
             1
         );
@@ -1108,6 +1135,61 @@ mod tests {
             rate_limit_config,
             None,
         )
+    }
+
+    #[tokio::test]
+    async fn test_zero_admission_event_records_metrics() {
+        let server_keys = Keys::generate();
+        let sender_keys = Keys::generate();
+        let device_token = "aabbccdd11223344aabbccdd11223344aabbccdd11223344aabbccdd11223344";
+
+        let (processor, metrics) = create_processor_with_metrics_and_rate_limits(
+            &server_keys,
+            TokenRateLimitConfig {
+                max_cache_size: 100,
+                encrypted_token_per_minute: 100,
+                encrypted_token_per_hour: 1000,
+                device_token_per_minute: 1,
+                device_token_per_hour: 100,
+            },
+        );
+
+        let event1 =
+            scenarios::single_apns_notification(&server_keys, &sender_keys, device_token).await;
+        assert!(processor.process(&event1).await.unwrap());
+
+        let event2 =
+            scenarios::single_apns_notification(&server_keys, &sender_keys, device_token).await;
+        assert!(processor.process(&event2).await.unwrap());
+
+        assert_eq!(
+            counter_value(&metrics, "transponder_events_processed_total", &[]),
+            2.0
+        );
+        assert_eq!(
+            counter_value(
+                &metrics,
+                "transponder_tokens_rate_limited_total",
+                &[("type", "device_token"), ("reason", "minute")],
+            ),
+            1.0
+        );
+        assert_eq!(
+            histogram_count(
+                &metrics,
+                "transponder_notifications_admitted_per_event",
+                &[]
+            ),
+            2
+        );
+        assert_eq!(
+            histogram_sample_sum(
+                &metrics,
+                "transponder_notifications_admitted_per_event",
+                &[]
+            ),
+            1.0
+        );
     }
 
     #[tokio::test]

--- a/src/nostr/events.rs
+++ b/src/nostr/events.rs
@@ -14,6 +14,7 @@ use tokio::sync::RwLock;
 use tokio::time::Instant;
 use tracing::{debug, trace, warn};
 
+use crate::crypto::token::ENCRYPTED_TOKEN_SIZE;
 use crate::crypto::{Nip59Handler, TokenDecryptor, TokenPayload};
 use crate::error::Result;
 use crate::metrics::{EventOutcome, Metrics, OperationOutcome};
@@ -288,7 +289,7 @@ impl EventProcessor {
                     );
                     m.observe_tokens_per_event(token_bytes.len());
                     m.observe_notification_content_size_bytes(
-                        token_bytes.iter().map(Vec::len).sum(),
+                        token_bytes.len() * ENCRYPTED_TOKEN_SIZE,
                     );
                 }
                 token_bytes

--- a/src/nostr/events.rs
+++ b/src/nostr/events.rs
@@ -517,60 +517,13 @@ mod tests {
     use crate::config::ApnsConfig;
     use crate::metrics::{Metrics, OutcomeLabel};
     use crate::push::{ApnsClient, PushDispatcher};
+    use crate::test_metrics::{
+        counter_value, gauge_value as metric_gauge_value, histogram_sample_count as histogram_count,
+    };
     use crate::test_vectors::scenarios;
-    use prometheus::proto::Metric;
-
-    fn metric_matches_labels(metric: &Metric, labels: &[(&str, &str)]) -> bool {
-        labels.iter().all(|(name, value)| {
-            metric
-                .get_label()
-                .iter()
-                .any(|label| label.name() == *name && label.value() == *value)
-        })
-    }
-
-    fn counter_value(metrics: &Metrics, name: &str, labels: &[(&str, &str)]) -> f64 {
-        metrics
-            .gather()
-            .into_iter()
-            .find(|family| family.name() == name)
-            .and_then(|family| {
-                family
-                    .get_metric()
-                    .iter()
-                    .find(|metric| metric_matches_labels(metric, labels))
-                    .and_then(|metric| metric.get_counter().value)
-            })
-            .unwrap_or_default()
-    }
 
     fn gauge_value(metrics: &Metrics, name: &str) -> f64 {
-        metrics
-            .gather()
-            .into_iter()
-            .find(|family| family.name() == name)
-            .and_then(|family| {
-                family
-                    .get_metric()
-                    .first()
-                    .and_then(|metric| metric.get_gauge().value)
-            })
-            .unwrap_or_default()
-    }
-
-    fn histogram_count(metrics: &Metrics, name: &str, labels: &[(&str, &str)]) -> u64 {
-        metrics
-            .gather()
-            .into_iter()
-            .find(|family| family.name() == name)
-            .and_then(|family| {
-                family
-                    .get_metric()
-                    .iter()
-                    .find(|metric| metric_matches_labels(metric, labels))
-                    .and_then(|metric| metric.get_histogram().sample_count)
-            })
-            .unwrap_or_default()
+        metric_gauge_value(metrics, name, &[])
     }
 
     fn create_processor(server_keys: &Keys) -> EventProcessor {

--- a/src/nostr/events.rs
+++ b/src/nostr/events.rs
@@ -406,6 +406,7 @@ impl EventProcessor {
                         OperationOutcome::Failed,
                         dispatch_started_at.elapsed_secs(),
                     );
+                    m.observe_notifications_admitted_per_event(0);
                 }
                 Err(e)
             }
@@ -596,6 +597,43 @@ mod tests {
                 push_dispatcher,
                 DEFAULT_MAX_DEDUP_CACHE_SIZE,
                 rate_limit_config,
+                Some(metrics.clone()),
+            ),
+            metrics,
+        )
+    }
+
+    async fn create_processor_with_shutdown_dispatcher_metrics(
+        server_keys: &Keys,
+    ) -> (EventProcessor, Metrics) {
+        let nip59_handler = Nip59Handler::new(server_keys.clone());
+        let secp_secret_key =
+            secp256k1::SecretKey::from_slice(&server_keys.secret_key().to_secret_bytes())
+                .expect("valid secret key");
+        let token_decryptor = TokenDecryptor::new(secp_secret_key);
+        let apns_config = ApnsConfig {
+            enabled: true,
+            key_id: "KEY123".to_string(),
+            team_id: "TEAM456".to_string(),
+            private_key_path: String::new(),
+            environment: "sandbox".to_string(),
+            bundle_id: "com.example.app".to_string(),
+        };
+        let metrics = Metrics::new().expect("metrics");
+        let push_dispatcher = Arc::new(PushDispatcher::with_metrics(
+            Some(ApnsClient::mock(apns_config, true)),
+            None,
+            Some(metrics.clone()),
+        ));
+        push_dispatcher.wait_for_completion().await;
+
+        (
+            EventProcessor::with_full_config(
+                nip59_handler,
+                token_decryptor,
+                push_dispatcher,
+                DEFAULT_MAX_DEDUP_CACHE_SIZE,
+                TokenRateLimitConfig::default(),
                 Some(metrics.clone()),
             ),
             metrics,
@@ -846,6 +884,51 @@ mod tests {
                 &[("outcome", OperationOutcome::Failed.as_str())],
             ),
             1
+        );
+    }
+
+    #[tokio::test]
+    async fn test_process_dispatch_failure_records_zero_admissions() {
+        let server_keys = Keys::generate();
+        let sender_keys = Keys::generate();
+        let device_token = "aabbccdd11223344aabbccdd11223344aabbccdd11223344aabbccdd11223344";
+
+        let event =
+            scenarios::single_apns_notification(&server_keys, &sender_keys, device_token).await;
+
+        let (processor, metrics) =
+            create_processor_with_shutdown_dispatcher_metrics(&server_keys).await;
+        let result = processor.process(&event).await;
+
+        assert!(result.is_ok());
+        assert!(!result.unwrap());
+        assert_eq!(
+            counter_value(&metrics, "transponder_events_failed_total", &[]),
+            1.0
+        );
+        assert_eq!(
+            histogram_count(
+                &metrics,
+                "transponder_push_dispatch_admission_duration_seconds",
+                &[("outcome", OperationOutcome::Failed.as_str())],
+            ),
+            1
+        );
+        assert_eq!(
+            histogram_count(
+                &metrics,
+                "transponder_notifications_admitted_per_event",
+                &[]
+            ),
+            1
+        );
+        assert_eq!(
+            histogram_sample_sum(
+                &metrics,
+                "transponder_notifications_admitted_per_event",
+                &[]
+            ),
+            0.0
         );
     }
 

--- a/src/nostr/events.rs
+++ b/src/nostr/events.rs
@@ -5,7 +5,7 @@
 
 use std::num::NonZeroUsize;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant as StdInstant};
 
 use lru::LruCache;
 use nostr_sdk::prelude::*;
@@ -31,6 +31,28 @@ const CLEANUP_BATCH_SIZE: usize = 1000;
 
 /// Default maximum size for the deduplication cache.
 pub const DEFAULT_MAX_DEDUP_CACHE_SIZE: usize = 100_000;
+
+struct InFlightEventGuard {
+    metrics: Option<Metrics>,
+}
+
+impl InFlightEventGuard {
+    fn new(metrics: Option<Metrics>) -> Self {
+        if let Some(ref m) = metrics {
+            m.inc_events_in_flight();
+        }
+
+        Self { metrics }
+    }
+}
+
+impl Drop for InFlightEventGuard {
+    fn drop(&mut self) {
+        if let Some(ref m) = self.metrics {
+            m.dec_events_in_flight();
+        }
+    }
+}
 
 /// Event processor for handling incoming gift-wrapped notifications.
 pub struct EventProcessor {
@@ -150,6 +172,9 @@ impl EventProcessor {
     /// Returns `Ok(true)` if the event was processed, `Ok(false)` if it was
     /// deduplicated (already seen), or an error if processing failed.
     pub async fn process(&self, event: &Event) -> Result<bool> {
+        let _in_flight = InFlightEventGuard::new(self.metrics.clone());
+        let started_at = StdInstant::now();
+
         // Record event received
         if let Some(ref m) = self.metrics {
             m.record_event_received();
@@ -160,6 +185,10 @@ impl EventProcessor {
             trace!(event_id = %event.id, "Skipping duplicate event");
             if let Some(ref m) = self.metrics {
                 m.record_event_deduplicated();
+                m.observe_event_processing_duration(
+                    "duplicate",
+                    started_at.elapsed().as_secs_f64(),
+                );
             }
             return Ok(false);
         }
@@ -179,6 +208,10 @@ impl EventProcessor {
 
                 if let Some(ref m) = self.metrics {
                     m.record_event_processed();
+                    m.observe_event_processing_duration(
+                        "processed",
+                        started_at.elapsed().as_secs_f64(),
+                    );
                 }
                 Ok(true)
             }
@@ -191,6 +224,10 @@ impl EventProcessor {
                 );
                 if let Some(ref m) = self.metrics {
                     m.record_event_failed();
+                    m.observe_event_processing_duration(
+                        "failed",
+                        started_at.elapsed().as_secs_f64(),
+                    );
                 }
                 Ok(false)
             }
@@ -200,15 +237,60 @@ impl EventProcessor {
     /// Inner processing logic for an event.
     async fn process_inner(&self, event: &Event) -> Result<usize> {
         // Unwrap the gift wrap to get the notification request
-        let notification = self.nip59_handler.unwrap(event).await?;
+        let unwrap_started_at = StdInstant::now();
+        let notification = match self.nip59_handler.unwrap(event).await {
+            Ok(notification) => {
+                if let Some(ref m) = self.metrics {
+                    m.observe_gift_wrap_unwrap_duration(
+                        "success",
+                        unwrap_started_at.elapsed().as_secs_f64(),
+                    );
+                }
+                notification
+            }
+            Err(e) => {
+                if let Some(ref m) = self.metrics {
+                    m.observe_gift_wrap_unwrap_duration(
+                        "failed",
+                        unwrap_started_at.elapsed().as_secs_f64(),
+                    );
+                }
+                return Err(e);
+            }
+        };
 
         trace!(
             sender = %notification.sender_pubkey,
             "Unwrapped notification request"
         );
 
+        if let Some(ref m) = self.metrics {
+            m.observe_notification_content_size_bytes(notification.content.len());
+        }
+
         // Parse the encrypted tokens from the content
-        let token_bytes = notification.parse_tokens()?;
+        let parse_started_at = StdInstant::now();
+        let token_bytes = match notification.parse_tokens() {
+            Ok(token_bytes) => {
+                if let Some(ref m) = self.metrics {
+                    m.observe_notification_parse_duration(
+                        "success",
+                        parse_started_at.elapsed().as_secs_f64(),
+                    );
+                    m.observe_tokens_per_event(token_bytes.len());
+                }
+                token_bytes
+            }
+            Err(e) => {
+                if let Some(ref m) = self.metrics {
+                    m.observe_notification_parse_duration(
+                        "failed",
+                        parse_started_at.elapsed().as_secs_f64(),
+                    );
+                }
+                return Err(e);
+            }
+        };
 
         if token_bytes.is_empty() {
             return Ok(0);
@@ -240,10 +322,15 @@ impl EventProcessor {
             }
 
             // Decrypt the token
+            let decrypt_started_at = StdInstant::now();
             let payload = match self.token_decryptor.decrypt_bytes(&bytes) {
                 Ok(p) => {
                     if let Some(ref m) = self.metrics {
                         m.record_token_decrypted();
+                        m.observe_token_decrypt_duration(
+                            "success",
+                            decrypt_started_at.elapsed().as_secs_f64(),
+                        );
                     }
                     p
                 }
@@ -252,6 +339,10 @@ impl EventProcessor {
                     trace!(error = %e, "Failed to decrypt token (ignoring)");
                     if let Some(ref m) = self.metrics {
                         m.record_token_decryption_failed();
+                        m.observe_token_decrypt_duration(
+                            "failed",
+                            decrypt_started_at.elapsed().as_secs_f64(),
+                        );
                     }
                     continue;
                 }
@@ -282,7 +373,28 @@ impl EventProcessor {
         }
 
         // Dispatch notifications
-        self.push_dispatcher.dispatch(payloads).await
+        let dispatch_started_at = StdInstant::now();
+        match self.push_dispatcher.dispatch(payloads).await {
+            Ok(count) => {
+                if let Some(ref m) = self.metrics {
+                    m.observe_push_dispatch_admission_duration(
+                        "success",
+                        dispatch_started_at.elapsed().as_secs_f64(),
+                    );
+                    m.observe_notifications_admitted_per_event(count);
+                }
+                Ok(count)
+            }
+            Err(e) => {
+                if let Some(ref m) = self.metrics {
+                    m.observe_push_dispatch_admission_duration(
+                        "failed",
+                        dispatch_started_at.elapsed().as_secs_f64(),
+                    );
+                }
+                Err(e)
+            }
+        }
     }
 
     /// Hash arbitrary bytes to a fixed-size key for rate limiting.

--- a/src/nostr/events.rs
+++ b/src/nostr/events.rs
@@ -16,7 +16,7 @@ use tracing::{debug, trace, warn};
 
 use crate::crypto::{Nip59Handler, TokenDecryptor, TokenPayload};
 use crate::error::Result;
-use crate::metrics::Metrics;
+use crate::metrics::{Metrics, OutcomeLabel};
 use crate::push::PushDispatcher;
 use crate::rate_limiter::{
     DEFAULT_MAX_SIZE, DEFAULT_RATE_LIMIT_PER_HOUR, DEFAULT_RATE_LIMIT_PER_MINUTE, RateLimitConfig,
@@ -32,13 +32,14 @@ const CLEANUP_BATCH_SIZE: usize = 1000;
 /// Default maximum size for the deduplication cache.
 pub const DEFAULT_MAX_DEDUP_CACHE_SIZE: usize = 100_000;
 
-struct InFlightEventGuard {
-    metrics: Option<Metrics>,
+#[must_use]
+struct InFlightEventGuard<'a> {
+    metrics: Option<&'a Metrics>,
 }
 
-impl InFlightEventGuard {
-    fn new(metrics: Option<Metrics>) -> Self {
-        if let Some(ref m) = metrics {
+impl<'a> InFlightEventGuard<'a> {
+    fn new(metrics: Option<&'a Metrics>) -> Self {
+        if let Some(m) = metrics {
             m.inc_events_in_flight();
         }
 
@@ -46,9 +47,9 @@ impl InFlightEventGuard {
     }
 }
 
-impl Drop for InFlightEventGuard {
+impl Drop for InFlightEventGuard<'_> {
     fn drop(&mut self) {
-        if let Some(ref m) = self.metrics {
+        if let Some(m) = self.metrics {
             m.dec_events_in_flight();
         }
     }
@@ -172,7 +173,7 @@ impl EventProcessor {
     /// Returns `Ok(true)` if the event was processed, `Ok(false)` if it was
     /// deduplicated (already seen), or an error if processing failed.
     pub async fn process(&self, event: &Event) -> Result<bool> {
-        let _in_flight = InFlightEventGuard::new(self.metrics.clone());
+        let _in_flight = InFlightEventGuard::new(self.metrics.as_ref());
         let started_at = StdInstant::now();
 
         // Record event received
@@ -186,7 +187,7 @@ impl EventProcessor {
             if let Some(ref m) = self.metrics {
                 m.record_event_deduplicated();
                 m.observe_event_processing_duration(
-                    "duplicate",
+                    OutcomeLabel::Duplicate,
                     started_at.elapsed().as_secs_f64(),
                 );
             }
@@ -209,7 +210,7 @@ impl EventProcessor {
                 if let Some(ref m) = self.metrics {
                     m.record_event_processed();
                     m.observe_event_processing_duration(
-                        "processed",
+                        OutcomeLabel::Processed,
                         started_at.elapsed().as_secs_f64(),
                     );
                 }
@@ -225,7 +226,7 @@ impl EventProcessor {
                 if let Some(ref m) = self.metrics {
                     m.record_event_failed();
                     m.observe_event_processing_duration(
-                        "failed",
+                        OutcomeLabel::Failed,
                         started_at.elapsed().as_secs_f64(),
                     );
                 }
@@ -242,7 +243,7 @@ impl EventProcessor {
             Ok(notification) => {
                 if let Some(ref m) = self.metrics {
                     m.observe_gift_wrap_unwrap_duration(
-                        "success",
+                        OutcomeLabel::Success,
                         unwrap_started_at.elapsed().as_secs_f64(),
                     );
                 }
@@ -251,7 +252,7 @@ impl EventProcessor {
             Err(e) => {
                 if let Some(ref m) = self.metrics {
                     m.observe_gift_wrap_unwrap_duration(
-                        "failed",
+                        OutcomeLabel::Failed,
                         unwrap_started_at.elapsed().as_secs_f64(),
                     );
                 }
@@ -274,7 +275,7 @@ impl EventProcessor {
             Ok(token_bytes) => {
                 if let Some(ref m) = self.metrics {
                     m.observe_notification_parse_duration(
-                        "success",
+                        OutcomeLabel::Success,
                         parse_started_at.elapsed().as_secs_f64(),
                     );
                     m.observe_tokens_per_event(token_bytes.len());
@@ -284,7 +285,7 @@ impl EventProcessor {
             Err(e) => {
                 if let Some(ref m) = self.metrics {
                     m.observe_notification_parse_duration(
-                        "failed",
+                        OutcomeLabel::Failed,
                         parse_started_at.elapsed().as_secs_f64(),
                     );
                 }
@@ -328,7 +329,7 @@ impl EventProcessor {
                     if let Some(ref m) = self.metrics {
                         m.record_token_decrypted();
                         m.observe_token_decrypt_duration(
-                            "success",
+                            OutcomeLabel::Success,
                             decrypt_started_at.elapsed().as_secs_f64(),
                         );
                     }
@@ -340,7 +341,7 @@ impl EventProcessor {
                     if let Some(ref m) = self.metrics {
                         m.record_token_decryption_failed();
                         m.observe_token_decrypt_duration(
-                            "failed",
+                            OutcomeLabel::Failed,
                             decrypt_started_at.elapsed().as_secs_f64(),
                         );
                     }
@@ -378,7 +379,7 @@ impl EventProcessor {
             Ok(count) => {
                 if let Some(ref m) = self.metrics {
                     m.observe_push_dispatch_admission_duration(
-                        "success",
+                        OutcomeLabel::Success,
                         dispatch_started_at.elapsed().as_secs_f64(),
                     );
                     m.observe_notifications_admitted_per_event(count);
@@ -388,7 +389,7 @@ impl EventProcessor {
             Err(e) => {
                 if let Some(ref m) = self.metrics {
                     m.observe_push_dispatch_admission_duration(
-                        "failed",
+                        OutcomeLabel::Failed,
                         dispatch_started_at.elapsed().as_secs_f64(),
                     );
                 }
@@ -513,8 +514,64 @@ impl EventProcessor {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::push::PushDispatcher;
+    use crate::config::ApnsConfig;
+    use crate::metrics::{Metrics, OutcomeLabel};
+    use crate::push::{ApnsClient, PushDispatcher};
     use crate::test_vectors::scenarios;
+    use prometheus::proto::Metric;
+
+    fn metric_matches_labels(metric: &Metric, labels: &[(&str, &str)]) -> bool {
+        labels.iter().all(|(name, value)| {
+            metric
+                .get_label()
+                .iter()
+                .any(|label| label.name() == *name && label.value() == *value)
+        })
+    }
+
+    fn counter_value(metrics: &Metrics, name: &str, labels: &[(&str, &str)]) -> f64 {
+        metrics
+            .gather()
+            .into_iter()
+            .find(|family| family.name() == name)
+            .and_then(|family| {
+                family
+                    .get_metric()
+                    .iter()
+                    .find(|metric| metric_matches_labels(metric, labels))
+                    .and_then(|metric| metric.get_counter().value)
+            })
+            .unwrap_or_default()
+    }
+
+    fn gauge_value(metrics: &Metrics, name: &str) -> f64 {
+        metrics
+            .gather()
+            .into_iter()
+            .find(|family| family.name() == name)
+            .and_then(|family| {
+                family
+                    .get_metric()
+                    .first()
+                    .and_then(|metric| metric.get_gauge().value)
+            })
+            .unwrap_or_default()
+    }
+
+    fn histogram_count(metrics: &Metrics, name: &str, labels: &[(&str, &str)]) -> u64 {
+        metrics
+            .gather()
+            .into_iter()
+            .find(|family| family.name() == name)
+            .and_then(|family| {
+                family
+                    .get_metric()
+                    .iter()
+                    .find(|metric| metric_matches_labels(metric, labels))
+                    .and_then(|metric| metric.get_histogram().sample_count)
+            })
+            .unwrap_or_default()
+    }
 
     fn create_processor(server_keys: &Keys) -> EventProcessor {
         let nip59_handler = Nip59Handler::new(server_keys.clone());
@@ -536,6 +593,39 @@ mod tests {
         EventProcessor::with_cache_size(nip59_handler, token_decryptor, push_dispatcher, cache_size)
     }
 
+    fn create_processor_with_metrics(server_keys: &Keys) -> (EventProcessor, Metrics) {
+        let nip59_handler = Nip59Handler::new(server_keys.clone());
+        let secp_secret_key =
+            secp256k1::SecretKey::from_slice(&server_keys.secret_key().to_secret_bytes())
+                .expect("valid secret key");
+        let token_decryptor = TokenDecryptor::new(secp_secret_key);
+        let apns_config = ApnsConfig {
+            enabled: true,
+            key_id: "KEY123".to_string(),
+            team_id: "TEAM456".to_string(),
+            private_key_path: String::new(),
+            environment: "sandbox".to_string(),
+            bundle_id: "com.example.app".to_string(),
+        };
+        let metrics = Metrics::new().expect("metrics");
+        let push_dispatcher = Arc::new(PushDispatcher::with_metrics(
+            Some(ApnsClient::mock(apns_config, true)),
+            None,
+            Some(metrics.clone()),
+        ));
+        (
+            EventProcessor::with_full_config(
+                nip59_handler,
+                token_decryptor,
+                push_dispatcher,
+                DEFAULT_MAX_DEDUP_CACHE_SIZE,
+                TokenRateLimitConfig::default(),
+                Some(metrics.clone()),
+            ),
+            metrics,
+        )
+    }
+
     #[tokio::test]
     async fn test_process_valid_gift_wrap_event() {
         let server_keys = Keys::generate();
@@ -550,6 +640,83 @@ mod tests {
 
         assert!(result.is_ok());
         assert!(result.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_process_valid_gift_wrap_event_records_metrics() {
+        let server_keys = Keys::generate();
+        let sender_keys = Keys::generate();
+        let device_token = "aabbccdd11223344aabbccdd11223344aabbccdd11223344aabbccdd11223344";
+
+        let event =
+            scenarios::single_apns_notification(&server_keys, &sender_keys, device_token).await;
+
+        let (processor, metrics) = create_processor_with_metrics(&server_keys);
+        let result = processor.process(&event).await;
+
+        assert!(result.is_ok());
+        assert!(result.unwrap());
+        assert_eq!(
+            counter_value(&metrics, "transponder_events_received_total", &[]),
+            1.0
+        );
+        assert_eq!(
+            counter_value(&metrics, "transponder_events_processed_total", &[]),
+            1.0
+        );
+        assert_eq!(gauge_value(&metrics, "transponder_events_in_flight"), 0.0);
+        assert_eq!(
+            histogram_count(
+                &metrics,
+                "transponder_event_processing_duration_seconds",
+                &[("outcome", OutcomeLabel::Processed.as_str())],
+            ),
+            1
+        );
+        assert_eq!(
+            histogram_count(
+                &metrics,
+                "transponder_gift_wrap_unwrap_duration_seconds",
+                &[("outcome", OutcomeLabel::Success.as_str())],
+            ),
+            1
+        );
+        assert_eq!(
+            histogram_count(
+                &metrics,
+                "transponder_notification_parse_duration_seconds",
+                &[("outcome", OutcomeLabel::Success.as_str())],
+            ),
+            1
+        );
+        assert_eq!(
+            histogram_count(
+                &metrics,
+                "transponder_token_decrypt_duration_seconds",
+                &[("outcome", OutcomeLabel::Success.as_str())],
+            ),
+            1
+        );
+        assert_eq!(
+            histogram_count(
+                &metrics,
+                "transponder_push_dispatch_admission_duration_seconds",
+                &[("outcome", OutcomeLabel::Success.as_str())],
+            ),
+            1
+        );
+        assert_eq!(
+            histogram_count(&metrics, "transponder_tokens_per_event", &[]),
+            1
+        );
+        assert_eq!(
+            histogram_count(
+                &metrics,
+                "transponder_notifications_admitted_per_event",
+                &[]
+            ),
+            1
+        );
     }
 
     #[tokio::test]
@@ -575,6 +742,42 @@ mod tests {
         let result2 = processor.process(&event).await;
         assert!(result2.is_ok());
         assert!(!result2.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_process_duplicate_event_records_metrics() {
+        let server_keys = Keys::generate();
+        let sender_keys = Keys::generate();
+
+        let event = scenarios::single_apns_notification(
+            &server_keys,
+            &sender_keys,
+            "deadbeef12345678deadbeef12345678deadbeef12345678deadbeef12345678",
+        )
+        .await;
+
+        let (processor, metrics) = create_processor_with_metrics(&server_keys);
+
+        assert!(processor.process(&event).await.unwrap());
+        assert!(!processor.process(&event).await.unwrap());
+
+        assert_eq!(
+            counter_value(&metrics, "transponder_events_received_total", &[]),
+            2.0
+        );
+        assert_eq!(
+            counter_value(&metrics, "transponder_events_deduplicated_total", &[]),
+            1.0
+        );
+        assert_eq!(gauge_value(&metrics, "transponder_events_in_flight"), 0.0);
+        assert_eq!(
+            histogram_count(
+                &metrics,
+                "transponder_event_processing_duration_seconds",
+                &[("outcome", OutcomeLabel::Duplicate.as_str())],
+            ),
+            1
+        );
     }
 
     #[tokio::test]
@@ -626,6 +829,47 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_process_failed_event_records_metrics() {
+        let server_keys = Keys::generate();
+        let wrong_server_keys = Keys::generate();
+        let sender_keys = Keys::generate();
+
+        let event = scenarios::single_apns_notification(
+            &wrong_server_keys,
+            &sender_keys,
+            "deadbeef12345678deadbeef12345678deadbeef12345678deadbeef12345678",
+        )
+        .await;
+
+        let (processor, metrics) = create_processor_with_metrics(&server_keys);
+        let result = processor.process(&event).await;
+
+        assert!(result.is_ok());
+        assert!(!result.unwrap());
+        assert_eq!(
+            counter_value(&metrics, "transponder_events_failed_total", &[]),
+            1.0
+        );
+        assert_eq!(gauge_value(&metrics, "transponder_events_in_flight"), 0.0);
+        assert_eq!(
+            histogram_count(
+                &metrics,
+                "transponder_event_processing_duration_seconds",
+                &[("outcome", OutcomeLabel::Failed.as_str())],
+            ),
+            1
+        );
+        assert_eq!(
+            histogram_count(
+                &metrics,
+                "transponder_gift_wrap_unwrap_duration_seconds",
+                &[("outcome", OutcomeLabel::Failed.as_str())],
+            ),
+            1
+        );
+    }
+
+    #[tokio::test]
     async fn test_process_empty_token_blob() {
         let server_keys = Keys::generate();
         let sender_keys = Keys::generate();
@@ -637,6 +881,32 @@ mod tests {
 
         assert!(result.is_ok());
         assert!(!result.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_process_empty_token_blob_records_parse_failure_metrics() {
+        let server_keys = Keys::generate();
+        let sender_keys = Keys::generate();
+
+        let event = scenarios::empty_notification(&server_keys, &sender_keys).await;
+
+        let (processor, metrics) = create_processor_with_metrics(&server_keys);
+        let result = processor.process(&event).await;
+
+        assert!(result.is_ok());
+        assert!(!result.unwrap());
+        assert_eq!(
+            counter_value(&metrics, "transponder_events_failed_total", &[]),
+            1.0
+        );
+        assert_eq!(
+            histogram_count(
+                &metrics,
+                "transponder_notification_parse_duration_seconds",
+                &[("outcome", OutcomeLabel::Failed.as_str())],
+            ),
+            1
+        );
     }
 
     #[tokio::test]

--- a/src/push/dispatcher.rs
+++ b/src/push/dispatcher.rs
@@ -102,9 +102,12 @@ impl PushDispatcher {
         let queue_depth = Arc::new(AtomicUsize::new(0));
         let shutting_down = Arc::new(AtomicBool::new(false));
 
-        // Initialize semaphore metric
+        // Initialize push capacity metrics
         if let Some(ref m) = metrics {
+            m.set_push_queue_size(0);
+            m.set_push_queue_capacity(MAX_PENDING_QUEUE_SIZE);
             m.set_push_semaphore_available(MAX_CONCURRENT_PUSHES);
+            m.set_push_concurrency_limit(MAX_CONCURRENT_PUSHES);
         }
 
         // Spawn worker tasks
@@ -302,6 +305,9 @@ impl PushDispatcher {
         let _admission_guard = self.admission_lock.lock().await;
 
         if self.shutting_down.load(Ordering::SeqCst) {
+            if let Some(ref m) = self.metrics {
+                m.record_push_queue_rejected();
+            }
             debug!("Dispatcher shutting down, ignoring dispatch request");
             return Err(Error::Dispatch("Dispatcher is shutting down".to_string()));
         }
@@ -348,6 +354,9 @@ impl PushDispatcher {
                 .try_reserve_many(message_count)
                 .map_err(|error| match error {
                     mpsc::error::TrySendError::Full(_) => {
+                        if let Some(ref m) = self.metrics {
+                            m.record_push_queue_rejected();
+                        }
                         warn!(
                             requested = message_count,
                             available = self.sender.capacity(),
@@ -358,6 +367,9 @@ impl PushDispatcher {
                         ))
                     }
                     mpsc::error::TrySendError::Closed(_) => {
+                        if let Some(ref m) = self.metrics {
+                            m.record_push_queue_rejected();
+                        }
                         warn!("Push queue closed, rejecting notification batch");
                         Error::Dispatch("Push queue closed".to_string())
                     }

--- a/src/push/dispatcher.rs
+++ b/src/push/dispatcher.rs
@@ -336,19 +336,19 @@ impl PushDispatcher {
             messages.push(QueuedPushMessage { platform, token });
         }
 
-        if messages.is_empty() {
-            return Ok(0);
-        }
-
         let message_count = messages.len();
-        // Check shutdown after platform/token filtering so the rejection metric only
-        // counts messages that would otherwise have been admissible.
+        // Check shutdown after platform/token filtering so post-shutdown requests
+        // always fail while the rejection metric only counts admissible messages.
         if self.shutting_down.load(Ordering::SeqCst) {
             if let Some(ref m) = self.metrics {
                 m.record_push_queue_rejected(message_count as u64);
             }
             debug!("Dispatcher shutting down, ignoring dispatch request");
             return Err(Error::Dispatch("Dispatcher is shutting down".to_string()));
+        }
+
+        if messages.is_empty() {
+            return Ok(0);
         }
 
         let mut permits =
@@ -1006,6 +1006,21 @@ mod tests {
             counter_metric_value(&metrics, "transponder_push_queue_rejected_total"),
             1
         );
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_after_shutdown_rejects_filtered_batch() {
+        let dispatcher = PushDispatcher::new(None, None);
+
+        dispatcher.wait_for_completion().await;
+
+        let payloads = vec![TokenPayload {
+            platform: Platform::Apns,
+            device_token: vec![0xaa, 0xbb, 0xcc],
+        }];
+
+        let error = dispatcher.dispatch(payloads).await.unwrap_err();
+        assert!(matches!(error, Error::Dispatch(_)));
     }
 
     #[tokio::test]

--- a/src/push/dispatcher.rs
+++ b/src/push/dispatcher.rs
@@ -304,15 +304,6 @@ impl PushDispatcher {
     pub async fn dispatch(&self, payloads: Vec<TokenPayload>) -> Result<usize> {
         let _admission_guard = self.admission_lock.lock().await;
         let requested_count = payloads.len();
-
-        if self.shutting_down.load(Ordering::SeqCst) {
-            if let Some(ref m) = self.metrics {
-                m.record_push_queue_rejected(requested_count as u64);
-            }
-            debug!("Dispatcher shutting down, ignoring dispatch request");
-            return Err(Error::Dispatch("Dispatcher is shutting down".to_string()));
-        }
-
         let mut messages = Vec::with_capacity(requested_count);
 
         for payload in payloads {
@@ -350,6 +341,8 @@ impl PushDispatcher {
         }
 
         let message_count = messages.len();
+        // Check shutdown after platform/token filtering so the rejection metric only
+        // counts messages that would otherwise have been admissible.
         if self.shutting_down.load(Ordering::SeqCst) {
             if let Some(ref m) = self.metrics {
                 m.record_push_queue_rejected(message_count as u64);
@@ -880,7 +873,23 @@ mod tests {
 
     #[tokio::test]
     async fn test_dispatch_after_shutdown() {
-        let dispatcher = PushDispatcher::new(None, None);
+        use crate::config::ApnsConfig;
+        use crate::push::ApnsClient;
+
+        let dispatcher = PushDispatcher::new(
+            Some(ApnsClient::mock(
+                ApnsConfig {
+                    enabled: true,
+                    key_id: "KEY123".to_string(),
+                    team_id: "TEAM456".to_string(),
+                    private_key_path: String::new(),
+                    environment: "sandbox".to_string(),
+                    bundle_id: "com.example.app".to_string(),
+                },
+                true,
+            )),
+            None,
+        );
 
         // Shutdown the dispatcher
         dispatcher.wait_for_completion().await;
@@ -919,10 +928,26 @@ mod tests {
 
     #[tokio::test]
     async fn test_dispatch_after_shutdown_records_rejection_metric() {
+        use crate::config::ApnsConfig;
         use crate::metrics::Metrics;
+        use crate::push::ApnsClient;
 
         let metrics = Metrics::default();
-        let dispatcher = PushDispatcher::with_metrics(None, None, Some(metrics.clone()));
+        let dispatcher = PushDispatcher::with_metrics(
+            Some(ApnsClient::mock(
+                ApnsConfig {
+                    enabled: true,
+                    key_id: "KEY123".to_string(),
+                    team_id: "TEAM456".to_string(),
+                    private_key_path: String::new(),
+                    environment: "sandbox".to_string(),
+                    bundle_id: "com.example.app".to_string(),
+                },
+                true,
+            )),
+            None,
+            Some(metrics.clone()),
+        );
 
         dispatcher.wait_for_completion().await;
 
@@ -930,6 +955,50 @@ mod tests {
             platform: Platform::Apns,
             device_token: vec![0xaa, 0xbb, 0xcc],
         }];
+
+        let error = dispatcher.dispatch(payloads).await.unwrap_err();
+        assert!(matches!(error, Error::Dispatch(_)));
+        assert_eq!(
+            counter_metric_value(&metrics, "transponder_push_queue_rejected_total"),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_after_shutdown_rejects_only_admissible_payloads() {
+        use crate::config::ApnsConfig;
+        use crate::metrics::Metrics;
+        use crate::push::ApnsClient;
+
+        let metrics = Metrics::default();
+        let dispatcher = PushDispatcher::with_metrics(
+            Some(ApnsClient::mock(
+                ApnsConfig {
+                    enabled: true,
+                    key_id: "KEY123".to_string(),
+                    team_id: "TEAM456".to_string(),
+                    private_key_path: String::new(),
+                    environment: "sandbox".to_string(),
+                    bundle_id: "com.example.app".to_string(),
+                },
+                true,
+            )),
+            None,
+            Some(metrics.clone()),
+        );
+
+        dispatcher.wait_for_completion().await;
+
+        let payloads = vec![
+            TokenPayload {
+                platform: Platform::Apns,
+                device_token: vec![0xaa, 0xbb, 0xcc],
+            },
+            TokenPayload {
+                platform: Platform::Fcm,
+                device_token: b"fcm-token-123".to_vec(),
+            },
+        ];
 
         let error = dispatcher.dispatch(payloads).await.unwrap_err();
         assert!(matches!(error, Error::Dispatch(_)));

--- a/src/push/dispatcher.rs
+++ b/src/push/dispatcher.rs
@@ -303,16 +303,17 @@ impl PushDispatcher {
     /// admitted locally". Invalid tokens are silently ignored per MIP-05 spec.
     pub async fn dispatch(&self, payloads: Vec<TokenPayload>) -> Result<usize> {
         let _admission_guard = self.admission_lock.lock().await;
+        let requested_count = payloads.len();
 
         if self.shutting_down.load(Ordering::SeqCst) {
             if let Some(ref m) = self.metrics {
-                m.record_push_queue_rejected();
+                m.record_push_queue_rejected(requested_count as u64);
             }
             debug!("Dispatcher shutting down, ignoring dispatch request");
             return Err(Error::Dispatch("Dispatcher is shutting down".to_string()));
         }
 
-        let mut messages = Vec::with_capacity(payloads.len());
+        let mut messages = Vec::with_capacity(requested_count);
 
         for payload in payloads {
             // Extract token as Zeroizing<String> for automatic cleanup
@@ -349,13 +350,21 @@ impl PushDispatcher {
         }
 
         let message_count = messages.len();
+        if self.shutting_down.load(Ordering::SeqCst) {
+            if let Some(ref m) = self.metrics {
+                m.record_push_queue_rejected(message_count as u64);
+            }
+            debug!("Dispatcher shutting down, ignoring dispatch request");
+            return Err(Error::Dispatch("Dispatcher is shutting down".to_string()));
+        }
+
         let mut permits =
             self.sender
                 .try_reserve_many(message_count)
                 .map_err(|error| match error {
                     mpsc::error::TrySendError::Full(_) => {
                         if let Some(ref m) = self.metrics {
-                            m.record_push_queue_rejected();
+                            m.record_push_queue_rejected(message_count as u64);
                         }
                         warn!(
                             requested = message_count,
@@ -368,7 +377,7 @@ impl PushDispatcher {
                     }
                     mpsc::error::TrySendError::Closed(_) => {
                         if let Some(ref m) = self.metrics {
-                            m.record_push_queue_rejected();
+                            m.record_push_queue_rejected(message_count as u64);
                         }
                         warn!("Push queue closed, rejecting notification batch");
                         Error::Dispatch("Push queue closed".to_string())
@@ -498,11 +507,11 @@ mod tests {
     use super::*;
     use std::time::Duration;
 
-    fn queue_size_metric_value(metrics: &crate::metrics::Metrics) -> i64 {
+    fn gauge_metric_value(metrics: &crate::metrics::Metrics, name: &str) -> i64 {
         metrics
             .gather()
             .into_iter()
-            .find(|family| family.name() == "transponder_push_queue_size")
+            .find(|family| family.name() == name)
             .and_then(|family| {
                 family
                     .get_metric()
@@ -511,6 +520,25 @@ mod tests {
             })
             .map(|value| value as i64)
             .unwrap_or_default()
+    }
+
+    fn counter_metric_value(metrics: &crate::metrics::Metrics, name: &str) -> u64 {
+        metrics
+            .gather()
+            .into_iter()
+            .find(|family| family.name() == name)
+            .and_then(|family| {
+                family
+                    .get_metric()
+                    .first()
+                    .and_then(|metric| metric.get_counter().value)
+            })
+            .map(|value| value as u64)
+            .unwrap_or_default()
+    }
+
+    fn queue_size_metric_value(metrics: &crate::metrics::Metrics) -> i64 {
+        gauge_metric_value(metrics, "transponder_push_queue_size")
     }
 
     #[tokio::test]
@@ -887,6 +915,50 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_capacity_metrics_initialized() {
+        use crate::metrics::Metrics;
+
+        let metrics = Metrics::default();
+        let _dispatcher = PushDispatcher::with_metrics(None, None, Some(metrics.clone()));
+
+        assert_eq!(queue_size_metric_value(&metrics), 0);
+        assert_eq!(
+            gauge_metric_value(&metrics, "transponder_push_queue_capacity"),
+            MAX_PENDING_QUEUE_SIZE as i64
+        );
+        assert_eq!(
+            gauge_metric_value(&metrics, "transponder_push_semaphore_available"),
+            MAX_CONCURRENT_PUSHES as i64
+        );
+        assert_eq!(
+            gauge_metric_value(&metrics, "transponder_push_concurrency_limit"),
+            MAX_CONCURRENT_PUSHES as i64
+        );
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_after_shutdown_records_rejection_metric() {
+        use crate::metrics::Metrics;
+
+        let metrics = Metrics::default();
+        let dispatcher = PushDispatcher::with_metrics(None, None, Some(metrics.clone()));
+
+        dispatcher.wait_for_completion().await;
+
+        let payloads = vec![TokenPayload {
+            platform: Platform::Apns,
+            device_token: vec![0xaa, 0xbb, 0xcc],
+        }];
+
+        let error = dispatcher.dispatch(payloads).await.unwrap_err();
+        assert!(matches!(error, Error::Dispatch(_)));
+        assert_eq!(
+            counter_metric_value(&metrics, "transponder_push_queue_rejected_total"),
+            1
+        );
+    }
+
+    #[tokio::test]
     async fn test_bounded_queue_prevents_unbounded_growth() {
         use crate::config::ApnsConfig;
         use crate::push::ApnsClient;
@@ -968,6 +1040,7 @@ mod tests {
     #[tokio::test]
     async fn test_dispatch_rejects_batch_larger_than_queue() {
         use crate::config::ApnsConfig;
+        use crate::metrics::Metrics;
         use crate::push::ApnsClient;
 
         let apns_config = ApnsConfig {
@@ -979,7 +1052,9 @@ mod tests {
             bundle_id: "com.example.app".to_string(),
         };
         let apns_client = ApnsClient::mock(apns_config, true);
-        let dispatcher = PushDispatcher::new(Some(apns_client), None);
+        let metrics = Metrics::default();
+        let dispatcher =
+            PushDispatcher::with_metrics(Some(apns_client), None, Some(metrics.clone()));
 
         let payloads = vec![
             TokenPayload {
@@ -992,5 +1067,9 @@ mod tests {
         let error = dispatcher.dispatch(payloads).await.unwrap_err();
 
         assert!(matches!(error, Error::Dispatch(message) if message.contains("Push queue full")));
+        assert_eq!(
+            counter_metric_value(&metrics, "transponder_push_queue_rejected_total"),
+            (MAX_PENDING_QUEUE_SIZE + 1) as u64
+        );
     }
 }

--- a/src/push/dispatcher.rs
+++ b/src/push/dispatcher.rs
@@ -505,36 +505,17 @@ impl PushDispatcher {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_metrics::{
+        counter_value as metric_counter_value, gauge_value as metric_gauge_value,
+    };
     use std::time::Duration;
 
     fn gauge_metric_value(metrics: &crate::metrics::Metrics, name: &str) -> i64 {
-        metrics
-            .gather()
-            .into_iter()
-            .find(|family| family.name() == name)
-            .and_then(|family| {
-                family
-                    .get_metric()
-                    .first()
-                    .and_then(|metric| metric.get_gauge().value)
-            })
-            .map(|value| value as i64)
-            .unwrap_or_default()
+        metric_gauge_value(metrics, name, &[]) as i64
     }
 
     fn counter_metric_value(metrics: &crate::metrics::Metrics, name: &str) -> u64 {
-        metrics
-            .gather()
-            .into_iter()
-            .find(|family| family.name() == name)
-            .and_then(|family| {
-                family
-                    .get_metric()
-                    .first()
-                    .and_then(|metric| metric.get_counter().value)
-            })
-            .map(|value| value as u64)
-            .unwrap_or_default()
+        metric_counter_value(metrics, name, &[]) as u64
     }
 
     fn queue_size_metric_value(metrics: &crate::metrics::Metrics) -> i64 {

--- a/src/test_metrics.rs
+++ b/src/test_metrics.rs
@@ -1,0 +1,54 @@
+use crate::metrics::Metrics;
+use prometheus::proto::{Metric, MetricFamily};
+
+fn metric_matches_labels(metric: &Metric, labels: &[(&str, &str)]) -> bool {
+    labels.iter().all(|(name, value)| {
+        metric
+            .get_label()
+            .iter()
+            .any(|label| label.name() == *name && label.value() == *value)
+    })
+}
+
+fn family(metrics: &Metrics, name: &str) -> MetricFamily {
+    metrics
+        .gather()
+        .into_iter()
+        .find(|family| family.name() == name)
+        .unwrap_or_else(|| panic!("metric family {name} not found"))
+}
+
+fn metric<'a>(family: &'a MetricFamily, labels: &[(&str, &str)]) -> Option<&'a Metric> {
+    family
+        .get_metric()
+        .iter()
+        .find(|metric| metric_matches_labels(metric, labels))
+}
+
+pub(crate) fn counter_value(metrics: &Metrics, name: &str, labels: &[(&str, &str)]) -> f64 {
+    metric(&family(metrics, name), labels)
+        .and_then(|metric| metric.get_counter().value)
+        .unwrap_or_default()
+}
+
+pub(crate) fn gauge_value(metrics: &Metrics, name: &str, labels: &[(&str, &str)]) -> f64 {
+    metric(&family(metrics, name), labels)
+        .and_then(|metric| metric.get_gauge().value)
+        .unwrap_or_default()
+}
+
+pub(crate) fn histogram_sample_count(
+    metrics: &Metrics,
+    name: &str,
+    labels: &[(&str, &str)],
+) -> u64 {
+    metric(&family(metrics, name), labels)
+        .and_then(|metric| metric.get_histogram().sample_count)
+        .unwrap_or_default()
+}
+
+pub(crate) fn histogram_sample_sum(metrics: &Metrics, name: &str, labels: &[(&str, &str)]) -> f64 {
+    metric(&family(metrics, name), labels)
+        .and_then(|metric| metric.get_histogram().sample_sum)
+        .unwrap_or_default()
+}

--- a/src/test_metrics.rs
+++ b/src/test_metrics.rs
@@ -27,18 +27,34 @@ fn metric<'a>(family: &'a MetricFamily, labels: &[(&str, &str)]) -> Option<&'a M
         .find(|metric| metric_matches_labels(metric, labels))
 }
 
+/// Return the counter value for a metric family selected by name and labels.
+///
+/// `metrics` is the registry wrapper to inspect, `name` is the Prometheus
+/// metric family name, and `labels` selects the labeled sample within that
+/// family. Returns the counter value, or `0.0` when no matching sample exists.
 pub(crate) fn counter_value(metrics: &Metrics, name: &str, labels: &[(&str, &str)]) -> f64 {
     metric(&family(metrics, name), labels)
         .and_then(|metric| metric.get_counter().value)
         .unwrap_or_default()
 }
 
+/// Return the gauge value for a metric family selected by name and labels.
+///
+/// `metrics` is the registry wrapper to inspect, `name` is the Prometheus
+/// metric family name, and `labels` selects the labeled sample within that
+/// family. Returns the gauge value, or `0.0` when no matching sample exists.
 pub(crate) fn gauge_value(metrics: &Metrics, name: &str, labels: &[(&str, &str)]) -> f64 {
     metric(&family(metrics, name), labels)
         .and_then(|metric| metric.get_gauge().value)
         .unwrap_or_default()
 }
 
+/// Return the histogram sample count for a metric family selected by name and
+/// labels.
+///
+/// `metrics` is the registry wrapper to inspect, `name` is the Prometheus
+/// metric family name, and `labels` selects the labeled sample within that
+/// family. Returns the histogram sample count, or `0` when no match exists.
 pub(crate) fn histogram_sample_count(
     metrics: &Metrics,
     name: &str,
@@ -49,6 +65,12 @@ pub(crate) fn histogram_sample_count(
         .unwrap_or_default()
 }
 
+/// Return the histogram sample sum for a metric family selected by name and
+/// labels.
+///
+/// `metrics` is the registry wrapper to inspect, `name` is the Prometheus
+/// metric family name, and `labels` selects the labeled sample within that
+/// family. Returns the histogram sample sum, or `0.0` when no match exists.
 pub(crate) fn histogram_sample_sum(metrics: &Metrics, name: &str, labels: &[(&str, &str)]) -> f64 {
     metric(&family(metrics, name), labels)
         .and_then(|metric| metric.get_histogram().sample_sum)

--- a/src/test_metrics.rs
+++ b/src/test_metrics.rs
@@ -1,3 +1,5 @@
+#![cfg(test)]
+
 use crate::metrics::Metrics;
 use prometheus::proto::{Metric, MetricFamily};
 


### PR DESCRIPTION
## Summary
- add event pipeline histograms and gauges for end-to-end processing, unwrap, parse, token decrypt, and push admission
- expose relay lag/drop counters plus push queue capacity, concurrency, and rejection metrics
- instrument event processing and push dispatch paths while keeping the existing `/metrics` endpoint and no required observability stack changes

## Testing
- cargo test
- just ci

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded Prometheus surface: in‑flight gauge, outcome‑labeled duration histograms, per‑token size/count metrics, push admission timing, and relay notification lag/drop counters.

* **Chores**
  * Wired metrics into event processing and push dispatch paths so gauges/counters update for processing, admission, rejection, lag, and drop events.

* **Documentation**
  * Updated README metrics tables to include labels and outcome values.

* **Tests**
  * Added test helpers and coverage validating metric increments for lagged/closed notifications and push rejections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->