### PR TITLE
[codex] Fix relay lookback for NIP-59 gift wraps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3566,9 +3566,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring 0.17.14",
  "rustls-pki-types",

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -137,6 +137,9 @@ pub struct Metrics {
     /// Total number of relay notifications dropped because the receiver lagged.
     pub relay_notifications_dropped_total: IntCounter,
 
+    /// Relay subscription lookback window in seconds.
+    pub relay_subscription_lookback_seconds: IntGauge,
+
     // === Server Metrics ===
     /// Timestamp when the server started (Unix seconds).
     pub server_start_time_seconds: Gauge,
@@ -502,6 +505,12 @@ impl Metrics {
         ))?;
         registry.register(Box::new(relay_notifications_dropped_total.clone()))?;
 
+        let relay_subscription_lookback_seconds = IntGauge::with_opts(Opts::new(
+            "transponder_relay_subscription_lookback_seconds",
+            "Relay subscription lookback window in seconds",
+        ))?;
+        registry.register(Box::new(relay_subscription_lookback_seconds.clone()))?;
+
         // === Server Metrics ===
         let server_start_time_seconds = Gauge::with_opts(Opts::new(
             "transponder_server_start_time_seconds",
@@ -556,6 +565,7 @@ impl Metrics {
             relays_configured,
             relay_notifications_lagged_total,
             relay_notifications_dropped_total,
+            relay_subscription_lookback_seconds,
             server_start_time_seconds,
             server_info,
         })
@@ -815,6 +825,11 @@ impl Metrics {
         self.relay_notifications_dropped_total.inc_by(count);
     }
 
+    /// Set the relay subscription lookback window.
+    pub fn set_relay_subscription_lookback(&self, seconds: u64) {
+        self.relay_subscription_lookback_seconds.set(seconds as i64);
+    }
+
     /// Gather all metrics for export.
     pub fn gather(&self) -> Vec<prometheus::proto::MetricFamily> {
         self.registry.gather()
@@ -1064,6 +1079,7 @@ mod tests {
         metrics.set_relays_connected("onion", 1);
         metrics.record_relay_notifications_lagged();
         metrics.record_relay_notifications_dropped(4);
+        metrics.set_relay_subscription_lookback(172_800);
 
         assert_eq!(
             gauge_value(
@@ -1112,6 +1128,14 @@ mod tests {
                 &[]
             ),
             4.0
+        );
+        assert_eq!(
+            gauge_value(
+                &metrics,
+                "transponder_relay_subscription_lookback_seconds",
+                &[]
+            ),
+            172_800.0
         );
     }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -827,7 +827,8 @@ impl Metrics {
 
     /// Set the relay subscription lookback window.
     pub fn set_relay_subscription_lookback(&self, seconds: u64) {
-        self.relay_subscription_lookback_seconds.set(seconds as i64);
+        self.relay_subscription_lookback_seconds
+            .set(i64::try_from(seconds).unwrap_or(i64::MAX));
     }
 
     /// Gather all metrics for export.
@@ -1136,6 +1137,22 @@ mod tests {
                 &[]
             ),
             172_800.0
+        );
+    }
+
+    #[test]
+    fn test_relay_subscription_lookback_saturates_large_values() {
+        let metrics = Metrics::new().unwrap();
+
+        metrics.set_relay_subscription_lookback(u64::MAX);
+
+        assert_eq!(
+            gauge_value(
+                &metrics,
+                "transponder_relay_subscription_lookback_seconds",
+                &[]
+            ),
+            i64::MAX as f64
         );
     }
 

--- a/src/nostr/client.rs
+++ b/src/nostr/client.rs
@@ -17,6 +17,13 @@ use crate::metrics::Metrics;
 // Type alias to avoid confusion with our RelayStatus
 use nostr_sdk::RelayStatus as NostrRelayStatus;
 
+/// Maximum NIP-59 timestamp randomization window for gift wraps.
+///
+/// NIP-59 gift wraps intentionally randomize `created_at` into the past to
+/// reduce timing correlation. Relay subscriptions must look back by the same
+/// window or relays will filter out compliant gift wraps before delivery.
+const NIP59_TIMESTAMP_TWEAK_WINDOW_SECS: u64 = nip59::RANGE_RANDOM_TIMESTAMP_TWEAK.end;
+
 #[cfg(feature = "tor")]
 const TOR_FEATURE_ENABLED: bool = true;
 #[cfg(not(feature = "tor"))]
@@ -62,6 +69,7 @@ impl RelayClient {
 
         if let Some(metrics) = &metrics {
             metrics.set_relay_counts(config.clearnet.len(), config.onion.len());
+            metrics.set_relay_subscription_lookback(NIP59_TIMESTAMP_TWEAK_WINDOW_SECS);
         }
 
         Ok(Self {
@@ -154,13 +162,23 @@ impl RelayClient {
 
     /// Subscribe to gift-wrapped events for the server's public key.
     pub async fn subscribe(&self, server_pubkey: PublicKey) -> Result<()> {
+        let since = Timestamp::from_secs(
+            Timestamp::now()
+                .as_secs()
+                .saturating_sub(NIP59_TIMESTAMP_TWEAK_WINDOW_SECS),
+        );
+
         // Create filter for kind 1059 (gift wrap) events addressed to us
         let filter = Filter::new()
             .kind(Kind::GiftWrap)
             .pubkey(server_pubkey)
-            .since(Timestamp::now());
+            .since(since);
 
-        debug!(pubkey = %server_pubkey, "Subscribing to gift wrap events");
+        debug!(
+            pubkey = %server_pubkey,
+            lookback_secs = NIP59_TIMESTAMP_TWEAK_WINDOW_SECS,
+            "Subscribing to gift wrap events"
+        );
 
         self.client
             .subscribe(filter, None)
@@ -272,6 +290,28 @@ fn validate_relay_config(config: &RelayConfig) -> Result<()> {
 mod tests {
     use super::*;
 
+    async fn receive_gift_wrap(
+        notifications: &mut broadcast::Receiver<RelayPoolNotification>,
+        timeout: std::time::Duration,
+    ) -> Option<Box<Event>> {
+        tokio::time::timeout(timeout, async {
+            loop {
+                match notifications.recv().await {
+                    Ok(RelayPoolNotification::Event { event, .. }) => {
+                        if event.kind == Kind::GiftWrap {
+                            return Some(event);
+                        }
+                    }
+                    Ok(_) => continue,
+                    Err(_) => return None,
+                }
+            }
+        })
+        .await
+        .ok()
+        .flatten()
+    }
+
     #[test]
     fn test_relay_status_default() {
         let status = RelayStatus::default();
@@ -349,6 +389,64 @@ mod tests {
         assert!(result.is_ok());
 
         client.disconnect().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_relay_client_receives_nip59_backdated_gift_wraps() {
+        use nostr_relay_builder::MockRelay;
+        use std::time::Duration;
+
+        let mock = MockRelay::run().await.unwrap();
+        let relay_url = mock.url().await;
+
+        let server_keys = Keys::generate();
+        let server_pubkey = server_keys.public_key();
+        let config = test_relay_config(vec![relay_url.to_string()]);
+
+        let receiver = RelayClient::new(server_keys, config).await.unwrap();
+        receiver.client.add_relay(&relay_url).await.unwrap();
+        receiver.client.connect().await;
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        receiver.subscribe(server_pubkey).await.unwrap();
+        let mut notifications = receiver.notifications();
+
+        let sender_keys = Keys::generate();
+        let sender = Client::builder().signer(sender_keys.clone()).build();
+        sender.add_relay(&relay_url).await.unwrap();
+        sender.connect().await;
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let backdated = Timestamp::from_secs(
+            Timestamp::now()
+                .as_secs()
+                .saturating_sub(NIP59_TIMESTAMP_TWEAK_WINDOW_SECS),
+        );
+        let gift_wrap = EventBuilder::new(Kind::GiftWrap, "ignored")
+            .tags([Tag::public_key(server_pubkey)])
+            .custom_created_at(backdated)
+            .sign_with_keys(&sender_keys)
+            .unwrap();
+
+        sender.send_event(&gift_wrap).await.unwrap();
+
+        let received = receive_gift_wrap(&mut notifications, Duration::from_secs(2)).await;
+
+        assert!(
+            matches!(received.as_deref(), Some(event) if event.id == gift_wrap.id),
+            "subscription must receive kind 1059 events backdated within the NIP-59 tweak window"
+        );
+
+        receiver.disconnect().await.unwrap();
+        sender.disconnect().await;
+    }
+
+    #[test]
+    fn test_subscription_lookback_matches_nip59_tweak_window() {
+        assert_eq!(
+            NIP59_TIMESTAMP_TWEAK_WINDOW_SECS,
+            nip59::RANGE_RANDOM_TIMESTAMP_TWEAK.end
+        );
     }
 
     #[tokio::test]

--- a/src/nostr/client.rs
+++ b/src/nostr/client.rs
@@ -303,7 +303,8 @@ mod tests {
                         }
                     }
                     Ok(_) => continue,
-                    Err(_) => return None,
+                    Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(broadcast::error::RecvError::Closed) => return None,
                 }
             }
         })
@@ -444,8 +445,8 @@ mod tests {
     #[test]
     fn test_subscription_lookback_matches_nip59_tweak_window() {
         assert_eq!(
-            NIP59_TIMESTAMP_TWEAK_WINDOW_SECS,
-            nip59::RANGE_RANDOM_TIMESTAMP_TWEAK.end
+            NIP59_TIMESTAMP_TWEAK_WINDOW_SECS, 172_800,
+            "lookback must cover NIP-59's 2-day timestamp tweak window"
         );
     }
 


### PR DESCRIPTION
## Summary

- make the gift-wrap relay subscription look back by the NIP-59 timestamp tweak window instead of subscribing from `Timestamp::now()`
- add a relay regression test proving backdated kind 1059 events addressed to the server are delivered
- expose `transponder_relay_subscription_lookback_seconds` so operators can confirm the deployed lookback
- update `rustls-webpki` in `Cargo.lock` from `0.103.10` to `0.103.13` so the audit gate remains green

## Verification

- Confirmed the issue is real by temporarily restoring `since(Timestamp::now())`; the new backdated gift-wrap relay test failed because no event was delivered.
- `cargo test test_relay_client_receives_nip59_backdated_gift_wraps -- --nocapture`
- `cargo test test_subscription_lookback_matches_nip59_tweak_window -- --nocapture`
- `cargo test test_relay_metrics -- --nocapture`
- `just ci`

Closes marmot-protocol/marmot-security#96

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added monitoring metric for relay subscription lookback tracking.

* **Bug Fixes**
  * Enhanced gift-wrap message delivery to properly handle timestamp windows, ensuring messages are processed correctly within the specified timeframe.

* **Tests**
  * Added tests for gift-wrap handling and timestamp windowing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->