### PR TITLE
[codex] Limit per-event token parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## Unreleased
+
+### Fixed
+
+- Limit each notification event to at most 100 encrypted tokens before base64 decoding, preventing oversized events from forcing unbounded token blob allocation and rate-limit work.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,4 @@
 
 ### Fixed
 
-- Limit each notification event to at most 100 encrypted tokens before base64 decoding, preventing oversized events from forcing unbounded token blob allocation and rate-limit work.
+- Limit each notification event to at most 100 encrypted tokens before base64 decoding, preventing oversized events from forcing unbounded token blob allocation and rate-limit work ([#38](https://github.com/marmot-protocol/transponder/pull/38)).

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ shutdown_timeout_secs = 10
 
 # Rate limiting to prevent spam and replay attacks
 # max_rate_limit_cache_size = 100000           # LRU cache size per limiter
+# max_tokens_per_event = 100                   # Per notification event
 # encrypted_token_rate_limit_per_minute = 240  # Per encrypted token (replay protection)
 # encrypted_token_rate_limit_per_hour = 5000
 # device_token_rate_limit_per_minute = 240     # Per device (spam protection)

--- a/config/default.toml
+++ b/config/default.toml
@@ -24,6 +24,10 @@ shutdown_timeout_secs = 10
 # Default: 100000 entries per cache
 # max_rate_limit_cache_size = 100000
 
+# Maximum encrypted tokens accepted in a single notification event.
+# Default: 100
+# max_tokens_per_event = 100
+
 # Rate limit: max notifications per encrypted token per minute.
 # Limits identical encrypted blobs to prevent replay attacks.
 # Default: 240 (4 per second)

--- a/config/production.toml.example
+++ b/config/production.toml.example
@@ -13,6 +13,7 @@ shutdown_timeout_secs = 20
 # Reduce them if you are running on a very small VM.
 # max_dedup_cache_size = 100000
 # max_rate_limit_cache_size = 100000
+# max_tokens_per_event = 100
 # encrypted_token_rate_limit_per_minute = 240
 # encrypted_token_rate_limit_per_hour = 5000
 # device_token_rate_limit_per_minute = 240

--- a/src/config.rs
+++ b/src/config.rs
@@ -137,6 +137,7 @@ impl std::fmt::Debug for ServerConfig {
             .field("shutdown_timeout_secs", &self.shutdown_timeout_secs)
             .field("max_dedup_cache_size", &self.max_dedup_cache_size)
             .field("max_rate_limit_cache_size", &self.max_rate_limit_cache_size)
+            .field("max_tokens_per_event", &self.max_tokens_per_event)
             .field(
                 "encrypted_token_rate_limit_per_minute",
                 &self.encrypted_token_rate_limit_per_minute,
@@ -573,6 +574,7 @@ mod tests {
             shutdown_timeout_secs: 10,
             max_dedup_cache_size: 100_000,
             max_rate_limit_cache_size: 100_000,
+            max_tokens_per_event: DEFAULT_MAX_TOKENS_PER_EVENT,
             encrypted_token_rate_limit_per_minute: 240,
             encrypted_token_rate_limit_per_hour: 5000,
             device_token_rate_limit_per_minute: 240,

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,7 @@ use config::{Config, ConfigBuilder, File, builder::DefaultState};
 use serde::Deserialize;
 use std::{env, ffi::OsString, path::Path};
 
+use crate::crypto::nip59::DEFAULT_MAX_TOKENS_PER_EVENT;
 use crate::error::Result;
 use crate::rate_limiter::{
     DEFAULT_MAX_SIZE as DEFAULT_MAX_RATE_LIMIT_CACHE_SIZE, DEFAULT_RATE_LIMIT_PER_HOUR,
@@ -55,6 +56,10 @@ fn default_max_rate_limit_cache_size() -> usize {
     DEFAULT_MAX_RATE_LIMIT_CACHE_SIZE
 }
 
+fn default_max_tokens_per_event() -> usize {
+    DEFAULT_MAX_TOKENS_PER_EVENT
+}
+
 fn default_rate_limit_per_minute() -> u32 {
     DEFAULT_RATE_LIMIT_PER_MINUTE
 }
@@ -90,6 +95,12 @@ pub struct ServerConfig {
     /// Default: 100,000 entries per cache.
     #[serde(default = "default_max_rate_limit_cache_size")]
     pub max_rate_limit_cache_size: usize,
+
+    /// Maximum encrypted tokens accepted in a single notification event.
+    ///
+    /// Default: 100.
+    #[serde(default = "default_max_tokens_per_event")]
+    pub max_tokens_per_event: usize,
 
     /// Maximum notifications per encrypted token per minute.
     ///
@@ -276,6 +287,10 @@ fn base_config_builder() -> Result<ConfigBuilder<DefaultState>> {
             DEFAULT_MAX_RATE_LIMIT_CACHE_SIZE as i64,
         )?
         .set_default(
+            "server.max_tokens_per_event",
+            DEFAULT_MAX_TOKENS_PER_EVENT as i64,
+        )?
+        .set_default(
             "server.encrypted_token_rate_limit_per_minute",
             DEFAULT_RATE_LIMIT_PER_MINUTE as i64,
         )?
@@ -391,6 +406,7 @@ fn is_supported_config_key(config_key: &str) -> bool {
                 | "server.shutdown_timeout_secs"
                 | "server.max_dedup_cache_size"
                 | "server.max_rate_limit_cache_size"
+                | "server.max_tokens_per_event"
                 | "server.encrypted_token_rate_limit_per_minute"
                 | "server.encrypted_token_rate_limit_per_hour"
                 | "server.device_token_rate_limit_per_minute"
@@ -714,6 +730,7 @@ mod tests {
             ("TRANSPONDER_SERVER_PRIVATE_KEY", "env-private-key"),
             ("TRANSPONDER_SERVER_SHUTDOWN_TIMEOUT_SECS", "30"),
             ("TRANSPONDER_SERVER_MAX_DEDUP_CACHE_SIZE", "50000"),
+            ("TRANSPONDER_SERVER_MAX_TOKENS_PER_EVENT", "25"),
             ("TRANSPONDER_APNS_KEY_ID", "KEY123"),
             ("TRANSPONDER_HEALTH_BIND_ADDRESS", "127.0.0.1:9090"),
         ])
@@ -722,6 +739,7 @@ mod tests {
         assert_eq!(config.server.private_key, "env-private-key");
         assert_eq!(config.server.shutdown_timeout_secs, 30);
         assert_eq!(config.server.max_dedup_cache_size, 50_000);
+        assert_eq!(config.server.max_tokens_per_event, 25);
         assert_eq!(config.apns.key_id, "KEY123");
         assert_eq!(config.health.bind_address, "127.0.0.1:9090");
     }
@@ -835,6 +853,7 @@ mod tests {
         assert_eq!(default_shutdown_timeout(), 10);
         assert_eq!(default_max_dedup_cache_size(), 100_000);
         assert_eq!(default_max_rate_limit_cache_size(), 100_000);
+        assert_eq!(default_max_tokens_per_event(), 100);
         assert_eq!(default_rate_limit_per_minute(), 240);
         assert_eq!(default_rate_limit_per_hour(), 5000);
     }
@@ -959,6 +978,7 @@ mod tests {
         assert_eq!(config.server.encrypted_token_rate_limit_per_hour, 5000);
         assert_eq!(config.server.device_token_rate_limit_per_minute, 240);
         assert_eq!(config.server.device_token_rate_limit_per_hour, 5000);
+        assert_eq!(config.server.max_tokens_per_event, 100);
     }
 
     #[test]
@@ -966,6 +986,7 @@ mod tests {
         let config_content = r#"
             [server]
             private_key = "test"
+            max_tokens_per_event = 25
             encrypted_token_rate_limit_per_minute = 100
             encrypted_token_rate_limit_per_hour = 2000
             device_token_rate_limit_per_minute = 50
@@ -979,5 +1000,6 @@ mod tests {
         assert_eq!(config.server.encrypted_token_rate_limit_per_hour, 2000);
         assert_eq!(config.server.device_token_rate_limit_per_minute, 50);
         assert_eq!(config.server.device_token_rate_limit_per_hour, 1000);
+        assert_eq!(config.server.max_tokens_per_event, 25);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -918,7 +918,7 @@ mod tests {
         assert_eq!(default_shutdown_timeout(), 10);
         assert_eq!(default_max_dedup_cache_size(), 100_000);
         assert_eq!(default_max_rate_limit_cache_size(), 100_000);
-        assert_eq!(default_max_tokens_per_event(), 100);
+        assert_eq!(default_max_tokens_per_event(), DEFAULT_MAX_TOKENS_PER_EVENT);
         assert_eq!(default_rate_limit_per_minute(), 240);
         assert_eq!(default_rate_limit_per_hour(), 5000);
     }

--- a/src/crypto/nip59.rs
+++ b/src/crypto/nip59.rs
@@ -183,13 +183,6 @@ impl UnwrappedNotification {
             )));
         }
 
-        let token_count = decoded.len() / ENCRYPTED_TOKEN_SIZE;
-        if token_count > max_tokens {
-            return Err(Error::InvalidToken(format!(
-                "Token blob too large: contains {token_count} tokens, maximum is {max_tokens}"
-            )));
-        }
-
         Ok(decoded
             .chunks(ENCRYPTED_TOKEN_SIZE)
             .map(|chunk| chunk.to_vec())

--- a/src/crypto/nip59.rs
+++ b/src/crypto/nip59.rs
@@ -145,6 +145,7 @@ impl UnwrappedNotification {
     /// The content is expected to be a single RFC 4648 standard base64 string
     /// containing one or more concatenated encrypted tokens.
     #[allow(dead_code)]
+    #[must_use = "parsed tokens must be handled or parsing errors will be ignored"]
     pub fn parse_tokens(&self) -> Result<Vec<Vec<u8>>> {
         self.parse_tokens_with_limit(DEFAULT_MAX_TOKENS_PER_EVENT)
     }
@@ -153,6 +154,7 @@ impl UnwrappedNotification {
     ///
     /// The base64 input length is checked before decoding so oversized events
     /// are rejected before allocating a decoded token blob.
+    #[must_use = "parsed tokens must be handled or parsing errors will be ignored"]
     pub fn parse_tokens_with_limit(&self, max_tokens: usize) -> Result<Vec<Vec<u8>>> {
         use base64::prelude::*;
 
@@ -334,10 +336,16 @@ mod tests {
     fn test_parse_tokens_with_custom_limit() {
         const MAX_TOKENS: usize = 2;
 
-        let concatenated = vec![0x42; (MAX_TOKENS + 1) * ENCRYPTED_TOKEN_SIZE];
-        let notification = notification(BASE64_STANDARD.encode(&concatenated));
+        let concatenated = vec![0x24; MAX_TOKENS * ENCRYPTED_TOKEN_SIZE];
+        let within_limit = notification(BASE64_STANDARD.encode(&concatenated));
 
-        let result = notification.parse_tokens_with_limit(MAX_TOKENS);
+        let tokens = within_limit.parse_tokens_with_limit(MAX_TOKENS).unwrap();
+        assert_eq!(tokens.len(), MAX_TOKENS);
+
+        let concatenated = vec![0x42; (MAX_TOKENS + 1) * ENCRYPTED_TOKEN_SIZE];
+        let over_limit = notification(BASE64_STANDARD.encode(&concatenated));
+
+        let result = over_limit.parse_tokens_with_limit(MAX_TOKENS);
         assert!(result.is_err());
         let expected_error = exceeds_max_tokens_message(MAX_TOKENS);
         assert!(result.unwrap_err().to_string().contains(&expected_error));

--- a/src/crypto/nip59.rs
+++ b/src/crypto/nip59.rs
@@ -17,6 +17,16 @@ const TAG_ENCODING: &str = "encoding";
 const VERSION_MIP05_V1: &str = "mip05-v1";
 const ENCODING_BASE64: &str = "base64";
 
+/// Default maximum number of encrypted tokens accepted in one notification event.
+pub const DEFAULT_MAX_TOKENS_PER_EVENT: usize = 100;
+
+fn max_encoded_token_blob_len(max_tokens: usize) -> usize {
+    max_tokens
+        .saturating_mul(ENCRYPTED_TOKEN_SIZE)
+        .div_ceil(3)
+        .saturating_mul(4)
+}
+
 /// Handler for NIP-59 gift wrap operations.
 #[derive(Clone)]
 pub struct Nip59Handler {
@@ -134,11 +144,27 @@ impl UnwrappedNotification {
     ///
     /// The content is expected to be a single RFC 4648 standard base64 string
     /// containing one or more concatenated encrypted tokens.
+    #[allow(dead_code)]
     pub fn parse_tokens(&self) -> Result<Vec<Vec<u8>>> {
+        self.parse_tokens_with_limit(DEFAULT_MAX_TOKENS_PER_EVENT)
+    }
+
+    /// Parse the encrypted tokens from the content with an event-local token limit.
+    ///
+    /// The base64 input length is checked before decoding so oversized events
+    /// are rejected before allocating a decoded token blob.
+    pub fn parse_tokens_with_limit(&self, max_tokens: usize) -> Result<Vec<Vec<u8>>> {
         use base64::prelude::*;
 
         self.require_tag_value(TAG_VERSION, VERSION_MIP05_V1)?;
         self.require_tag_value(TAG_ENCODING, ENCODING_BASE64)?;
+
+        let max_encoded_len = max_encoded_token_blob_len(max_tokens);
+        if self.content.len() > max_encoded_len {
+            return Err(Error::InvalidToken(format!(
+                "Token blob too large: exceeds maximum of {max_tokens} tokens"
+            )));
+        }
 
         let decoded = BASE64_STANDARD
             .decode(&self.content)
@@ -154,6 +180,13 @@ impl UnwrappedNotification {
             return Err(Error::InvalidToken(format!(
                 "Decoded token blob length {} is not a multiple of {ENCRYPTED_TOKEN_SIZE}",
                 decoded.len()
+            )));
+        }
+
+        let token_count = decoded.len() / ENCRYPTED_TOKEN_SIZE;
+        if token_count > max_tokens {
+            return Err(Error::InvalidToken(format!(
+                "Token blob too large: contains {token_count} tokens, maximum is {max_tokens}"
             )));
         }
 
@@ -278,6 +311,45 @@ mod tests {
         for (i, token) in tokens.iter().enumerate() {
             assert_eq!(token, &vec![i as u8; ENCRYPTED_TOKEN_SIZE]);
         }
+    }
+
+    #[test]
+    fn test_parse_accepts_default_max_tokens() {
+        let concatenated = vec![0x42; DEFAULT_MAX_TOKENS_PER_EVENT * ENCRYPTED_TOKEN_SIZE];
+        let notification = notification(BASE64_STANDARD.encode(&concatenated));
+
+        let tokens = notification.parse_tokens().unwrap();
+        assert_eq!(tokens.len(), DEFAULT_MAX_TOKENS_PER_EVENT);
+    }
+
+    #[test]
+    fn test_parse_rejects_more_than_default_max_tokens_before_decode() {
+        let concatenated = vec![0x42; (DEFAULT_MAX_TOKENS_PER_EVENT + 1) * ENCRYPTED_TOKEN_SIZE];
+        let notification = notification(BASE64_STANDARD.encode(&concatenated));
+
+        let result = notification.parse_tokens();
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("exceeds maximum of 100 tokens")
+        );
+    }
+
+    #[test]
+    fn test_parse_tokens_with_custom_limit() {
+        let concatenated = vec![0x42; 3 * ENCRYPTED_TOKEN_SIZE];
+        let notification = notification(BASE64_STANDARD.encode(&concatenated));
+
+        let result = notification.parse_tokens_with_limit(2);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("exceeds maximum of 2 tokens")
+        );
     }
 
     #[test]

--- a/src/crypto/nip59.rs
+++ b/src/crypto/nip59.rs
@@ -202,6 +202,10 @@ mod tests {
     use super::*;
     use base64::prelude::*;
 
+    fn exceeds_max_tokens_message(max_tokens: usize) -> String {
+        format!("exceeds maximum of {max_tokens} tokens")
+    }
+
     fn valid_tags() -> Tags {
         Tags::parse([
             [TAG_VERSION, VERSION_MIP05_V1],
@@ -329,27 +333,21 @@ mod tests {
 
         let result = notification.parse_tokens();
         assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("exceeds maximum of 100 tokens")
-        );
+        let expected_error = exceeds_max_tokens_message(DEFAULT_MAX_TOKENS_PER_EVENT);
+        assert!(result.unwrap_err().to_string().contains(&expected_error));
     }
 
     #[test]
     fn test_parse_tokens_with_custom_limit() {
-        let concatenated = vec![0x42; 3 * ENCRYPTED_TOKEN_SIZE];
+        const MAX_TOKENS: usize = 2;
+
+        let concatenated = vec![0x42; (MAX_TOKENS + 1) * ENCRYPTED_TOKEN_SIZE];
         let notification = notification(BASE64_STANDARD.encode(&concatenated));
 
-        let result = notification.parse_tokens_with_limit(2);
+        let result = notification.parse_tokens_with_limit(MAX_TOKENS);
         assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("exceeds maximum of 2 tokens")
-        );
+        let expected_error = exceeds_max_tokens_message(MAX_TOKENS);
+        assert!(result.unwrap_err().to_string().contains(&expected_error));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,6 +110,7 @@ fn validate_startup_config(server_private_key: &str, relays: &config::RelayConfi
 fn build_rate_limit_config(server: &config::ServerConfig) -> nostr::events::TokenRateLimitConfig {
     nostr::events::TokenRateLimitConfig {
         max_cache_size: server.max_rate_limit_cache_size,
+        max_tokens_per_event: server.max_tokens_per_event,
         encrypted_token_per_minute: server.encrypted_token_rate_limit_per_minute,
         encrypted_token_per_hour: server.encrypted_token_rate_limit_per_hour,
         device_token_per_minute: server.device_token_rate_limit_per_minute,
@@ -578,6 +579,7 @@ mod tests {
             shutdown_timeout_secs: 10,
             max_dedup_cache_size: 100_000,
             max_rate_limit_cache_size: 100_000,
+            max_tokens_per_event: crate::crypto::nip59::DEFAULT_MAX_TOKENS_PER_EVENT,
             encrypted_token_rate_limit_per_minute: 240,
             encrypted_token_rate_limit_per_hour: 5000,
             device_token_rate_limit_per_minute: 240,
@@ -598,6 +600,7 @@ mod tests {
             shutdown_timeout_secs: 10,
             max_dedup_cache_size: 100_000,
             max_rate_limit_cache_size: 100_000,
+            max_tokens_per_event: crate::crypto::nip59::DEFAULT_MAX_TOKENS_PER_EVENT,
             encrypted_token_rate_limit_per_minute: 240,
             encrypted_token_rate_limit_per_hour: 5000,
             device_token_rate_limit_per_minute: 240,
@@ -618,6 +621,7 @@ mod tests {
             shutdown_timeout_secs: 10,
             max_dedup_cache_size: 100_000,
             max_rate_limit_cache_size: 100_000,
+            max_tokens_per_event: crate::crypto::nip59::DEFAULT_MAX_TOKENS_PER_EVENT,
             encrypted_token_rate_limit_per_minute: 240,
             encrypted_token_rate_limit_per_hour: 5000,
             device_token_rate_limit_per_minute: 240,
@@ -635,6 +639,7 @@ mod tests {
             shutdown_timeout_secs: 10,
             max_dedup_cache_size: 100_000,
             max_rate_limit_cache_size: 100_000,
+            max_tokens_per_event: crate::crypto::nip59::DEFAULT_MAX_TOKENS_PER_EVENT,
             encrypted_token_rate_limit_per_minute: 240,
             encrypted_token_rate_limit_per_hour: 5000,
             device_token_rate_limit_per_minute: 240,
@@ -652,6 +657,7 @@ mod tests {
             shutdown_timeout_secs: 10,
             max_dedup_cache_size: 100_000,
             max_rate_limit_cache_size: 100_000,
+            max_tokens_per_event: crate::crypto::nip59::DEFAULT_MAX_TOKENS_PER_EVENT,
             encrypted_token_rate_limit_per_minute: 240,
             encrypted_token_rate_limit_per_hour: 5000,
             device_token_rate_limit_per_minute: 240,
@@ -748,6 +754,7 @@ mod tests {
             shutdown_timeout_secs: 10,
             max_dedup_cache_size: 100_000,
             max_rate_limit_cache_size: 100_000,
+            max_tokens_per_event: crate::crypto::nip59::DEFAULT_MAX_TOKENS_PER_EVENT,
             encrypted_token_rate_limit_per_minute: 240,
             encrypted_token_rate_limit_per_hour: 5000,
             device_token_rate_limit_per_minute: 240,
@@ -768,6 +775,7 @@ mod tests {
             shutdown_timeout_secs: 10,
             max_dedup_cache_size: 100_000,
             max_rate_limit_cache_size: 1234,
+            max_tokens_per_event: 25,
             encrypted_token_rate_limit_per_minute: 111,
             encrypted_token_rate_limit_per_hour: 2222,
             device_token_rate_limit_per_minute: 333,
@@ -777,6 +785,7 @@ mod tests {
         let rate_limit_config = build_rate_limit_config(&server);
 
         assert_eq!(rate_limit_config.max_cache_size, 1234);
+        assert_eq!(rate_limit_config.max_tokens_per_event, 25);
         assert_eq!(rate_limit_config.encrypted_token_per_minute, 111);
         assert_eq!(rate_limit_config.encrypted_token_per_hour, 2222);
         assert_eq!(rate_limit_config.device_token_per_minute, 333);

--- a/src/nostr/events.rs
+++ b/src/nostr/events.rs
@@ -14,6 +14,7 @@ use tokio::sync::RwLock;
 use tokio::time::Instant;
 use tracing::{debug, trace, warn};
 
+use crate::crypto::nip59::DEFAULT_MAX_TOKENS_PER_EVENT;
 use crate::crypto::token::ENCRYPTED_TOKEN_SIZE;
 use crate::crypto::{Nip59Handler, TokenDecryptor, TokenPayload};
 use crate::error::Result;
@@ -79,6 +80,8 @@ pub struct EventProcessor {
     encrypted_token_limiter: RateLimiter<[u8; 32]>,
     /// Device token rate limiter.
     device_token_limiter: RateLimiter<[u8; 32]>,
+    /// Maximum encrypted tokens accepted in a single event.
+    max_tokens_per_event: usize,
     metrics: Option<Metrics>,
 }
 
@@ -87,6 +90,8 @@ pub struct EventProcessor {
 pub struct TokenRateLimitConfig {
     /// Maximum entries in each rate limit cache.
     pub max_cache_size: usize,
+    /// Maximum encrypted tokens accepted in a single event.
+    pub max_tokens_per_event: usize,
     /// Max encrypted token requests per minute.
     pub encrypted_token_per_minute: u32,
     /// Max encrypted token requests per hour.
@@ -101,6 +106,7 @@ impl Default for TokenRateLimitConfig {
     fn default() -> Self {
         Self {
             max_cache_size: DEFAULT_MAX_SIZE,
+            max_tokens_per_event: DEFAULT_MAX_TOKENS_PER_EVENT,
             encrypted_token_per_minute: DEFAULT_RATE_LIMIT_PER_MINUTE,
             encrypted_token_per_hour: DEFAULT_RATE_LIMIT_PER_HOUR,
             device_token_per_minute: DEFAULT_RATE_LIMIT_PER_MINUTE,
@@ -177,6 +183,7 @@ impl EventProcessor {
                 max_per_hour: rate_limit_config.device_token_per_hour,
                 max_entries: rate_limit_config.max_cache_size,
             }),
+            max_tokens_per_event: rate_limit_config.max_tokens_per_event,
             metrics,
         }
     }
@@ -280,7 +287,7 @@ impl EventProcessor {
 
         // Parse the encrypted tokens from the content
         let parse_started_at = StageTimer::start();
-        let token_bytes = match notification.parse_tokens() {
+        let token_bytes = match notification.parse_tokens_with_limit(self.max_tokens_per_event) {
             Ok(token_bytes) => {
                 if let Some(ref m) = self.metrics {
                     m.observe_notification_parse_duration(
@@ -1231,6 +1238,7 @@ mod tests {
             &server_keys,
             TokenRateLimitConfig {
                 max_cache_size: 100,
+                max_tokens_per_event: DEFAULT_MAX_TOKENS_PER_EVENT,
                 encrypted_token_per_minute: 100,
                 encrypted_token_per_hour: 1000,
                 device_token_per_minute: 1,
@@ -1286,6 +1294,7 @@ mod tests {
             &server_keys,
             TokenRateLimitConfig {
                 max_cache_size: 100,
+                max_tokens_per_event: DEFAULT_MAX_TOKENS_PER_EVENT,
                 encrypted_token_per_minute: 100, // High limit for encrypted tokens
                 encrypted_token_per_hour: 1000,
                 device_token_per_minute: 2, // Only allow 2 per minute per device
@@ -1345,6 +1354,7 @@ mod tests {
             &server_keys,
             TokenRateLimitConfig {
                 max_cache_size: 100,
+                max_tokens_per_event: DEFAULT_MAX_TOKENS_PER_EVENT,
                 encrypted_token_per_minute: 2, // Only allow 2 per minute per encrypted token
                 encrypted_token_per_hour: 100,
                 device_token_per_minute: 100, // High limit for device tokens
@@ -1421,6 +1431,7 @@ mod tests {
             &server_keys,
             TokenRateLimitConfig {
                 max_cache_size: 100,
+                max_tokens_per_event: DEFAULT_MAX_TOKENS_PER_EVENT,
                 encrypted_token_per_minute: 1,
                 encrypted_token_per_hour: 100,
                 device_token_per_minute: 100,

--- a/src/test_metrics.rs
+++ b/src/test_metrics.rs
@@ -1,5 +1,3 @@
-#![cfg(test)]
-
 use crate::metrics::Metrics;
 use prometheus::proto::{Metric, MetricFamily};
 


### PR DESCRIPTION
## Summary

- Add a configurable `server.max_tokens_per_event` limit with a default of 100 encrypted tokens per notification event.
- Reject oversized base64 token blobs before decoding to avoid unnecessary allocation and per-token rate-limit work.
- Document the new setting in config examples and add an Unreleased changelog entry.

## Root Cause

`parse_tokens()` decoded the entire notification content blob before checking how many encrypted token chunks it contained, so a large event could force memory allocation and downstream chunk processing before existing rate limits had a chance to apply.

## Validation

- `cargo test crypto::nip59`
- `cargo test config::`
- `just ci`

Note: `just ci` completed successfully with the existing allowed `rand` audit warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Notification events are capped at 100 encrypted tokens by default to prevent oversized events from causing excessive memory use and extra rate-limit work.
  * Event processing now enforces the per-event token cap during token parsing.

* **Documentation**
  * Added a documented server configuration option to control the per-notification-event token limit (default: 100) in README and example/default configs.

* **Tests / Chores**
  * Metrics module no longer restricted to test-only builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

fixes https://github.com/marmot-protocol/marmot-security/issues/58