### PR TITLE
Fix health server default bind address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## Unreleased
+
+### Security
+
+- Changed the default health server bind address to localhost and documented internal-only exposure for the unauthenticated health, readiness, and metrics endpoints ([#39](https://github.com/marmot-protocol/transponder/pull/39)).

--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ project_id = ""
 enabled = true
 
 # Address and port to bind the health server to
-# Use "127.0.0.1:8080" to restrict to localhost only
-bind_address = "0.0.0.0:8080"
+# Keep this on localhost unless an internal proxy, VPN, or load balancer needs it
+bind_address = "127.0.0.1:8080"
 
 [metrics]
 # Whether Prometheus metrics are enabled
@@ -217,8 +217,11 @@ docker run -d \
   -v /path/to/config.toml:/etc/transponder/config.toml:ro \
   -v /path/to/credentials:/credentials:ro \
   -e TRANSPONDER_SERVER_PRIVATE_KEY="your-hex-key" \
+  -e TRANSPONDER_HEALTH_BIND_ADDRESS="0.0.0.0:8080" \
   transponder
 ```
+
+Docker port publishing needs the service to listen on the container interface. The command above still binds the host side to `127.0.0.1`, keeping the endpoints local to the host by default.
 
 ### Docker Compose
 
@@ -316,6 +319,8 @@ When enabled, Transponder exposes HTTP endpoints for monitoring:
 | `GET /ready` | Readiness check - can the server process requests? | 200 if relays connected and at least one push service configured |
 | `GET /metrics` | Prometheus metrics (when metrics enabled) | 200 with metrics in Prometheus text format |
 
+The default bind address is `127.0.0.1:8080` so these unauthenticated endpoints stay local. If external health checks are required, bind to a specific internal interface or put the endpoints behind a reverse proxy, VPN, or load balancer with access controls.
+
 ### Readiness Response
 
 ```json
@@ -329,7 +334,7 @@ When enabled, Transponder exposes HTTP endpoints for monitoring:
 
 ## Metrics
 
-Transponder exposes Prometheus metrics at `/metrics` on the health server port (default 8080). Metrics are enabled by default and can be disabled via configuration.
+Transponder exposes Prometheus metrics at `/metrics` on the health server port (default 8080 on localhost). Metrics are enabled by default and can be disabled via configuration.
 
 ### Available Metrics
 
@@ -404,7 +409,7 @@ Label values: `type` = `encrypted_token` or `device_token`; `reason` = `minute` 
 
 ### Security Note
 
-All metrics are designed to be safe for exposure. They do not include device tokens, user identifiers, message content, or relay URLs.
+Metrics do not include device tokens, user identifiers, message content, or relay URLs, but aggregate operational data can still reveal traffic patterns and deployment state. Keep `/metrics` internal-only unless it is protected by a deliberate access-control layer.
 
 ## Monitoring Integration
 
@@ -467,7 +472,7 @@ The server private key is critical:
 ### Network Security
 
 - **TLS everywhere**: All connections to relays, APNs, and FCM use TLS
-- **Health endpoint exposure**: Consider binding to localhost (`127.0.0.1:8080`) and using a reverse proxy
+- **Health endpoint exposure**: Keep the default localhost bind (`127.0.0.1:8080`) unless an internal proxy, VPN, or load balancer needs it
 - **Firewall rules**: Only expose port 8080 if health checks are needed externally
 - **Prefer localhost binds** in Compose and publish through a reverse proxy only when needed
 - **Default inbound policy**: SSH only

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -19,6 +19,9 @@ services:
       - ${TRANSPONDER_CREDENTIALS_DIR:-./credentials}:/credentials:ro
     environment:
       TRANSPONDER_SERVER_PRIVATE_KEY_FILE: /run/secrets/transponder_private_key
+      # The host port is bound to 127.0.0.1 above; this keeps Docker port
+      # publishing reachable without exposing it on public host interfaces.
+      TRANSPONDER_HEALTH_BIND_ADDRESS: "0.0.0.0:8080"
       TRANSPONDER_LOGGING_LEVEL: ${TRANSPONDER_LOGGING_LEVEL:-info}
       TRANSPONDER_LOGGING_FORMAT: json
     secrets:

--- a/config/default.toml
+++ b/config/default.toml
@@ -91,8 +91,10 @@ project_id = ""
 # Whether the health check HTTP server is enabled
 enabled = true
 
-# Address to bind the health check server to
-bind_address = "0.0.0.0:8080"
+# Address to bind the health check server to.
+# Keep this on localhost unless an internal proxy, VPN, or load balancer needs
+# access to the endpoint.
+bind_address = "127.0.0.1:8080"
 
 [metrics]
 # Whether Prometheus metrics are enabled

--- a/config/production.toml.example
+++ b/config/production.toml.example
@@ -48,7 +48,10 @@ project_id = ""
 
 [health]
 enabled = true
-bind_address = "0.0.0.0:8080"
+# Keep native deployments bound to localhost by default. For Docker Compose,
+# compose.prod.yml overrides this to 0.0.0.0 inside the container while
+# publishing the host port on 127.0.0.1 only.
+bind_address = "127.0.0.1:8080"
 
 [metrics]
 enabled = true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,9 +23,12 @@ services:
       # TRANSPONDER_SERVER_PRIVATE_KEY: "your-hex-private-key"
       # TRANSPONDER_APNS_ENABLED: "true"
       # TRANSPONDER_FCM_ENABLED: "true"
+      # The host port is bound to 127.0.0.1 above; this keeps Docker port
+      # publishing reachable without exposing it on public host interfaces.
+      TRANSPONDER_HEALTH_BIND_ADDRESS: "0.0.0.0:8080"
       TRANSPONDER_LOGGING_LEVEL: "info"
     healthcheck:
-      # If you override health.bind_address, update this URL to match.
+      # If you change the health server port, update this URL too.
       test: ["CMD", "/bin/transponder", "healthcheck", "--url", "http://127.0.0.1:8080/health"]
       interval: 30s
       timeout: 10s

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -97,6 +97,7 @@ chmod 600 secrets/server_private_key
 - set APNs identifiers and bundle ID
 - set FCM project ID if you want to override the service-account value
 - if you add any `relays.onion` entries, plan to build a Tor-enabled image or binary
+- keep `health.bind_address` on `127.0.0.1:8080` for native deployments unless an internal proxy, VPN, or load balancer needs it
 
 5. Edit `deploy/production.env`:
 
@@ -131,7 +132,7 @@ docker compose -f compose.prod.yml --env-file deploy/production.env up -d
 
 If you built a Tor-enabled image, set `TRANSPONDER_IMAGE=transponder:tor` in `deploy/production.env` before starting the stack.
 
-The Compose stack binds Transponder to `127.0.0.1:${TRANSPONDER_PUBLISHED_PORT}` by default. If you need remote access to `/health`, `/ready`, or `/metrics`, put it behind your existing proxy, VPN, or SSH tunnel rather than publishing it broadly.
+The Compose stack publishes Transponder on `127.0.0.1:${TRANSPONDER_PUBLISHED_PORT}` by default and sets `TRANSPONDER_HEALTH_BIND_ADDRESS=0.0.0.0:8080` inside the container so Docker port publishing can reach it. If you need remote access to `/health`, `/ready`, or `/metrics`, put it behind your existing proxy, VPN, or SSH tunnel rather than publishing it broadly.
 
 ## Native systemd Deployment
 
@@ -194,7 +195,7 @@ curl http://127.0.0.1:<HEALTH_PORT>/ready
 curl http://127.0.0.1:<HEALTH_PORT>/metrics
 ```
 
-For Docker, `TRANSPONDER_PUBLISHED_PORT` defaults to `8080` if unset. For native deployments, `<HEALTH_PORT>` is whatever you configure in `health.bind_address`; the production example defaults to `8080`.
+For Docker, `TRANSPONDER_PUBLISHED_PORT` defaults to `8080` if unset. For native deployments, use the port from `health.bind_address`; the production example defaults to `127.0.0.1:8080`.
 
 `/ready` should return HTTP 200 only when at least one relay is connected and at least one push provider is configured.
 

--- a/plan.md
+++ b/plan.md
@@ -182,7 +182,7 @@ tokio-test = "0.4.5"
 
   [health]
   enabled = true
-  bind_address = "0.0.0.0:8080"
+  bind_address = "127.0.0.1:8080"
 
   [logging]
   # Level: "trace", "debug", "info", "warn", "error", "off"

--- a/src/config.rs
+++ b/src/config.rs
@@ -45,6 +45,7 @@ pub struct AppConfig {
 
 /// Default maximum size for the deduplication cache.
 const DEFAULT_MAX_DEDUP_CACHE_SIZE: usize = 100_000;
+const DEFAULT_HEALTH_BIND_ADDRESS: &str = "127.0.0.1:8080";
 const ENV_PREFIX: &str = "TRANSPONDER_";
 
 fn default_max_dedup_cache_size() -> usize {
@@ -226,7 +227,7 @@ fn default_health_enabled() -> bool {
 }
 
 fn default_health_bind_address() -> String {
-    "0.0.0.0:8080".to_string()
+    DEFAULT_HEALTH_BIND_ADDRESS.to_string()
 }
 
 /// Metrics configuration.
@@ -306,7 +307,7 @@ fn base_config_builder() -> Result<ConfigBuilder<DefaultState>> {
         .set_default("fcm.service_account_path", "")?
         .set_default("fcm.project_id", "")?
         .set_default("health.enabled", true)?
-        .set_default("health.bind_address", "0.0.0.0:8080")?
+        .set_default("health.bind_address", DEFAULT_HEALTH_BIND_ADDRESS)?
         .set_default("metrics.enabled", true)?
         .set_default("logging.level", "info")?
         .set_default("logging.format", "json")?)
@@ -673,7 +674,7 @@ mod tests {
         assert_eq!(config.apns.environment, "production");
         assert!(!config.fcm.enabled);
         assert!(config.health.enabled);
-        assert_eq!(config.health.bind_address, "0.0.0.0:8080");
+        assert_eq!(config.health.bind_address, "127.0.0.1:8080");
         assert!(config.metrics.enabled);
         assert_eq!(config.logging.level, "info");
         assert_eq!(config.logging.format, "json");
@@ -703,7 +704,7 @@ mod tests {
         assert_eq!(config.apns.environment, "production");
         assert!(!config.fcm.enabled);
         assert!(config.health.enabled);
-        assert_eq!(config.health.bind_address, "0.0.0.0:8080");
+        assert_eq!(config.health.bind_address, "127.0.0.1:8080");
         assert_eq!(config.logging.level, "info");
         assert_eq!(config.logging.format, "json");
     }
@@ -816,7 +817,7 @@ mod tests {
     #[test]
     fn test_health_config_defaults() {
         assert!(default_health_enabled());
-        assert_eq!(default_health_bind_address(), "0.0.0.0:8080");
+        assert_eq!(default_health_bind_address(), "127.0.0.1:8080");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Change the default health server bind address to `127.0.0.1:8080`.
- Update config examples and docs to keep unauthenticated health, readiness, and metrics endpoints internal by default.
- Preserve Docker/Compose health checks by binding inside the container while publishing only to localhost on the host.

## Testing
- `cargo fmt --check`
- `cargo test config::`
- `cargo test`
- `cargo clippy -- -D warnings`
- `git diff --check`

fixes https://github.com/marmot-protocol/marmot-security/issues/28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Changed default health server bind address to localhost-only to restrict unauthenticated health and metrics endpoints to internal access by default.

* **Documentation**
  * Updated configuration examples and deployment guides to reflect the new localhost-only default binding and explain Docker override behavior for health endpoint exposure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->