### PR TITLE
Drop retained sender identity from notifications

### DIFF
--- a/src/crypto/nip59.rs
+++ b/src/crypto/nip59.rs
@@ -77,13 +77,9 @@ impl Nip59Handler {
             )));
         }
 
-        // Extract the sender's public key
-        let sender_pubkey = unwrapped.sender;
-
         let rumor = unwrapped.rumor;
 
         Ok(UnwrappedNotification {
-            sender_pubkey,
             content: rumor.content,
             tags: rumor.tags,
             created_at: rumor.created_at,
@@ -92,11 +88,8 @@ impl Nip59Handler {
 }
 
 /// Unwrapped notification request data.
-#[derive(Debug, Clone)]
 #[allow(dead_code)]
 pub struct UnwrappedNotification {
-    /// Public key of the sender.
-    pub sender_pubkey: PublicKey,
     /// Content containing encrypted tokens as a single base64 blob.
     pub content: String,
     /// Rumor tags used for versioning and content encoding validation.
@@ -211,7 +204,6 @@ mod tests {
 
     fn notification(content: String) -> UnwrappedNotification {
         UnwrappedNotification {
-            sender_pubkey: Keys::generate().public_key(),
             content,
             tags: valid_tags(),
             created_at: Timestamp::now(),
@@ -243,7 +235,6 @@ mod tests {
     #[test]
     fn test_parse_rejects_missing_version_tag() {
         let notification = UnwrappedNotification {
-            sender_pubkey: Keys::generate().public_key(),
             content: BASE64_STANDARD.encode(vec![0x01; ENCRYPTED_TOKEN_SIZE]),
             tags: Tags::parse([[TAG_ENCODING, ENCODING_BASE64]]).unwrap(),
             created_at: Timestamp::now(),
@@ -256,6 +247,27 @@ mod tests {
                 .unwrap_err()
                 .to_string()
                 .contains("Missing required v tag")
+        );
+    }
+
+    #[test]
+    fn test_parse_rejects_missing_version_tag_value() {
+        let notification = UnwrappedNotification {
+            content: BASE64_STANDARD.encode(vec![0x01; ENCRYPTED_TOKEN_SIZE]),
+            tags: Tags::from_list(vec![
+                Tag::parse([TAG_VERSION]).unwrap(),
+                Tag::parse([TAG_ENCODING, ENCODING_BASE64]).unwrap(),
+            ]),
+            created_at: Timestamp::now(),
+        };
+
+        let result = notification.parse_tokens();
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Missing value for required v tag")
         );
     }
 
@@ -364,7 +376,6 @@ mod tests {
     #[test]
     fn test_parse_rejects_invalid_encoding_tag() {
         let notification = UnwrappedNotification {
-            sender_pubkey: Keys::generate().public_key(),
             content: BASE64_STANDARD.encode(vec![0x11; ENCRYPTED_TOKEN_SIZE]),
             tags: Tags::parse([[TAG_VERSION, VERSION_MIP05_V1], [TAG_ENCODING, "hex"]]).unwrap(),
             created_at: Timestamp::now(),

--- a/src/nostr/events.rs
+++ b/src/nostr/events.rs
@@ -305,10 +305,7 @@ impl EventProcessor {
             }
         };
 
-        trace!(
-            sender = %notification.sender_pubkey,
-            "Unwrapped notification request"
-        );
+        trace!("Unwrapped notification request");
 
         // Parse the encrypted tokens from the content
         let parse_started_at = StageTimer::start();

--- a/src/test_vectors.rs
+++ b/src/test_vectors.rs
@@ -493,9 +493,6 @@ mod tests {
         let handler = Nip59Handler::new(server_keys.clone());
         let unwrapped = handler.unwrap(&gift_wrap).await.unwrap();
 
-        // Verify sender
-        assert_eq!(unwrapped.sender_pubkey, sender_keys.public_key());
-
         // Verify content is parseable
         let tokens = unwrapped.parse_tokens().unwrap();
         assert_eq!(tokens.len(), 1);


### PR DESCRIPTION
## Summary
- remove `sender_pubkey` from `UnwrappedNotification` so decrypted sender identity is not retained after NIP-59 unwrap
- remove the sender-bearing trace field from event processing
- update notification parsing and gift-wrap roundtrip tests to avoid sender identity assertions

Fixes marmot-protocol/marmot-security#83

## Verification
- `cargo test crypto::nip59`
- `cargo test test_gift_wrap_unwrap_roundtrip`
- `just ci`

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/transponder/pull/49">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Removed sender public key from unwrapped gift-wrapped notifications.

* **Tests**
  * Updated gift-wrap notification tests to reflect changes in unwrapped notification structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->