### PR TITLE
Update MIP-05 token sizing and APNs token validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Updated MIP-05 token handling for the expanded 1084-byte encrypted token format and variable-length APNs/FCM device tokens introduced in [marmot-protocol/mdk#254](https://github.com/marmot-protocol/mdk/pull/254) ([#40](https://github.com/marmot-protocol/transponder/pull/40)).
+
 ### Security
 
 - Store the server secp256k1 secret key in zeroizing memory and erase temporary `SecretKey` values used during token decryption, addressing the long-term key retention risk reported in marmot-security#24 ([#36](https://github.com/marmot-protocol/transponder/pull/36)).

--- a/src/crypto/token.rs
+++ b/src/crypto/token.rs
@@ -29,11 +29,11 @@ const HKDF_SALT: &[u8] = b"mip05-v1";
 /// MIP-05 HKDF info string for token encryption key.
 const HKDF_INFO: &[u8] = b"mip05-token-encryption";
 
-/// Expected size of the encrypted token (280 bytes total).
+/// Expected size of the encrypted token (1084 bytes total).
 /// - 32 bytes: x-only ephemeral public key
 /// - 12 bytes: nonce
-/// - 236 bytes: ciphertext (220-byte plaintext + 16-byte auth tag)
-pub const ENCRYPTED_TOKEN_SIZE: usize = 280;
+/// - 1040 bytes: ciphertext (1024-byte plaintext + 16-byte auth tag)
+pub const ENCRYPTED_TOKEN_SIZE: usize = 1084;
 
 /// Size of x-only secp256k1 public key.
 const PUBKEY_SIZE: usize = 32;
@@ -42,13 +42,10 @@ const PUBKEY_SIZE: usize = 32;
 const NONCE_SIZE: usize = 12;
 
 /// Size of decrypted token plaintext.
-const TOKEN_PLAINTEXT_SIZE: usize = 220;
+pub(crate) const TOKEN_PLAINTEXT_SIZE: usize = 1024;
 
-/// Required APNs device token length in bytes.
-const APNS_DEVICE_TOKEN_SIZE: usize = 32;
-
-/// Maximum allowed FCM device token length in bytes.
-const MAX_FCM_DEVICE_TOKEN_SIZE: usize = 200;
+/// Maximum allowed device token length in bytes.
+pub(crate) const MAX_DEVICE_TOKEN_SIZE: usize = TOKEN_PLAINTEXT_SIZE - 3;
 
 /// Platform identifier for APNs (iOS).
 pub const PLATFORM_APNS: u8 = 0x01;
@@ -110,7 +107,7 @@ impl EncryptedToken {
     /// Expected format:
     /// - Bytes 0-31: X-only ephemeral public key
     /// - Bytes 32-43: Nonce
-    /// - Bytes 44-279: Ciphertext with auth tag
+    /// - Bytes 44..: Ciphertext with auth tag
     pub fn from_bytes(data: &[u8]) -> Result<Self> {
         if data.len() != ENCRYPTED_TOKEN_SIZE {
             return Err(Error::InvalidToken(format!(
@@ -170,18 +167,10 @@ impl TokenPayload {
         let platform = Platform::from_byte(data[0])?;
         let token_length = u16::from_be_bytes([data[1], data[2]]) as usize;
 
-        match platform {
-            Platform::Apns if token_length != APNS_DEVICE_TOKEN_SIZE => {
-                return Err(Error::InvalidToken(format!(
-                    "Invalid APNs token length: expected {APNS_DEVICE_TOKEN_SIZE}, got {token_length}"
-                )));
-            }
-            Platform::Fcm if !(1..=MAX_FCM_DEVICE_TOKEN_SIZE).contains(&token_length) => {
-                return Err(Error::InvalidToken(format!(
-                    "Invalid FCM token length: expected 1..={MAX_FCM_DEVICE_TOKEN_SIZE}, got {token_length}"
-                )));
-            }
-            _ => {}
+        if !(1..=MAX_DEVICE_TOKEN_SIZE).contains(&token_length) {
+            return Err(Error::InvalidToken(format!(
+                "Invalid device token length: expected 1..={MAX_DEVICE_TOKEN_SIZE}, got {token_length}"
+            )));
         }
 
         let payload_end = 3 + token_length;
@@ -383,24 +372,29 @@ mod tests {
 
     #[test]
     fn test_token_payload_parsing() {
-        let device_token = [0xAA; APNS_DEVICE_TOKEN_SIZE];
-        let data = build_plaintext(PLATFORM_APNS, APNS_DEVICE_TOKEN_SIZE as u16, &device_token);
+        let device_token = [0xAA; 32];
+        let data = build_plaintext(PLATFORM_APNS, device_token.len() as u16, &device_token);
         let payload = TokenPayload::from_decrypted(&data).unwrap();
         assert_eq!(payload.platform, Platform::Apns);
         assert_eq!(payload.device_token, device_token);
     }
 
     #[test]
-    fn test_token_payload_invalid_apns_length() {
+    fn test_token_payload_accepts_variable_apns_length() {
         let data = build_plaintext(PLATFORM_APNS, 31, &[0xAA; 31]);
-        let result = TokenPayload::from_decrypted(&data);
-        assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("Invalid APNs token length")
+        let payload = TokenPayload::from_decrypted(&data).unwrap();
+        assert_eq!(payload.platform, Platform::Apns);
+        assert_eq!(payload.device_token, [0xAA; 31]);
+
+        let max_device_token = vec![0xBB; MAX_DEVICE_TOKEN_SIZE];
+        let data = build_plaintext(
+            PLATFORM_APNS,
+            max_device_token.len() as u16,
+            &max_device_token,
         );
+        let payload = TokenPayload::from_decrypted(&data).unwrap();
+        assert_eq!(payload.platform, Platform::Apns);
+        assert_eq!(payload.device_token, max_device_token);
     }
 
     #[test]
@@ -482,20 +476,29 @@ mod tests {
             result
                 .unwrap_err()
                 .to_string()
-                .contains("Invalid FCM token length")
+                .contains("Invalid device token length")
         );
     }
 
     #[test]
-    fn test_token_payload_fcm_length_too_large() {
-        let data = build_plaintext(PLATFORM_FCM, 201, &[0x11; 200]);
+    fn test_token_payload_accepts_large_fcm_token() {
+        let device_token = vec![0x11; 201];
+        let data = build_plaintext(PLATFORM_FCM, device_token.len() as u16, &device_token);
+        let payload = TokenPayload::from_decrypted(&data).unwrap();
+        assert_eq!(payload.platform, Platform::Fcm);
+        assert_eq!(payload.device_token, device_token);
+    }
+
+    #[test]
+    fn test_token_payload_device_token_length_too_large() {
+        let data = build_plaintext(PLATFORM_FCM, (MAX_DEVICE_TOKEN_SIZE + 1) as u16, &[]);
         let result = TokenPayload::from_decrypted(&data);
         assert!(result.is_err());
         assert!(
             result
                 .unwrap_err()
                 .to_string()
-                .contains("Invalid FCM token length")
+                .contains("Invalid device token length")
         );
     }
 
@@ -521,7 +524,7 @@ mod tests {
             result
                 .unwrap_err()
                 .to_string()
-                .contains("Invalid FCM token length")
+                .contains("Invalid device token length")
         );
     }
 

--- a/src/push/apns.rs
+++ b/src/push/apns.rs
@@ -67,17 +67,14 @@ struct ApnsErrorResponse {
     reason: String,
 }
 
-/// Expected length of an APNs device token in hexadecimal format (32 bytes = 64 hex chars).
-const APNS_DEVICE_TOKEN_LENGTH: usize = 64;
-
 /// Validate an APNs device token format.
 ///
-/// APNs device tokens should be exactly 64 hexadecimal characters (representing 32 bytes).
-/// This validation prevents malformed tokens from being sent to APNs, which is more
-/// efficient than waiting for a server-side rejection.
+/// MIP-05 treats APNs tokens as variable-length opaque bytes. Transponder
+/// hex-encodes those bytes for the APNs device-token URL path, so only reject
+/// empty or non-hex strings here.
 #[must_use]
 fn is_valid_device_token(token: &str) -> bool {
-    token.len() == APNS_DEVICE_TOKEN_LENGTH && token.chars().all(|c| c.is_ascii_hexdigit())
+    !token.is_empty() && token.chars().all(|c| c.is_ascii_hexdigit())
 }
 
 /// APNs client for sending push notifications.
@@ -383,36 +380,27 @@ mod tests {
 
     #[test]
     fn test_valid_device_token() {
+        // Valid short hex token (lowercase)
+        assert!(is_valid_device_token("0123456789abcdef"));
+
         // Valid 64-character hex token (lowercase)
         assert!(is_valid_device_token(
             "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
         ));
 
-        // Valid 64-character hex token (uppercase)
+        // Valid longer-than-64-character hex token (uppercase)
         assert!(is_valid_device_token(
-            "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF"
+            "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF01"
         ));
 
-        // Valid 64-character hex token (mixed case)
+        // Valid mixed-case hex token
         assert!(is_valid_device_token(
             "0123456789AbCdEf0123456789AbCdEf0123456789AbCdEf0123456789AbCdEf"
         ));
     }
 
     #[test]
-    fn test_invalid_device_token_wrong_length() {
-        // Too short
-        assert!(!is_valid_device_token("0123456789abcdef"));
-        assert!(!is_valid_device_token(
-            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcde"
-        )); // 63 chars
-
-        // Too long
-        assert!(!is_valid_device_token(
-            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0"
-        )); // 65 chars
-
-        // Empty
+    fn test_invalid_device_token_empty() {
         assert!(!is_valid_device_token(""));
     }
 
@@ -461,9 +449,12 @@ mod tests {
             metrics: None,
         };
 
-        // Test with token that's too short
+        // Test with a token that contains non-hex characters
         let result = client.send("tooshort").await.unwrap();
-        assert!(!result, "Should return false for token that's too short");
+        assert!(
+            !result,
+            "Should return false for token with non-hex characters"
+        );
 
         // Test with token that has invalid characters
         let result = client

--- a/src/push/apns.rs
+++ b/src/push/apns.rs
@@ -71,10 +71,12 @@ struct ApnsErrorResponse {
 ///
 /// MIP-05 treats APNs tokens as variable-length opaque bytes. Transponder
 /// hex-encodes those bytes for the APNs device-token URL path, so only reject
-/// empty or non-hex strings here.
+/// empty, odd-length, or non-hex strings here.
 #[must_use]
 fn is_valid_device_token(token: &str) -> bool {
-    !token.is_empty() && token.chars().all(|c| c.is_ascii_hexdigit())
+    !token.is_empty()
+        && token.len().is_multiple_of(2)
+        && token.chars().all(|c| c.is_ascii_hexdigit())
 }
 
 /// APNs client for sending push notifications.
@@ -402,6 +404,11 @@ mod tests {
     #[test]
     fn test_invalid_device_token_empty() {
         assert!(!is_valid_device_token(""));
+    }
+
+    #[test]
+    fn test_invalid_device_token_odd_length() {
+        assert!(!is_valid_device_token("abc"));
     }
 
     #[test]

--- a/src/test_vectors.rs
+++ b/src/test_vectors.rs
@@ -18,7 +18,9 @@ use chacha20poly1305::{
 use nostr_sdk::prelude::*;
 use sha2::Sha256;
 
-use crate::crypto::token::{ENCRYPTED_TOKEN_SIZE, PLATFORM_APNS, PLATFORM_FCM};
+use crate::crypto::token::{
+    ENCRYPTED_TOKEN_SIZE, MAX_DEVICE_TOKEN_SIZE, PLATFORM_APNS, PLATFORM_FCM, TOKEN_PLAINTEXT_SIZE,
+};
 
 /// MIP-05 HKDF salt for key derivation (same as in token.rs).
 const HKDF_SALT: &[u8] = b"mip05-v1";
@@ -29,9 +31,6 @@ const HKDF_INFO: &[u8] = b"mip05-token-encryption";
 /// Kind for MIP-05 notification requests.
 pub const KIND_NOTIFICATION_REQUEST: u16 = 446;
 
-const TOKEN_PLAINTEXT_SIZE: usize = 220;
-const APNS_DEVICE_TOKEN_SIZE: usize = 32;
-const MAX_FCM_DEVICE_TOKEN_SIZE: usize = 200;
 const TAG_VERSION: &str = "v";
 const TAG_ENCODING: &str = "encoding";
 const VERSION_MIP05_V1: &str = "mip05-v1";
@@ -94,14 +93,9 @@ impl TestToken {
     /// Format: platform || token_length || device_token || random_padding
     fn to_plaintext(&self) -> Vec<u8> {
         match self.platform {
-            PLATFORM_APNS => assert_eq!(
-                self.device_token.len(),
-                APNS_DEVICE_TOKEN_SIZE,
-                "APNs token must be 32 bytes"
-            ),
-            PLATFORM_FCM => assert!(
-                (1..=MAX_FCM_DEVICE_TOKEN_SIZE).contains(&self.device_token.len()),
-                "FCM token must be 1..=200 bytes"
+            PLATFORM_APNS | PLATFORM_FCM => assert!(
+                (1..=MAX_DEVICE_TOKEN_SIZE).contains(&self.device_token.len()),
+                "device token must be 1..={MAX_DEVICE_TOKEN_SIZE} bytes"
             ),
             _ => panic!("unsupported test platform"),
         }
@@ -147,7 +141,7 @@ impl TokenEncryptor {
 
     /// Encrypt a test token.
     ///
-    /// Returns the encrypted token bytes (280 bytes total).
+    /// Returns the encrypted token bytes.
     pub fn encrypt(&self, token: &TestToken) -> Vec<u8> {
         // Generate ephemeral keypair
         let mut ephemeral_secret_bytes = [0u8; 32];
@@ -184,7 +178,7 @@ impl TokenEncryptor {
         let mut encrypted = Vec::with_capacity(ENCRYPTED_TOKEN_SIZE);
         encrypted.extend_from_slice(&ephemeral_xonly.serialize()); // 32 bytes
         encrypted.extend_from_slice(&nonce_bytes); // 12 bytes
-        encrypted.extend_from_slice(&ciphertext); // 236 bytes (220 + 16 tag)
+        encrypted.extend_from_slice(&ciphertext);
 
         assert_eq!(encrypted.len(), ENCRYPTED_TOKEN_SIZE);
         encrypted
@@ -256,7 +250,7 @@ impl NotificationContentBuilder {
         assert_eq!(
             token.len(),
             ENCRYPTED_TOKEN_SIZE,
-            "token should be 280 bytes"
+            "token should be {ENCRYPTED_TOKEN_SIZE} bytes"
         );
         self.tokens.push(token);
         self


### PR DESCRIPTION
**Summary**
- Update encrypted token parsing to use 1084-byte tokens with 1024-byte plaintext payloads.
- Replace platform-specific APNs/FCM device token length checks with a shared opaque token length bound.
- Allow variable-length APNs tokens by removing the exact 64-character validation requirement.
- Update token test vectors and unit tests for the new token format.

**Testing**
- `cargo fmt --check`
- `git diff --check`
- `cargo test -- --nocapture`
- `cargo clippy -- -D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced token compatibility: support for larger encrypted tokens (1084 bytes) and variable-length device tokens for APNs and FCM. Unified device-token validation replaces platform-specific length rules for more consistent handling.

* **Tests / Documentation**
  * Updated tests and changelog entries to reflect new token sizes and validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->