### PR TITLE
Fix FCM service account debug redaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,4 @@ All notable changes to this project will be documented in this file.
 
 ### Security
 
-- Redacted FCM service account private keys from debug output and zeroized the service account JSON buffer after loading.
+- [#35](https://github.com/marmot-protocol/transponder/pull/35) Redacted FCM service account private keys from debug output and zeroized the service account JSON buffer after loading.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## Unreleased
+
+### Security
+
+- Redacted FCM service account private keys from debug output and zeroized the service account JSON buffer after loading.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6438,6 +6438,7 @@ version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 dependencies = [
+ "serde",
  "zeroize_derive",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ prometheus = "0.14"
 
 # Utilities
 thiserror = "2"
-zeroize = { version = "1.8", features = ["derive"] }
+zeroize = { version = "1.8", features = ["derive", "serde"] }
 anyhow = "1.0"
 base64 = "0.22"
 hex = "0.4.3"

--- a/src/push/fcm.rs
+++ b/src/push/fcm.rs
@@ -2,6 +2,7 @@
 //!
 //! Uses service account credentials for OAuth2 authentication.
 
+use std::fmt;
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
@@ -10,6 +11,7 @@ use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
 use tracing::{debug, error, trace, warn};
+use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
 use crate::config::FcmConfig;
 use crate::error::{Error, Result};
@@ -26,15 +28,31 @@ const FCM_SCOPE: &str = "https://www.googleapis.com/auth/firebase.messaging";
 const TOKEN_LIFETIME: Duration = Duration::from_secs(50 * 60);
 
 /// Service account JSON structure.
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize, Zeroize, ZeroizeOnDrop)]
 #[allow(dead_code)]
 pub(crate) struct ServiceAccount {
     #[serde(rename = "type")]
+    #[zeroize(skip)]
     pub(crate) account_type: String,
+    #[zeroize(skip)]
     pub(crate) project_id: String,
-    pub(crate) private_key: String,
+    pub(crate) private_key: Zeroizing<String>,
+    #[zeroize(skip)]
     pub(crate) client_email: String,
+    #[zeroize(skip)]
     pub(crate) token_uri: String,
+}
+
+impl fmt::Debug for ServiceAccount {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ServiceAccount")
+            .field("account_type", &self.account_type)
+            .field("project_id", &self.project_id)
+            .field("private_key", &"[REDACTED]")
+            .field("client_email", &self.client_email)
+            .field("token_uri", &self.token_uri)
+            .finish()
+    }
 }
 
 /// JWT claims for OAuth2.
@@ -426,7 +444,7 @@ impl FcmClient {
             let sa = ServiceAccount {
                 account_type: "service_account".to_string(),
                 project_id: config.project_id.clone(),
-                private_key: "fake-key".to_string(),
+                private_key: Zeroizing::new("fake-key".to_string()),
                 client_email: "test@test.iam.gserviceaccount.com".to_string(),
                 token_uri: "https://oauth2.googleapis.com/token".to_string(),
             };
@@ -471,6 +489,26 @@ mod tests {
         assert!(json.contains("test-token"));
         assert!(json.contains("high"));
         assert!(json.contains("content_available"));
+    }
+
+    #[test]
+    fn test_service_account_debug_redacts_private_key() {
+        let private_key =
+            "-----BEGIN PRIVATE KEY-----\nsecret-key-material\n-----END PRIVATE KEY-----";
+        let sa = ServiceAccount {
+            account_type: "service_account".to_string(),
+            project_id: "test-project".to_string(),
+            private_key: Zeroizing::new(private_key.to_string()),
+            client_email: "test@test.iam.gserviceaccount.com".to_string(),
+            token_uri: "https://oauth2.googleapis.com/token".to_string(),
+        };
+
+        let debug = format!("{sa:?}");
+
+        assert!(debug.contains("ServiceAccount"));
+        assert!(debug.contains("[REDACTED]"));
+        assert!(!debug.contains(private_key));
+        assert!(!debug.contains("secret-key-material"));
     }
 
     #[tokio::test]

--- a/src/push/fcm.rs
+++ b/src/push/fcm.rs
@@ -142,16 +142,18 @@ impl FcmClient {
 
         // Load service account if configured
         let (service_account, encoding_key) = if !config.service_account_path.is_empty() {
-            let data = tokio::fs::read_to_string(&config.service_account_path)
-                .await
-                .map_err(|e| {
-                    Error::Fcm(format!(
-                        "Failed to read service account file '{}': {e}",
-                        config.service_account_path
-                    ))
-                })?;
+            let data = Zeroizing::new(
+                tokio::fs::read_to_string(&config.service_account_path)
+                    .await
+                    .map_err(|e| {
+                        Error::Fcm(format!(
+                            "Failed to read service account file '{}': {e}",
+                            config.service_account_path
+                        ))
+                    })?,
+            );
 
-            let sa: ServiceAccount = serde_json::from_str(&data)
+            let sa: ServiceAccount = serde_json::from_str(data.as_str())
                 .map_err(|e| Error::Fcm(format!("Failed to parse service account JSON: {e}")))?;
 
             let key = EncodingKey::from_rsa_pem(sa.private_key.as_bytes())


### PR DESCRIPTION
## Summary
- Replace derived `Debug` on FCM `ServiceAccount` with a manual implementation that redacts `private_key`.
- Store the service account private key in `Zeroizing<String>` and enable zeroize serde support.
- Add a regression test to ensure debug output does not include key material.

## Testing
- `cargo test test_service_account_debug_redacts_private_key -- --nocapture`
- `cargo test`
- `cargo clippy -- -D warnings`
- `just ci`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced credential handling: sensitive keys are now securely cleared from memory and redacted in debug/log output to prevent retention or accidental exposure.

* **Chores**
  * Updated dependency configuration to support the improved secure-credential behavior.

* **Tests**
  * Added/updated tests to verify redaction and secure clearing of sensitive credential material.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

fixes https://github.com/marmot-protocol/marmot-security/issues/55