### PR TITLE
[codex] Ignore local planning artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 /target
 /trees/*
 !/trees/.gitkeep
+/plans/
+/reviews/
 
 # Config files (may contain secrets)
 config/local.toml


### PR DESCRIPTION
## Summary

- Ignore root-level `plans/` and `reviews/` directories.
- Keep local planning and review notes out of git status by default.

## Validation

- Ran `git check-ignore -v plans reviews plans/example.md reviews/example.md`.
- Confirmed the PR contains only the `.gitignore` update.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/transponder/pull/45">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration to exclude additional directories from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->