### PR TITLE
Harden rate limiter cache capacity handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ shutdown_timeout_secs = 10
 # max_dedup_cache_size = 100000
 
 # Rate limiting to prevent spam and replay attacks
-# max_rate_limit_cache_size = 100000           # LRU cache size per limiter
+# max_rate_limit_cache_size = 100000           # Tracked keys per limiter
 # max_tokens_per_event = 100                   # Per notification event
 # encrypted_token_rate_limit_per_minute = 240  # Per encrypted token (replay protection)
 # encrypted_token_rate_limit_per_hour = 5000
@@ -366,9 +366,9 @@ Transponder exposes Prometheus metrics at `/metrics` on the health server port (
 |--------|------|--------|-------------|
 | `transponder_tokens_rate_limited_total` | Counter | `type`, `reason` | Tokens skipped due to rate limiting |
 | `transponder_rate_limit_cache_size` | Gauge | `type` | Current rate limit cache size |
-| `transponder_rate_limit_evictions_total` | Counter | `type` | Rate limit cache evictions |
+| `transponder_rate_limit_evictions_total` | Counter | `type` | Stale rate limit entries removed during cleanup |
 
-Label values: `type` = `encrypted_token` or `device_token`; `reason` = `minute` or `hour`
+Label values: `type` = `encrypted_token` or `device_token`; `reason` = `minute`, `hour`, or `capacity`
 
 `outcome` values vary by metric group:
 - Event processing: `processed`, `duplicate`, `failed`

--- a/config/default.toml
+++ b/config/default.toml
@@ -20,7 +20,7 @@ shutdown_timeout_secs = 10
 # max_dedup_cache_size = 100000
 
 # Maximum size for rate limit caches (encrypted_token and device_token).
-# Each cache uses LRU eviction to prevent unbounded memory growth.
+# Unknown keys are rate limited at capacity until cleanup removes stale entries.
 # Default: 100000 entries per cache
 # max_rate_limit_cache_size = 100000
 

--- a/config/production.toml.example
+++ b/config/production.toml.example
@@ -12,6 +12,7 @@ shutdown_timeout_secs = 20
 # These defaults are reasonable for small to medium deployments.
 # Reduce them if you are running on a very small VM.
 # max_dedup_cache_size = 100000
+# Unknown rate-limit keys are rejected at capacity until stale entries are cleaned up.
 # max_rate_limit_cache_size = 100000
 # max_tokens_per_event = 100
 # encrypted_token_rate_limit_per_minute = 240

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -23,6 +23,7 @@ Why these numbers make sense today:
 - the dispatcher allows up to 100 concurrent outbound push requests
 - the push queue is bounded at 10,000 pending notifications
 - the event deduplication and rate-limit caches default to 100,000 entries each
+- new rate-limit keys are rejected at capacity, so size these caches with headroom for legitimate unique devices and adversarial noise
 - Tor adds noticeable memory and connection-management overhead, which is why the default build leaves it disabled
 
 If you need to run on a smaller VM, lower the cache sizes in `config/production.toml`.

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -139,6 +139,7 @@ impl<K: Hash + Eq + Clone + Send + Sync + 'static> RateLimiter<K> {
     /// - `Allowed` if the request is within limits (counters are incremented)
     /// - `ExceededMinuteLimit` if per-minute limit is reached
     /// - `ExceededHourLimit` if per-hour limit is reached
+    /// - `ExceededCapacityLimit` if the cache is full and the key is unknown
     pub async fn check_and_increment(&self, key: &K) -> RateLimitResult {
         let now = Instant::now();
         let mut entries = self.entries.write().await;
@@ -219,6 +220,7 @@ impl<K: Hash + Eq + Clone + Send + Sync + 'static> RateLimiter<K> {
         // Collect stale keys (hour window expired)
         let stale: Vec<K> = entries
             .iter()
+            .rev()
             .take(CLEANUP_BATCH_SIZE)
             .filter(|(_, entry)| now.duration_since(entry.hour_window_start) >= hour)
             .map(|(k, _)| k.clone())
@@ -407,6 +409,29 @@ mod tests {
         let stats = limiter.cleanup().await;
         assert_eq!(stats.evicted, 2);
         assert_eq!(stats.remaining, 0);
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_scans_stale_lru_entries_first() {
+        tokio::time::pause();
+
+        let limiter: RateLimiter<u64> = RateLimiter::new(RateLimitConfig {
+            max_per_minute: 10,
+            max_per_hour: 100,
+            max_entries: CLEANUP_BATCH_SIZE + 1,
+        });
+
+        for key in 0..=CLEANUP_BATCH_SIZE as u64 {
+            assert!(limiter.check_and_increment(&key).await.is_allowed());
+        }
+
+        tokio::time::advance(Duration::from_secs(3601)).await;
+
+        assert!(limiter.check_and_increment(&0u64).await.is_allowed());
+
+        let stats = limiter.cleanup().await;
+        assert_eq!(stats.evicted, CLEANUP_BATCH_SIZE);
+        assert_eq!(stats.remaining, 1);
     }
 
     #[tokio::test]

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -32,6 +32,8 @@ pub enum RateLimitResult {
     ExceededMinuteLimit,
     /// Exceeded per-hour limit.
     ExceededHourLimit,
+    /// Cache is full and cannot admit a new key safely.
+    ExceededCapacityLimit,
 }
 
 impl RateLimitResult {
@@ -48,6 +50,7 @@ impl RateLimitResult {
             Self::Allowed => None,
             Self::ExceededMinuteLimit => Some("minute"),
             Self::ExceededHourLimit => Some("hour"),
+            Self::ExceededCapacityLimit => Some("capacity"),
         }
     }
 }
@@ -88,7 +91,11 @@ pub struct RateLimitConfig {
     pub max_per_minute: u32,
     /// Maximum requests per hour.
     pub max_per_hour: u32,
-    /// Maximum entries in the cache (LRU eviction).
+    /// Maximum entries in the cache.
+    ///
+    /// Unknown keys are rate limited once this capacity is reached. Existing
+    /// entries remain tracked until their windows expire and cleanup removes
+    /// them.
     pub max_entries: usize,
 }
 
@@ -104,8 +111,9 @@ impl Default for RateLimitConfig {
 
 /// Fixed-window rate limiter with per-minute and per-hour limits.
 ///
-/// Uses an LRU cache to bound memory usage. When the cache is full,
-/// the least recently used entries are evicted.
+/// Uses a bounded cache to limit memory usage. When the cache is full,
+/// unknown keys are rejected until cleanup removes stale entries. This
+/// preserves existing counters under adversarial cache pressure.
 pub struct RateLimiter<K: Hash + Eq + Clone + Send + Sync + 'static> {
     entries: RwLock<LruCache<K, RateLimitEntry>>,
     max_per_minute: u32,
@@ -135,10 +143,14 @@ impl<K: Hash + Eq + Clone + Send + Sync + 'static> RateLimiter<K> {
         let now = Instant::now();
         let mut entries = self.entries.write().await;
 
-        // Get or create entry (updates LRU position)
+        // Get or create entry (updates access position). Unknown keys are
+        // rejected at capacity so pressure cannot evict existing counters.
         let entry = if let Some(entry) = entries.get_mut(key) {
             entry
         } else {
+            if entries.len() >= entries.cap().get() {
+                return RateLimitResult::ExceededCapacityLimit;
+            }
             entries.put(key.clone(), RateLimitEntry::new(now));
             entries.get_mut(key).expect("just inserted")
         };
@@ -398,7 +410,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_lru_eviction() {
+    async fn test_rejects_new_keys_at_capacity() {
         let limiter: RateLimiter<u64> = RateLimiter::new(RateLimitConfig {
             max_per_minute: 10,
             max_per_hour: 100,
@@ -410,12 +422,41 @@ mod tests {
         limiter.check_and_increment(&3u64).await;
         assert_eq!(limiter.len().await, 3);
 
-        // Adding 4th should evict LRU (key 1)
-        limiter.check_and_increment(&4u64).await;
+        assert_eq!(
+            limiter.check_and_increment(&4u64).await,
+            RateLimitResult::ExceededCapacityLimit
+        );
         assert_eq!(limiter.len().await, 3);
+        assert_eq!(limiter.peek_counts(&1u64).await, Some((1, 1)));
+    }
 
-        // Key 1 should have been evicted
-        assert_eq!(limiter.peek_counts(&1u64).await, None);
+    #[tokio::test]
+    async fn test_cache_pressure_does_not_reset_limited_key() {
+        let limiter: RateLimiter<u64> = RateLimiter::new(RateLimitConfig {
+            max_per_minute: 1,
+            max_per_hour: 100,
+            max_entries: 2,
+        });
+
+        assert_eq!(
+            limiter.check_and_increment(&1u64).await,
+            RateLimitResult::Allowed
+        );
+        assert_eq!(
+            limiter.check_and_increment(&1u64).await,
+            RateLimitResult::ExceededMinuteLimit
+        );
+
+        assert_eq!(
+            limiter.check_and_increment(&2u64).await,
+            RateLimitResult::Allowed
+        );
+        assert!(!limiter.check_and_increment(&3u64).await.is_allowed());
+
+        assert_eq!(
+            limiter.check_and_increment(&1u64).await,
+            RateLimitResult::ExceededMinuteLimit
+        );
     }
 
     #[tokio::test]
@@ -423,6 +464,7 @@ mod tests {
         assert!(RateLimitResult::Allowed.is_allowed());
         assert!(!RateLimitResult::ExceededMinuteLimit.is_allowed());
         assert!(!RateLimitResult::ExceededHourLimit.is_allowed());
+        assert!(!RateLimitResult::ExceededCapacityLimit.is_allowed());
 
         assert_eq!(RateLimitResult::Allowed.limit_reason(), None);
         assert_eq!(
@@ -432,6 +474,10 @@ mod tests {
         assert_eq!(
             RateLimitResult::ExceededHourLimit.limit_reason(),
             Some("hour")
+        );
+        assert_eq!(
+            RateLimitResult::ExceededCapacityLimit.limit_reason(),
+            Some("capacity")
         );
     }
 


### PR DESCRIPTION
## Summary
- reject unknown rate-limit keys when the bounded cache is at capacity
- preserve existing per-key counters until their normal cleanup window expires
- document the capacity behavior and `capacity` rate-limit metric reason

## Verification
- confirmed the new regression fails before the fix
- `cargo test rate_limiter::tests:: -- --nocapture`
- `just ci`

Addresses marmot-protocol/marmot-security#72.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/transponder/pull/50">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
- Added new Prometheus metric to monitor rate-limit cache evictions and capacity exceeded conditions

**Bug Fixes**
- Rate limiter now rejects new rate-limit keys when cache reaches capacity instead of evicting existing entries

**Documentation**
- Updated configuration reference with clarified rate-limiting cache behavior
- Updated metrics documentation with new measurement types and reason labels
- Added deployment sizing guidelines for rate-limit caches

<!-- end of auto-generated comment: release notes by coderabbit.ai -->