### PR TITLE
[codex] Zeroize push auth token caches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3566,9 +3566,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring 0.17.14",
  "rustls-pki-types",

--- a/src/push/apns.rs
+++ b/src/push/apns.rs
@@ -153,14 +153,17 @@ impl ApnsClient {
             return Ok(token.token.clone());
         }
 
-        // Generate and cache new token
+        // Generate and cache new token. The caller gets a short-lived zeroizing
+        // clone for request construction while the cache owns the reusable copy.
         let token = self.generate_token()?;
-        *cached = Some(CachedToken {
-            token: token.clone(),
+        let cached_token = CachedToken {
+            token,
             expires_at: SystemTime::now() + TOKEN_LIFETIME,
-        });
+        };
+        let outbound_token = cached_token.token.clone();
+        *cached = Some(cached_token);
 
-        Ok(token)
+        Ok(outbound_token)
     }
 
     /// Generate a new JWT token.
@@ -386,6 +389,7 @@ mod tests {
 
     #[test]
     fn test_cached_token_stores_jwt_in_zeroizing_string() {
+        // Compile-time guard: cached credentials must stay zeroizing.
         fn assert_zeroizing_string(_: &Zeroizing<String>) {}
 
         let cached = CachedToken {

--- a/src/push/apns.rs
+++ b/src/push/apns.rs
@@ -10,6 +10,7 @@ use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
 use tracing::{debug, error, trace, warn};
+use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
 use crate::config::ApnsConfig;
 use crate::error::{Error, Result};
@@ -34,8 +35,10 @@ struct ApnsClaims {
 }
 
 /// Cached JWT token.
+#[derive(Zeroize, ZeroizeOnDrop)]
 pub(crate) struct CachedToken {
-    token: String,
+    token: Zeroizing<String>,
+    #[zeroize(skip)]
     expires_at: SystemTime,
 }
 
@@ -131,7 +134,7 @@ impl ApnsClient {
     }
 
     /// Get a valid JWT token, refreshing if necessary.
-    async fn get_token(&self) -> Result<String> {
+    async fn get_token(&self) -> Result<Zeroizing<String>> {
         // First check with read lock (fast path)
         {
             let cached = self.cached_token.read().await;
@@ -161,7 +164,7 @@ impl ApnsClient {
     }
 
     /// Generate a new JWT token.
-    fn generate_token(&self) -> Result<String> {
+    fn generate_token(&self) -> Result<Zeroizing<String>> {
         let encoding_key = self
             .encoding_key
             .as_ref()
@@ -181,7 +184,7 @@ impl ApnsClient {
         let mut header = Header::new(Algorithm::ES256);
         header.kid = Some(self.config.key_id.clone());
 
-        let token = encode(&header, &claims, encoding_key)?;
+        let token = Zeroizing::new(encode(&header, &claims, encoding_key)?);
 
         if let Some(metrics) = &self.metrics {
             metrics.record_auth_token_refresh("apns_jwt");
@@ -246,7 +249,7 @@ impl ApnsClient {
             &transport_retry,
             "APNs",
             || async {
-                self.build_request(&url, &token)
+                self.build_request(&url, token.as_str())
                     .send()
                     .await
                     .map_err(Error::from)
@@ -360,6 +363,7 @@ mod tests {
     use base64::Engine;
     use wiremock::matchers::{header, method, path_regex};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+    use zeroize::Zeroizing;
 
     fn test_config() -> ApnsConfig {
         ApnsConfig {
@@ -378,6 +382,18 @@ mod tests {
         let json = serde_json::to_string(&payload).unwrap();
         assert!(json.contains("content-available"));
         assert!(json.contains("1"));
+    }
+
+    #[test]
+    fn test_cached_token_stores_jwt_in_zeroizing_string() {
+        fn assert_zeroizing_string(_: &Zeroizing<String>) {}
+
+        let cached = CachedToken {
+            token: Zeroizing::new("cached-jwt".to_string()),
+            expires_at: SystemTime::now() + Duration::from_secs(60),
+        };
+
+        assert_zeroizing_string(&cached.token);
     }
 
     #[test]
@@ -450,7 +466,7 @@ mod tests {
             config,
             encoding_key: Some(EncodingKey::from_secret(b"fake-key")),
             cached_token: Arc::new(RwLock::new(Some(CachedToken {
-                token: "test-token".to_string(),
+                token: Zeroizing::new("test-token".to_string()),
                 expires_at: SystemTime::now() + Duration::from_secs(3600),
             }))),
             metrics: None,
@@ -529,7 +545,7 @@ mod tests {
             },
             encoding_key: None,
             cached_token: Arc::new(RwLock::new(Some(CachedToken {
-                token: "test-token".to_string(),
+                token: Zeroizing::new("test-token".to_string()),
                 expires_at: SystemTime::now() + Duration::from_secs(3600),
             }))),
             metrics: None,
@@ -830,14 +846,14 @@ mod tests {
         {
             let mut cached = client.cached_token.write().await;
             *cached = Some(CachedToken {
-                token: "cached-test-token".to_string(),
+                token: Zeroizing::new("cached-test-token".to_string()),
                 expires_at: SystemTime::now() + Duration::from_secs(3600),
             });
         }
 
         // Should return cached token
         let token = client.get_token().await.unwrap();
-        assert_eq!(token, "cached-test-token");
+        assert_eq!(token.as_str(), "cached-test-token");
     }
 
     #[tokio::test]
@@ -858,7 +874,7 @@ mod tests {
         {
             let mut cached = client.cached_token.write().await;
             *cached = Some(CachedToken {
-                token: "expired-token".to_string(),
+                token: Zeroizing::new("expired-token".to_string()),
                 expires_at: SystemTime::now() - Duration::from_secs(1), // Already expired
             });
         }
@@ -885,14 +901,14 @@ mod tests {
         {
             let mut cached = client.cached_token.write().await;
             *cached = Some(CachedToken {
-                token: "valid-cached-token".to_string(),
+                token: Zeroizing::new("valid-cached-token".to_string()),
                 expires_at: SystemTime::now() + Duration::from_secs(3600), // 1 hour in the future
             });
         }
 
         // Should return cached token (no encoding key needed since we have valid cache)
         let token = client.get_token().await.unwrap();
-        assert_eq!(token, "valid-cached-token");
+        assert_eq!(token.as_str(), "valid-cached-token");
     }
 
     #[tokio::test]
@@ -966,7 +982,7 @@ mod tests {
             config,
             encoding_key: Some(EncodingKey::from_secret(b"fake-key")),
             cached_token: Arc::new(RwLock::new(Some(CachedToken {
-                token: "test-cached-token".to_string(),
+                token: Zeroizing::new("test-cached-token".to_string()),
                 expires_at: SystemTime::now() + Duration::from_secs(3600),
             }))),
             metrics: None,
@@ -979,7 +995,7 @@ mod tests {
 
         // Get token from cache
         let token = client.get_token().await.unwrap();
-        assert_eq!(token, "test-cached-token");
+        assert_eq!(token.as_str(), "test-cached-token");
 
         // Make request manually (simulating what send() does)
         let response = client
@@ -988,7 +1004,7 @@ mod tests {
             .header("apns-push-type", "background")
             .header("apns-priority", "5")
             .header("apns-topic", "com.example.app")
-            .header("authorization", format!("bearer {}", token))
+            .header("authorization", format!("bearer {}", token.as_str()))
             .json(&payload)
             .send()
             .await
@@ -1178,7 +1194,7 @@ OF/2NxApJCzGCEDdfSp6VQO30hyhRANCAAQRWz+jn65BtOMvdyHKcvjBeBSDZH2r
         {
             let cached = client.cached_token.read().await;
             assert!(cached.is_some());
-            assert_eq!(cached.as_ref().unwrap().token, token1);
+            assert_eq!(cached.as_ref().unwrap().token.as_str(), token1.as_str());
         }
 
         // Get token again - should return cached token (same value)
@@ -1218,7 +1234,7 @@ OF/2NxApJCzGCEDdfSp6VQO30hyhRANCAAQRWz+jn65BtOMvdyHKcvjBeBSDZH2r
             config,
             encoding_key: Some(EncodingKey::from_secret(b"fake-key")),
             cached_token: Arc::new(RwLock::new(Some(CachedToken {
-                token: "test-token".to_string(),
+                token: Zeroizing::new("test-token".to_string()),
                 expires_at: SystemTime::now() + Duration::from_secs(3600),
             }))),
             metrics: None,

--- a/src/push/fcm.rs
+++ b/src/push/fcm.rs
@@ -76,14 +76,16 @@ struct TokenRequest {
 #[derive(Debug, Deserialize)]
 #[allow(dead_code)]
 struct TokenResponse {
-    access_token: String,
+    access_token: Zeroizing<String>,
     expires_in: u64,
     token_type: String,
 }
 
 /// Cached access token.
+#[derive(Zeroize, ZeroizeOnDrop)]
 pub(crate) struct CachedToken {
-    token: String,
+    token: Zeroizing<String>,
+    #[zeroize(skip)]
     expires_at: SystemTime,
 }
 
@@ -175,7 +177,7 @@ impl FcmClient {
     }
 
     /// Get a valid access token, refreshing if necessary.
-    async fn get_access_token(&self) -> Result<String> {
+    async fn get_access_token(&self) -> Result<Zeroizing<String>> {
         // First check with read lock (fast path)
         {
             let cached = self.cached_token.read().await;
@@ -204,7 +206,7 @@ impl FcmClient {
     async fn refresh_token_inner(
         &self,
         cached: &mut tokio::sync::RwLockWriteGuard<'_, Option<CachedToken>>,
-    ) -> Result<String> {
+    ) -> Result<Zeroizing<String>> {
         let sa = self
             .service_account
             .as_ref()
@@ -348,7 +350,7 @@ impl FcmClient {
             &transport_retry,
             "FCM",
             || async {
-                self.build_request(&url, &access_token, device_token)
+                self.build_request(&url, access_token.as_str(), device_token)
                     .send()
                     .await
                     .map_err(Error::from)
@@ -471,6 +473,18 @@ mod tests {
     use super::*;
     use wiremock::matchers::{body_partial_json, header, method, path_regex};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[test]
+    fn test_cached_token_stores_access_token_in_zeroizing_string() {
+        fn assert_zeroizing_string(_: &Zeroizing<String>) {}
+
+        let cached = CachedToken {
+            token: Zeroizing::new("cached-access-token".to_string()),
+            expires_at: SystemTime::now() + Duration::from_secs(60),
+        };
+
+        assert_zeroizing_string(&cached.token);
+    }
 
     #[test]
     fn test_fcm_request_serialization() {
@@ -912,14 +926,14 @@ mod tests {
         {
             let mut cached = client.cached_token.write().await;
             *cached = Some(CachedToken {
-                token: "cached-access-token".to_string(),
+                token: Zeroizing::new("cached-access-token".to_string()),
                 expires_at: SystemTime::now() + Duration::from_secs(3600),
             });
         }
 
         // Should return cached token
         let token = client.get_access_token().await.unwrap();
-        assert_eq!(token, "cached-access-token");
+        assert_eq!(token.as_str(), "cached-access-token");
     }
 
     #[tokio::test]
@@ -1065,7 +1079,7 @@ mod tests {
         {
             let mut cached = client.cached_token.write().await;
             *cached = Some(CachedToken {
-                token: "expired-token".to_string(),
+                token: Zeroizing::new("expired-token".to_string()),
                 expires_at: SystemTime::now() - Duration::from_secs(1),
             });
         }
@@ -1109,7 +1123,7 @@ mod tests {
         {
             let mut cached = client.cached_token.write().await;
             *cached = Some(CachedToken {
-                token: "test-token".to_string(),
+                token: Zeroizing::new("test-token".to_string()),
                 expires_at: SystemTime::now() + Duration::from_secs(3600),
             });
         }

--- a/src/push/fcm.rs
+++ b/src/push/fcm.rs
@@ -69,7 +69,7 @@ struct OAuthClaims {
 #[derive(Debug, Serialize)]
 struct TokenRequest {
     grant_type: String,
-    assertion: String,
+    assertion: Zeroizing<String>,
 }
 
 /// OAuth2 token response.
@@ -233,7 +233,7 @@ impl FcmClient {
         };
 
         let header = Header::new(Algorithm::RS256);
-        let jwt = encode(&header, &claims, encoding_key)?;
+        let jwt = Zeroizing::new(encode(&header, &claims, encoding_key)?);
 
         let request = TokenRequest {
             grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer".to_string(),
@@ -484,6 +484,18 @@ mod tests {
         };
 
         assert_zeroizing_string(&cached.token);
+    }
+
+    #[test]
+    fn test_token_request_stores_assertion_in_zeroizing_string() {
+        fn assert_zeroizing_string(_: &Zeroizing<String>) {}
+
+        let request = TokenRequest {
+            grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer".to_string(),
+            assertion: Zeroizing::new("signed-jwt-assertion".to_string()),
+        };
+
+        assert_zeroizing_string(&request.assertion);
     }
 
     #[test]

--- a/src/push/fcm.rs
+++ b/src/push/fcm.rs
@@ -66,6 +66,7 @@ struct OAuthClaims {
 }
 
 /// OAuth2 token request.
+// Debug intentionally omitted: assertion contains credential material.
 #[derive(Serialize)]
 struct TokenRequest {
     grant_type: String,
@@ -73,12 +74,10 @@ struct TokenRequest {
 }
 
 /// OAuth2 token response.
+// Debug intentionally omitted: access_token contains credential material.
 #[derive(Deserialize)]
-#[allow(dead_code)]
 struct TokenResponse {
     access_token: Zeroizing<String>,
-    expires_in: u64,
-    token_type: String,
 }
 
 /// Cached access token.
@@ -257,18 +256,22 @@ impl FcmClient {
 
         let token_response: TokenResponse = response.json().await?;
 
-        // Cache the token while still holding the write lock
-        **cached = Some(CachedToken {
-            token: token_response.access_token.clone(),
+        // Cache the token while still holding the write lock. The caller gets a
+        // short-lived zeroizing clone for request construction while the cache
+        // owns the reusable copy.
+        let cached_token = CachedToken {
+            token: token_response.access_token,
             expires_at: SystemTime::now() + TOKEN_LIFETIME,
-        });
+        };
+        let outbound_token = cached_token.token.clone();
+        **cached = Some(cached_token);
 
         if let Some(metrics) = &self.metrics {
             metrics.record_auth_token_refresh("fcm_oauth");
         }
 
         trace!("Refreshed FCM access token");
-        Ok(token_response.access_token)
+        Ok(outbound_token)
     }
 
     /// Get the project ID, from config or service account.
@@ -476,6 +479,7 @@ mod tests {
 
     #[test]
     fn test_cached_token_stores_access_token_in_zeroizing_string() {
+        // Compile-time guard: cached credentials must stay zeroizing.
         fn assert_zeroizing_string(_: &Zeroizing<String>) {}
 
         let cached = CachedToken {
@@ -488,6 +492,7 @@ mod tests {
 
     #[test]
     fn test_token_request_stores_assertion_in_zeroizing_string() {
+        // Compile-time guard: OAuth assertions must stay zeroizing.
         fn assert_zeroizing_string(_: &Zeroizing<String>) {}
 
         let request = TokenRequest {
@@ -496,6 +501,23 @@ mod tests {
         };
 
         assert_zeroizing_string(&request.assertion);
+    }
+
+    #[test]
+    fn test_token_response_deserializes_access_token_as_zeroizing_string() {
+        // Compile-time guard: provider bearer tokens must deserialize directly
+        // into zeroizing storage while ignoring unused response metadata.
+        fn assert_zeroizing_string(_: &Zeroizing<String>) {}
+
+        let response: TokenResponse = serde_json::from_value(serde_json::json!({
+            "access_token": "provider-access-token",
+            "expires_in": 3600,
+            "token_type": "Bearer"
+        }))
+        .unwrap();
+
+        assert_eq!(response.access_token.as_str(), "provider-access-token");
+        assert_zeroizing_string(&response.access_token);
     }
 
     #[test]

--- a/src/push/fcm.rs
+++ b/src/push/fcm.rs
@@ -66,14 +66,14 @@ struct OAuthClaims {
 }
 
 /// OAuth2 token request.
-#[derive(Debug, Serialize)]
+#[derive(Serialize)]
 struct TokenRequest {
     grant_type: String,
     assertion: Zeroizing<String>,
 }
 
 /// OAuth2 token response.
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
 #[allow(dead_code)]
 struct TokenResponse {
     access_token: Zeroizing<String>,


### PR DESCRIPTION
## Summary

- Store cached APNs JWTs and FCM OAuth2 access tokens in `Zeroizing<String>` with `ZeroizeOnDrop`.
- Keep private APNs/FCM auth-token getter return values zeroizing until request header construction.
- Deserialize FCM OAuth2 response access tokens into `Zeroizing<String>`.
- Update `rustls-webpki` in `Cargo.lock` from `0.103.10` to `0.103.13` so the audit gate is clean.

Closes marmot-protocol/marmot-security#56.

## Why

The cached push-provider bearer credentials were plain heap-backed strings. When a cached token was refreshed or dropped, the old allocation could remain recoverable until reused by the allocator. These credentials are short-lived, but still usable bearer tokens during their provider validity window.

## Validation

- `cargo test push::apns`
- `cargo test push::fcm`
- `just ci`

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/transponder/pull/43">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved token handling for Apple and Firebase push services to enhance memory safety and protect sensitive in-memory credentials via secure zeroization.
* **Tests**
  * Updated and added tests to validate secure token handling while preserving request/response behavior.
* **Compatibility**
  * No changes to user-facing APIs or runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
