### PR TITLE
Stop retaining notification sender metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Security
 
 - Changed `generate-keys` to hide the private key by default, write secrets with `0600` file permissions via `--output`, and require `--show-private-key` for explicit display, addressing marmot-security#77 ([#51](https://github.com/marmot-protocol/transponder/pull/51)).
+- Removed the unwrapped notification sender public key from event processing state and trace logs, addressing marmot-security#79.
 - Store the server secp256k1 secret key in zeroizing memory and erase temporary `SecretKey` values used during token decryption, addressing the long-term key retention risk reported in marmot-security#24 ([#36](https://github.com/marmot-protocol/transponder/pull/36)).
 - Changed the default health server bind address to localhost and documented internal-only exposure for the unauthenticated health, readiness, and metrics endpoints ([#39](https://github.com/marmot-protocol/transponder/pull/39)).
 - Redacted FCM service account private keys from debug output and zeroized the service account JSON buffer after loading [#35](https://github.com/marmot-protocol/transponder/pull/35)

--- a/src/crypto/nip59.rs
+++ b/src/crypto/nip59.rs
@@ -88,6 +88,7 @@ impl Nip59Handler {
 }
 
 /// Unwrapped notification request data.
+#[derive(Debug, Clone)]
 #[allow(dead_code)]
 pub struct UnwrappedNotification {
     /// Content containing encrypted tokens as a single base64 blob.
@@ -208,6 +209,32 @@ mod tests {
             tags: valid_tags(),
             created_at: Timestamp::now(),
         }
+    }
+
+    fn contains_hex_run(input: &str, target_len: usize) -> bool {
+        let mut run_len = 0;
+
+        for ch in input.chars() {
+            if ch.is_ascii_hexdigit() {
+                run_len += 1;
+                if run_len >= target_len {
+                    return true;
+                }
+            } else {
+                run_len = 0;
+            }
+        }
+
+        false
+    }
+
+    #[test]
+    fn test_unwrapped_notification_debug_excludes_sender_metadata() {
+        let notification = notification(BASE64_STANDARD.encode(vec![0x01; ENCRYPTED_TOKEN_SIZE]));
+        let debug = format!("{notification:?}");
+
+        assert!(!debug.contains("sender"));
+        assert!(!contains_hex_run(&debug, 64));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- remove the sender public key from `UnwrappedNotification` so event processing does not retain it
- drop the `sender` field from the trace-level unwrap log
- add regression coverage for sender-free debug output and malformed notification tags
- document the security fix in the changelog

Fixes marmot-protocol/marmot-security#79.

## Verification

- `just ci`
  - fmt passed
  - clippy passed with `-D warnings`
  - tests passed: 295 passed
  - audit completed with the repo's two allowed `rand` warnings
- `cargo llvm-cov --all-features --json --output-path coverage-local.json`
  - line coverage: 92.10648148148148%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Removed sender public key from event processing state and trace logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->