### PR TITLE
[codex] Zeroize server private key config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,4 @@ All notable changes to this project will be documented in this file.
 
 ### Security
 
-- Zeroized the server Nostr private key in config state and shortened the lifetime of resolved key material during startup.
+- Zeroized the server Nostr private key in config state and shortened the lifetime of resolved key material during startup ([#37](https://github.com/marmot-protocol/transponder/pull/37)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## Unreleased
+
+### Security
+
+- Zeroized the server Nostr private key in config state and shortened the lifetime of resolved key material during startup.

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,8 +9,9 @@
 //! is rejected.
 
 use config::{Config, ConfigBuilder, File, builder::DefaultState};
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 use std::{env, ffi::OsString, path::Path};
+use zeroize::Zeroizing;
 
 use crate::error::Result;
 use crate::rate_limiter::{
@@ -67,7 +68,8 @@ fn default_rate_limit_per_hour() -> u32 {
 #[derive(Clone, Deserialize)]
 pub struct ServerConfig {
     /// Server's Nostr private key (hex or nsec format).
-    pub private_key: String,
+    #[serde(deserialize_with = "deserialize_zeroizing_string")]
+    pub private_key: Zeroizing<String>,
 
     /// Path to a file containing the server's Nostr private key.
     #[serde(default)]
@@ -148,6 +150,15 @@ impl std::fmt::Debug for ServerConfig {
 
 fn default_shutdown_timeout() -> u64 {
     10
+}
+
+fn deserialize_zeroizing_string<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Zeroizing<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    String::deserialize(deserializer).map(Zeroizing::new)
 }
 
 /// Relay connection configuration.
@@ -552,7 +563,7 @@ mod tests {
 
     fn test_server_config(private_key: &str) -> ServerConfig {
         ServerConfig {
-            private_key: private_key.to_string(),
+            private_key: Zeroizing::new(private_key.to_string()),
             private_key_file: String::new(),
             shutdown_timeout_secs: 10,
             max_dedup_cache_size: 100_000,
@@ -612,12 +623,30 @@ mod tests {
         let file = create_temp_config(config_content);
         let config = load_with_test_env(file.path(), &[]).unwrap();
 
-        assert_eq!(config.server.private_key, "abc123");
+        assert_eq!(config.server.private_key.as_str(), "abc123");
         assert_eq!(config.server.shutdown_timeout_secs, 10); // default
         assert_eq!(config.relays.clearnet.len(), 1);
         assert!(!config.apns.enabled);
         assert!(!config.fcm.enabled);
         assert!(config.metrics.enabled);
+    }
+
+    #[test]
+    fn test_server_private_key_is_zeroizing_and_debug_redacted() {
+        let config_content = r#"
+            [server]
+            private_key = "abc123"
+        "#;
+
+        let file = create_temp_config(config_content);
+        let config = load_with_test_env(file.path(), &[]).unwrap();
+
+        fn assert_zeroizing_string(_: &Zeroizing<String>) {}
+        assert_zeroizing_string(&config.server.private_key);
+
+        let debug = format!("{:?}", config.server);
+        assert!(debug.contains("[REDACTED]"));
+        assert!(!debug.contains("abc123"));
     }
 
     #[test]
@@ -693,7 +722,7 @@ mod tests {
         let config = load_with_test_env(file.path(), &[]).unwrap();
 
         assert_eq!(
-            config.server.private_key,
+            config.server.private_key.as_str(),
             "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
         );
         assert_eq!(config.server.shutdown_timeout_secs, 30);
@@ -781,7 +810,7 @@ mod tests {
         ])
         .unwrap();
 
-        assert_eq!(config.server.private_key, "env-private-key");
+        assert_eq!(config.server.private_key.as_str(), "env-private-key");
         assert_eq!(config.server.shutdown_timeout_secs, 30);
         assert_eq!(config.server.max_dedup_cache_size, 50_000);
         assert_eq!(config.apns.key_id, "KEY123");
@@ -809,7 +838,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(config.server.private_key, "env-private-key");
+        assert_eq!(config.server.private_key.as_str(), "env-private-key");
         assert_eq!(config.apns.private_key_path, "/env/key.p8");
     }
 
@@ -946,7 +975,7 @@ mod tests {
         let file = create_temp_config(config_content);
         let config = load_with_test_env(file.path(), &[]).unwrap();
 
-        assert_eq!(config.server.private_key, "test-key");
+        assert_eq!(config.server.private_key.as_str(), "test-key");
         assert!(config.apns.enabled);
         assert_eq!(config.apns.key_id, "MYKEY");
         assert_eq!(config.apns.environment, "production"); // default

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ use nostr_sdk::prelude::*;
 use tokio::sync::broadcast::error::RecvError;
 use tracing::{debug, error, info, warn};
 use tracing_subscriber::{EnvFilter, fmt, prelude::*};
+use zeroize::Zeroizing;
 
 mod config;
 mod crypto;
@@ -134,7 +135,7 @@ async fn main() -> Result<()> {
     }
 
     // Load configuration
-    let config = AppConfig::load(&args.config)
+    let mut config = AppConfig::load(&args.config)
         .with_context(|| format!("Failed to load config from {}", args.config))?;
 
     // Initialize logging
@@ -163,14 +164,15 @@ async fn main() -> Result<()> {
         "Starting Transponder"
     );
 
-    let server_private_key = resolve_server_private_key(&config.server)?;
+    let server_private_key = resolve_server_private_key(&mut config.server)?;
 
     // Validate configuration
-    validate_startup_config(&server_private_key, &config.relays)?;
+    validate_startup_config(server_private_key.as_str(), &config.relays)?;
 
     // Create server keys
-    let secret_key = parse_server_secret_key(&server_private_key)?;
+    let secret_key = parse_server_secret_key(server_private_key.as_str())?;
     let keys = Keys::new(secret_key);
+    drop(server_private_key);
 
     info!(
         pubkey = %keys.public_key().to_hex(),
@@ -180,7 +182,8 @@ async fn main() -> Result<()> {
     // Initialize crypto handlers
     let nip59_handler = Nip59Handler::new(keys.clone());
     // Convert nostr_sdk SecretKey to secp256k1 SecretKey for TokenDecryptor
-    let secp_secret_key = secp256k1::SecretKey::from_slice(&keys.secret_key().to_secret_bytes())
+    let secret_bytes = Zeroizing::new(keys.secret_key().to_secret_bytes());
+    let secp_secret_key = secp256k1::SecretKey::from_slice(secret_bytes.as_ref())
         .context("Failed to create secp256k1 secret key")?;
     let token_decryptor = TokenDecryptor::new(secp_secret_key);
 
@@ -407,26 +410,36 @@ fn generate_keys() -> Result<()> {
 }
 
 /// Resolve the server private key from config or a mounted secret file.
-fn resolve_server_private_key(config: &config::ServerConfig) -> Result<String> {
+fn resolve_server_private_key(config: &mut config::ServerConfig) -> Result<Zeroizing<String>> {
     let private_key = config.private_key.trim();
     if !private_key.is_empty() {
-        return Ok(private_key.to_string());
+        let private_key = Zeroizing::new(std::mem::take(&mut *config.private_key));
+
+        return if private_key.trim().len() == private_key.len() {
+            Ok(private_key)
+        } else {
+            Ok(Zeroizing::new(private_key.trim().to_string()))
+        };
     }
 
     let private_key_file = config.private_key_file.trim();
     if private_key_file.is_empty() {
-        return Ok(String::new());
+        return Ok(Zeroizing::new(String::new()));
     }
 
     let key_path = Path::new(private_key_file);
-    let key = fs::read_to_string(key_path).with_context(|| {
+    let key = Zeroizing::new(fs::read_to_string(key_path).with_context(|| {
         format!(
             "Failed to read server private key file {}",
             key_path.display()
         )
-    })?;
+    })?);
 
-    Ok(key.trim().to_string())
+    if key.trim().len() == key.len() {
+        Ok(key)
+    } else {
+        Ok(Zeroizing::new(key.trim().to_string()))
+    }
 }
 
 /// Probe a Transponder health endpoint and return a non-zero exit on failure.
@@ -572,8 +585,8 @@ mod tests {
 
     #[test]
     fn resolve_server_private_key_prefers_inline_value() {
-        let config = config::ServerConfig {
-            private_key: "abc123".to_string(),
+        let mut config = config::ServerConfig {
+            private_key: Zeroizing::new("abc123".to_string()),
             private_key_file: "/tmp/ignored".to_string(),
             shutdown_timeout_secs: 10,
             max_dedup_cache_size: 100_000,
@@ -584,7 +597,11 @@ mod tests {
             device_token_rate_limit_per_hour: 5000,
         };
 
-        assert_eq!(resolve_server_private_key(&config).unwrap(), "abc123");
+        assert_eq!(
+            resolve_server_private_key(&mut config).unwrap().as_str(),
+            "abc123"
+        );
+        assert_eq!(config.private_key.as_str(), "");
     }
 
     #[test]
@@ -592,8 +609,8 @@ mod tests {
         let mut file = NamedTempFile::new().unwrap();
         writeln!(file, "abc123").unwrap();
 
-        let config = config::ServerConfig {
-            private_key: String::new(),
+        let mut config = config::ServerConfig {
+            private_key: Zeroizing::new(String::new()),
             private_key_file: file.path().display().to_string(),
             shutdown_timeout_secs: 10,
             max_dedup_cache_size: 100_000,
@@ -604,7 +621,10 @@ mod tests {
             device_token_rate_limit_per_hour: 5000,
         };
 
-        assert_eq!(resolve_server_private_key(&config).unwrap(), "abc123");
+        assert_eq!(
+            resolve_server_private_key(&mut config).unwrap().as_str(),
+            "abc123"
+        );
     }
 
     #[test]
@@ -612,8 +632,8 @@ mod tests {
         let mut file = NamedTempFile::new().unwrap();
         writeln!(file, "abc123").unwrap();
 
-        let config = config::ServerConfig {
-            private_key: "   \n\t  ".to_string(),
+        let mut config = config::ServerConfig {
+            private_key: Zeroizing::new("   \n\t  ".to_string()),
             private_key_file: format!("  {}  ", file.path().display()),
             shutdown_timeout_secs: 10,
             max_dedup_cache_size: 100_000,
@@ -624,13 +644,16 @@ mod tests {
             device_token_rate_limit_per_hour: 5000,
         };
 
-        assert_eq!(resolve_server_private_key(&config).unwrap(), "abc123");
+        assert_eq!(
+            resolve_server_private_key(&mut config).unwrap().as_str(),
+            "abc123"
+        );
     }
 
     #[test]
     fn resolve_server_private_key_returns_empty_when_unset() {
-        let config = config::ServerConfig {
-            private_key: String::new(),
+        let mut config = config::ServerConfig {
+            private_key: Zeroizing::new(String::new()),
             private_key_file: String::new(),
             shutdown_timeout_secs: 10,
             max_dedup_cache_size: 100_000,
@@ -641,13 +664,16 @@ mod tests {
             device_token_rate_limit_per_hour: 5000,
         };
 
-        assert_eq!(resolve_server_private_key(&config).unwrap(), "");
+        assert_eq!(
+            resolve_server_private_key(&mut config).unwrap().as_str(),
+            ""
+        );
     }
 
     #[test]
     fn resolve_server_private_key_reports_missing_secret_file() {
-        let config = config::ServerConfig {
-            private_key: String::new(),
+        let mut config = config::ServerConfig {
+            private_key: Zeroizing::new(String::new()),
             private_key_file: "/tmp/definitely-missing-transponder-key".to_string(),
             shutdown_timeout_secs: 10,
             max_dedup_cache_size: 100_000,
@@ -658,7 +684,7 @@ mod tests {
             device_token_rate_limit_per_hour: 5000,
         };
 
-        let error = resolve_server_private_key(&config)
+        let error = resolve_server_private_key(&mut config)
             .expect_err("missing secret file should return an error");
         assert!(
             error
@@ -742,8 +768,8 @@ mod tests {
         let mut file = NamedTempFile::new().unwrap();
         writeln!(file, "  {secret_key}  ").unwrap();
 
-        let config = config::ServerConfig {
-            private_key: String::new(),
+        let mut config = config::ServerConfig {
+            private_key: Zeroizing::new(String::new()),
             private_key_file: file.path().display().to_string(),
             shutdown_timeout_secs: 10,
             max_dedup_cache_size: 100_000,
@@ -754,8 +780,8 @@ mod tests {
             device_token_rate_limit_per_hour: 5000,
         };
 
-        let resolved_key = resolve_server_private_key(&config).unwrap();
-        let parsed_key = parse_server_secret_key(&resolved_key).unwrap();
+        let resolved_key = resolve_server_private_key(&mut config).unwrap();
+        let parsed_key = parse_server_secret_key(resolved_key.as_str()).unwrap();
 
         assert_eq!(parsed_key.to_bech32().unwrap(), secret_key);
     }
@@ -763,7 +789,7 @@ mod tests {
     #[test]
     fn build_rate_limit_config_matches_server_settings() {
         let server = config::ServerConfig {
-            private_key: String::new(),
+            private_key: Zeroizing::new(String::new()),
             private_key_file: String::new(),
             shutdown_timeout_secs: 10,
             max_dedup_cache_size: 100_000,

--- a/src/main.rs
+++ b/src/main.rs
@@ -184,9 +184,9 @@ async fn main() -> Result<()> {
     let nip59_handler = Nip59Handler::new(keys.clone());
     // Convert nostr_sdk SecretKey to secp256k1 SecretKey for TokenDecryptor
     let secret_bytes = Zeroizing::new(keys.secret_key().to_secret_bytes());
-    let secp_secret_key = secp256k1::SecretKey::from_slice(secret_bytes.as_ref())
+    let mut secp_secret_key = secp256k1::SecretKey::from_slice(secret_bytes.as_ref())
         .context("Failed to create secp256k1 secret key")?;
-    let token_decryptor = TokenDecryptor::new(secp_secret_key);
+    let token_decryptor = TokenDecryptor::new(&mut secp_secret_key);
 
     // Initialize push clients
     let apns_client = if config.apns.enabled {


### PR DESCRIPTION
## Summary

- Wrap `ServerConfig::private_key` in `Zeroizing<String>` during config deserialization.
- Redact the server private key from `ServerConfig` debug output.
- Move the inline private key out of long-lived config during startup and drop the resolved text key after constructing Nostr keys.
- Zeroize the temporary secret-byte array used for the `secp256k1` key conversion.

## Root Cause

The server private key was stored as a plain `String` in cloneable config state, so cloned or dropped config values could leave unzeroed key material in heap memory longer than needed.

## Validation

- `cargo test`
- `cargo clippy -- -D warnings`
- `just ci`

`just ci` passed with the repo's existing allowed RustSec warnings for transitive `rand` advisories.

Addresses marmot-protocol/marmot-security#26.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Private key material is now stored in secure memory and cleared after use to reduce exposure risk.
  * Debug and logging output redact sensitive data to prevent accidental disclosure.

* **Chores**
  * Startup handling shortened the lifetime of resolved key material so secrets are retained only as long as needed.

* **Documentation**
  * Changelog updated with a Security note about zeroized private keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

fixes https://github.com/marmot-protocol/marmot-security/issues/26