### PR TITLE
[codex] Deduplicate permanent event failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3566,9 +3566,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring 0.17.14",
  "rustls-pki-types",

--- a/src/nostr/events.rs
+++ b/src/nostr/events.rs
@@ -190,8 +190,11 @@ impl EventProcessor {
 
     /// Process an incoming event.
     ///
-    /// Returns `Ok(true)` if the event was processed, `Ok(false)` if it was
-    /// deduplicated (already seen), or an error if processing failed.
+    /// Returns `Ok(true)` if the event was processed and marked seen.
+    ///
+    /// Returns `Ok(false)` if the event was already seen or if processing
+    /// failed and the failure was logged/recorded. Processing failures are not
+    /// propagated so the event loop can continue with later events.
     pub async fn process(&self, event: &Event) -> Result<bool> {
         let _in_flight = InFlightEventGuard::new(self.metrics.as_ref());
         let started_at = StageTimer::start();
@@ -237,7 +240,7 @@ impl EventProcessor {
                 Ok(true)
             }
             Err(e) => {
-                if Self::should_mark_failed_event_seen(&e) {
+                if Self::is_permanent_error(&e) {
                     self.mark_seen(event.id).await;
                 }
 
@@ -260,7 +263,7 @@ impl EventProcessor {
     }
 
     /// Returns true when an event failed in a way replaying it cannot fix.
-    fn should_mark_failed_event_seen(error: &Error) -> bool {
+    fn is_permanent_error(error: &Error) -> bool {
         match error {
             Error::Crypto(_) | Error::InvalidToken(_) => true,
             Error::Config(_)
@@ -379,6 +382,8 @@ impl EventProcessor {
                 }
                 Err(e) => {
                     // Silently ignore invalid tokens per MIP-05 spec
+                    // Keep the encrypted-token rate-limit increment: invalid
+                    // encrypted blobs should still spend replay/spam budget.
                     trace!(error = %e, "Failed to decrypt token (ignoring)");
                     if let Some(ref m) = self.metrics {
                         m.record_token_decryption_failed();
@@ -408,8 +413,10 @@ impl EventProcessor {
                 continue;
             }
 
-            admitted_rate_limit_keys.push((encrypted_key, device_key));
             payloads.push(payload);
+            // Keep this paired with `payloads`: dispatch admission failure
+            // rolls back exactly the rate-limit increments for admitted work.
+            admitted_rate_limit_keys.push((encrypted_key, device_key));
         }
 
         if payloads.is_empty() {
@@ -1078,6 +1085,84 @@ mod tests {
             0.0
         );
         assert_eq!(processor.cache_len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_rate_limited_event_does_not_dispatch_or_rollback_budget() {
+        use crate::test_vectors::{
+            GiftWrapBuilder, NotificationContentBuilder, TestToken, TokenEncryptor,
+        };
+        use base64::prelude::*;
+
+        let server_keys = Keys::generate();
+        let sender_keys = Keys::generate();
+        let device_token = "aabbccdd11223344aabbccdd11223344aabbccdd11223344aabbccdd11223344";
+
+        let encryptor = TokenEncryptor::from_keys(&server_keys);
+        let encrypted = encryptor.encrypt(&TestToken::apns(device_token));
+        let encrypted_key = EventProcessor::hash_bytes(&encrypted);
+        let content = NotificationContentBuilder::new(&server_keys)
+            .with_raw_token(BASE64_STANDARD.encode(&encrypted))
+            .build();
+        let event = GiftWrapBuilder::new(server_keys.clone(), sender_keys)
+            .build(&content)
+            .await;
+
+        let (processor, metrics) =
+            create_processor_with_shutdown_dispatcher_metrics_and_rate_limits(
+                &server_keys,
+                TokenRateLimitConfig {
+                    max_cache_size: 100,
+                    max_tokens_per_event: DEFAULT_MAX_TOKENS_PER_EVENT,
+                    encrypted_token_per_minute: 0,
+                    encrypted_token_per_hour: 100,
+                    device_token_per_minute: 100,
+                    device_token_per_hour: 100,
+                },
+            )
+            .await;
+
+        assert!(processor.process(&event).await.unwrap());
+
+        assert_eq!(
+            processor
+                .encrypted_token_limiter
+                .peek_counts(&encrypted_key)
+                .await,
+            Some((0, 0))
+        );
+        assert_eq!(processor.device_token_limiter.len().await, 0);
+        assert_eq!(
+            counter_value(&metrics, "transponder_events_processed_total", &[]),
+            1.0
+        );
+        assert_eq!(
+            counter_value(
+                &metrics,
+                "transponder_tokens_rate_limited_total",
+                &[("type", "encrypted_token"), ("reason", "minute")],
+            ),
+            1.0
+        );
+        assert!(metrics.gather().into_iter().all(|family| {
+            family.name() != "transponder_push_dispatch_admission_duration_seconds"
+        }));
+        assert_eq!(
+            histogram_count(
+                &metrics,
+                "transponder_notifications_admitted_per_event",
+                &[]
+            ),
+            1
+        );
+        assert_eq!(
+            histogram_sample_sum(
+                &metrics,
+                "transponder_notifications_admitted_per_event",
+                &[]
+            ),
+            0.0
+        );
     }
 
     #[tokio::test]

--- a/src/nostr/events.rs
+++ b/src/nostr/events.rs
@@ -1045,6 +1045,37 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_process_invalid_token_failure_is_deduplicated_on_replay() {
+        let server_keys = Keys::generate();
+        let sender_keys = Keys::generate();
+
+        let event = scenarios::empty_notification(&server_keys, &sender_keys).await;
+
+        let (processor, metrics) = create_processor_with_metrics(&server_keys);
+
+        assert!(!processor.process(&event).await.unwrap());
+        assert!(!processor.process(&event).await.unwrap());
+
+        assert_eq!(
+            counter_value(&metrics, "transponder_events_failed_total", &[]),
+            1.0
+        );
+        assert_eq!(
+            counter_value(&metrics, "transponder_events_deduplicated_total", &[]),
+            1.0
+        );
+        assert_eq!(
+            histogram_count(
+                &metrics,
+                "transponder_notification_parse_duration_seconds",
+                &[("outcome", OperationOutcome::Failed.as_str())],
+            ),
+            1
+        );
+        assert_eq!(processor.cache_len(), 1);
+    }
+
+    #[tokio::test]
     async fn test_process_multi_token_notification() {
         let server_keys = Keys::generate();
         let sender_keys = Keys::generate();

--- a/src/nostr/events.rs
+++ b/src/nostr/events.rs
@@ -261,7 +261,20 @@ impl EventProcessor {
 
     /// Returns true when an event failed in a way replaying it cannot fix.
     fn should_mark_failed_event_seen(error: &Error) -> bool {
-        matches!(error, Error::Crypto(_) | Error::InvalidToken(_))
+        match error {
+            Error::Crypto(_) | Error::InvalidToken(_) => true,
+            Error::Config(_)
+            | Error::Nostr(_)
+            | Error::Apns(_)
+            | Error::Fcm(_)
+            | Error::Dispatch(_)
+            | Error::Io(_)
+            | Error::Http(_)
+            | Error::Json(_)
+            | Error::Jwt(_)
+            | Error::Base64(_)
+            | Error::Hex(_) => false,
+        }
     }
 
     /// Inner processing logic for an event.
@@ -332,6 +345,7 @@ impl EventProcessor {
         // Rate limiting happens BEFORE decryption intentionally:
         // Prevents wasting CPU on tokens we'll immediately rate-limit anyway.
         let mut payloads = Vec::with_capacity(token_bytes.len());
+        let mut admitted_rate_limit_keys = Vec::with_capacity(token_bytes.len());
         for bytes in token_bytes {
             // Rate limit check 1: encrypted token (replay protection)
             let encrypted_key = Self::hash_bytes(&bytes);
@@ -394,6 +408,7 @@ impl EventProcessor {
                 continue;
             }
 
+            admitted_rate_limit_keys.push((encrypted_key, device_key));
             payloads.push(payload);
         }
 
@@ -418,6 +433,15 @@ impl EventProcessor {
                 Ok(count)
             }
             Err(e) => {
+                for (encrypted_key, device_key) in &admitted_rate_limit_keys {
+                    self.encrypted_token_limiter
+                        .rollback_increment(encrypted_key)
+                        .await;
+                    self.device_token_limiter
+                        .rollback_increment(device_key)
+                        .await;
+                }
+
                 if let Some(ref m) = self.metrics {
                     m.observe_push_dispatch_admission_duration(
                         OperationOutcome::Failed,
@@ -623,6 +647,17 @@ mod tests {
     async fn create_processor_with_shutdown_dispatcher_metrics(
         server_keys: &Keys,
     ) -> (EventProcessor, Metrics) {
+        create_processor_with_shutdown_dispatcher_metrics_and_rate_limits(
+            server_keys,
+            TokenRateLimitConfig::default(),
+        )
+        .await
+    }
+
+    async fn create_processor_with_shutdown_dispatcher_metrics_and_rate_limits(
+        server_keys: &Keys,
+        rate_limit_config: TokenRateLimitConfig,
+    ) -> (EventProcessor, Metrics) {
         let nip59_handler = Nip59Handler::new(server_keys.clone());
         let mut secp_secret_key =
             secp256k1::SecretKey::from_slice(&server_keys.secret_key().to_secret_bytes())
@@ -650,7 +685,7 @@ mod tests {
                 token_decryptor,
                 push_dispatcher,
                 DEFAULT_MAX_DEDUP_CACHE_SIZE,
-                TokenRateLimitConfig::default(),
+                rate_limit_config,
                 Some(metrics.clone()),
             ),
             metrics,
@@ -996,6 +1031,47 @@ mod tests {
         assert_eq!(
             counter_value(&metrics, "transponder_events_failed_total", &[]),
             2.0
+        );
+        assert_eq!(
+            counter_value(&metrics, "transponder_events_deduplicated_total", &[]),
+            0.0
+        );
+        assert_eq!(processor.cache_len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_process_dispatch_failure_does_not_spend_rate_limit_budget() {
+        let server_keys = Keys::generate();
+        let sender_keys = Keys::generate();
+        let device_token = "aabbccdd11223344aabbccdd11223344aabbccdd11223344aabbccdd11223344";
+
+        let event =
+            scenarios::single_apns_notification(&server_keys, &sender_keys, device_token).await;
+
+        let (processor, metrics) =
+            create_processor_with_shutdown_dispatcher_metrics_and_rate_limits(
+                &server_keys,
+                TokenRateLimitConfig {
+                    max_cache_size: 100,
+                    max_tokens_per_event: DEFAULT_MAX_TOKENS_PER_EVENT,
+                    encrypted_token_per_minute: 1,
+                    encrypted_token_per_hour: 1,
+                    device_token_per_minute: 1,
+                    device_token_per_hour: 1,
+                },
+            )
+            .await;
+
+        assert!(!processor.process(&event).await.unwrap());
+        assert!(!processor.process(&event).await.unwrap());
+
+        assert_eq!(
+            counter_value(&metrics, "transponder_events_failed_total", &[]),
+            2.0
+        );
+        assert_eq!(
+            counter_value(&metrics, "transponder_events_processed_total", &[]),
+            0.0
         );
         assert_eq!(
             counter_value(&metrics, "transponder_events_deduplicated_total", &[]),

--- a/src/nostr/events.rs
+++ b/src/nostr/events.rs
@@ -17,7 +17,7 @@ use tracing::{debug, trace, warn};
 use crate::crypto::nip59::DEFAULT_MAX_TOKENS_PER_EVENT;
 use crate::crypto::token::ENCRYPTED_TOKEN_SIZE;
 use crate::crypto::{Nip59Handler, TokenDecryptor, TokenPayload};
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::metrics::{EventOutcome, Metrics, OperationOutcome};
 use crate::push::PushDispatcher;
 use crate::rate_limiter::{
@@ -237,6 +237,10 @@ impl EventProcessor {
                 Ok(true)
             }
             Err(e) => {
+                if Self::should_mark_failed_event_seen(&e) {
+                    self.mark_seen(event.id).await;
+                }
+
                 // Log but don't propagate - we want to continue processing other events
                 warn!(
                     event_id = %event.id,
@@ -253,6 +257,11 @@ impl EventProcessor {
                 Ok(false)
             }
         }
+    }
+
+    /// Returns true when an event failed in a way replaying it cannot fix.
+    fn should_mark_failed_event_seen(error: &Error) -> bool {
+        matches!(error, Error::Crypto(_) | Error::InvalidToken(_))
     }
 
     /// Inner processing logic for an event.
@@ -855,6 +864,35 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_process_permanent_failure_is_deduplicated_on_replay() {
+        let server_keys = Keys::generate();
+        let wrong_server_keys = Keys::generate();
+        let sender_keys = Keys::generate();
+
+        let event = scenarios::single_apns_notification(
+            &wrong_server_keys,
+            &sender_keys,
+            "deadbeef12345678deadbeef12345678deadbeef12345678deadbeef12345678",
+        )
+        .await;
+
+        let (processor, metrics) = create_processor_with_metrics(&server_keys);
+
+        assert!(!processor.process(&event).await.unwrap());
+        assert!(!processor.process(&event).await.unwrap());
+
+        assert_eq!(
+            counter_value(&metrics, "transponder_events_failed_total", &[]),
+            1.0
+        );
+        assert_eq!(
+            counter_value(&metrics, "transponder_events_deduplicated_total", &[]),
+            1.0
+        );
+        assert_eq!(processor.cache_len(), 1);
+    }
+
+    #[tokio::test]
     async fn test_process_failed_event_records_metrics() {
         let server_keys = Keys::generate();
         let wrong_server_keys = Keys::generate();
@@ -938,6 +976,32 @@ mod tests {
             ),
             0.0
         );
+    }
+
+    #[tokio::test]
+    async fn test_process_transient_dispatch_failure_is_retryable() {
+        let server_keys = Keys::generate();
+        let sender_keys = Keys::generate();
+        let device_token = "aabbccdd11223344aabbccdd11223344aabbccdd11223344aabbccdd11223344";
+
+        let event =
+            scenarios::single_apns_notification(&server_keys, &sender_keys, device_token).await;
+
+        let (processor, metrics) =
+            create_processor_with_shutdown_dispatcher_metrics(&server_keys).await;
+
+        assert!(!processor.process(&event).await.unwrap());
+        assert!(!processor.process(&event).await.unwrap());
+
+        assert_eq!(
+            counter_value(&metrics, "transponder_events_failed_total", &[]),
+            2.0
+        );
+        assert_eq!(
+            counter_value(&metrics, "transponder_events_deduplicated_total", &[]),
+            0.0
+        );
+        assert_eq!(processor.cache_len(), 0);
     }
 
     #[tokio::test]

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -175,7 +175,9 @@ impl<K: Hash + Eq + Clone + Send + Sync + 'static> RateLimiter<K> {
     /// Rolls back one previously allowed increment for a key.
     ///
     /// This is used when downstream admission fails after a rate-limit check
-    /// has already reserved capacity for work that will not run.
+    /// has already reserved capacity for work that will not run. If both
+    /// counters reach zero, the entry is removed so the failed admission leaves
+    /// no window-start trace for the next real request.
     pub async fn rollback_increment(&self, key: &K) {
         let mut entries = self.entries.write().await;
         let should_remove = if let Some(entry) = entries.get_mut(key) {

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -172,6 +172,25 @@ impl<K: Hash + Eq + Clone + Send + Sync + 'static> RateLimiter<K> {
         RateLimitResult::Allowed
     }
 
+    /// Rolls back one previously allowed increment for a key.
+    ///
+    /// This is used when downstream admission fails after a rate-limit check
+    /// has already reserved capacity for work that will not run.
+    pub async fn rollback_increment(&self, key: &K) {
+        let mut entries = self.entries.write().await;
+        let should_remove = if let Some(entry) = entries.get_mut(key) {
+            entry.minute_count = entry.minute_count.saturating_sub(1);
+            entry.hour_count = entry.hour_count.saturating_sub(1);
+            entry.minute_count == 0 && entry.hour_count == 0
+        } else {
+            false
+        };
+
+        if should_remove {
+            entries.pop(key);
+        }
+    }
+
     /// Removes stale entries that haven't been accessed recently.
     ///
     /// Entries are considered stale if both windows have expired
@@ -256,6 +275,23 @@ mod tests {
 
         // Different key should still work
         assert!(limiter.check_and_increment(&2u64).await.is_allowed());
+    }
+
+    #[tokio::test]
+    async fn test_rollback_increment_refunds_allowed_request() {
+        let limiter: RateLimiter<u64> = RateLimiter::new(RateLimitConfig {
+            max_per_minute: 1,
+            max_per_hour: 1,
+            max_entries: 100,
+        });
+
+        assert!(limiter.check_and_increment(&1u64).await.is_allowed());
+        assert!(!limiter.check_and_increment(&1u64).await.is_allowed());
+
+        limiter.rollback_increment(&1u64).await;
+
+        assert_eq!(limiter.len().await, 0);
+        assert!(limiter.check_and_increment(&1u64).await.is_allowed());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Mark permanent event-level failures (`Crypto` and `InvalidToken`) as seen so replayed invalid events hit the dedup cache instead of re-running NIP-59 unwrap work.
- Keep transient dispatch failures retryable so recoverable push pipeline errors are not dropped.
- Update `rustls-webpki` in `Cargo.lock` to `0.103.13` so the audit gate is green with the current RustSec database.

Closes marmot-protocol/marmot-security#54.

## Verification

- Reproduced the issue first: `cargo test nostr::events::tests::test_process_permanent_failure_is_deduplicated_on_replay -- --nocapture` failed before the fix with `transponder_events_failed_total` at `2.0` instead of `1.0`.
- `cargo test nostr::events::tests::test_process_permanent_failure_is_deduplicated_on_replay -- --nocapture`
- `cargo test nostr::events::tests::test_process_transient_dispatch_failure_is_retryable -- --nocapture`
- `just ci` (`281 passed`; audit reports no vulnerabilities, with the existing allowed `rand` warnings)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/transponder/pull/42">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Event processing now marks certain permanent failures as seen so they are deduplicated on replay, reducing duplicate processing and unnecessary retries.
  * Transient dispatch failures are now handled as retryable, improving reliability of event delivery.

* **Tests**
  * Added tests validating deduplication for permanent failures and correct retry behavior for transient failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->