### PR TITLE
Require opt-in for generate-keys secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Security
 
+- Changed `generate-keys` to hide the private key by default, write secrets with `0600` file permissions via `--output`, and require `--show-private-key` for explicit display, addressing marmot-security#77 ([#51](https://github.com/marmot-protocol/transponder/pull/51)).
 - Store the server secp256k1 secret key in zeroizing memory and erase temporary `SecretKey` values used during token decryption, addressing the long-term key retention risk reported in marmot-security#24 ([#36](https://github.com/marmot-protocol/transponder/pull/36)).
 - Changed the default health server bind address to localhost and documented internal-only exposure for the unauthenticated health, readiness, and metrics endpoints ([#39](https://github.com/marmot-protocol/transponder/pull/39)).
 - Redacted FCM service account private keys from debug output and zeroized the service account JSON buffer after loading [#35](https://github.com/marmot-protocol/transponder/pull/35)

--- a/README.md
+++ b/README.md
@@ -50,9 +50,12 @@ Transponder uses TOML configuration files with environment variable overrides. T
 ```toml
 [server]
 # Server's Nostr private key in hex format (64 hex characters)
-# REQUIRED - Generate with: transponder generate-keys
-# SECURITY: Store in environment variable for production
+# Prefer private_key_file for production secret handling.
 private_key = ""
+
+# Alternative: path to a file containing the private key.
+# Generate with: transponder generate-keys --output /path/to/server.key
+# private_key_file = "/run/secrets/transponder_private_key"
 
 # Graceful shutdown timeout in seconds
 shutdown_timeout_secs = 10
@@ -138,11 +141,14 @@ format = "json"
 
 Override any config value using environment variables with the pattern `TRANSPONDER_<SECTION>_<KEY>`.
 The first underscore after `TRANSPONDER` separates the section from the key, so
-`TRANSPONDER_SERVER_PRIVATE_KEY` maps to `server.private_key`:
+`TRANSPONDER_SERVER_PRIVATE_KEY_FILE` maps to `server.private_key_file`:
 
 ```bash
-# Required: Server private key
-export TRANSPONDER_SERVER_PRIVATE_KEY="your-64-char-hex-private-key"
+# Recommended: mounted server private key file
+export TRANSPONDER_SERVER_PRIVATE_KEY_FILE="/run/secrets/transponder_private_key"
+
+# Also supported, but easier to capture in shell history or logs:
+# export TRANSPONDER_SERVER_PRIVATE_KEY="your-64-char-hex-private-key"
 
 # Push services
 export TRANSPONDER_APNS_ENABLED=true
@@ -165,17 +171,18 @@ export TRANSPONDER_LOGGING_FORMAT="pretty"
 
 ### Generating a Server Key Pair
 
-The server requires a secp256k1 private key for Nostr identity and token decryption. Use the built-in command to generate a new key pair:
+The server requires a secp256k1 private key for Nostr identity and token decryption. Use the built-in command to generate a new key pair and write the secret directly to a restricted file:
 
 ```bash
 # Using transponder (recommended)
-./target/release/transponder generate-keys
+./target/release/transponder generate-keys --output secrets/server_private_key
 ```
 
 This outputs:
-- **Private key (hex)**: 64-character hex string for your config
 - **Public key (hex)**: For clients that need the raw public key
 - **Public key (npub)**: Bech32-encoded format, easier to share
+
+The private key is not printed by default. Use `--show-private-key` only in a secure, non-logged terminal session.
 
 Alternatively, you can use [nak](https://github.com/fiatjaf/nak), a general-purpose Nostr CLI tool:
 
@@ -264,8 +271,7 @@ cp deploy/production.env.example deploy/production.env
 mkdir -p credentials secrets
 chmod 700 credentials secrets
 
-printf '%s\n' 'YOUR_64_CHAR_HEX_PRIVATE_KEY' > secrets/server_private_key
-chmod 600 secrets/server_private_key
+./target/release/transponder generate-keys --output secrets/server_private_key
 
 docker login dhi.io
 docker build -t transponder:local .
@@ -457,7 +463,7 @@ Nostr Relays (ClearNet/Tor)
 ### Credential Management
 
 - **Never commit credentials** to version control
-- **Use environment variables** for sensitive values in production
+- **Use secret files or a secrets manager** for sensitive values in production
 - **Prefer mounted secret files** for the server private key in Docker/Compose
 - **Restrict file permissions** on config files: `chmod 600 config/local.toml`
 - **Mount credentials read-only** in Docker: `-v /path:/credentials:ro`

--- a/config/default.toml
+++ b/config/default.toml
@@ -3,11 +3,12 @@
 
 [server]
 # Server's Nostr private key (hex format)
-# REQUIRED: Set via TRANSPONDER_SERVER_PRIVATE_KEY environment variable
+# Prefer private_key_file for production secret handling.
 private_key = ""
 
 # Alternative: path to a file containing the private key.
 # Useful with Docker secrets or other mounted secret files.
+# Generate with: transponder generate-keys --output /run/secrets/transponder_private_key
 # private_key_file = "/run/secrets/transponder_private_key"
 
 # Graceful shutdown timeout in seconds

--- a/config/production.toml.example
+++ b/config/production.toml.example
@@ -4,6 +4,7 @@
 [server]
 # Recommended for production: supply the key via
 # TRANSPONDER_SERVER_PRIVATE_KEY_FILE=/run/secrets/transponder_private_key
+# Generate with: transponder generate-keys --output /run/secrets/transponder_private_key
 private_key = ""
 # private_key_file = "/run/secrets/transponder_private_key"
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -81,8 +81,7 @@ chmod 700 credentials secrets
 2. Create the server private key secret file:
 
 ```bash
-printf '%s\n' 'YOUR_64_CHAR_HEX_PRIVATE_KEY' > secrets/server_private_key
-chmod 600 secrets/server_private_key
+./target/release/transponder generate-keys --output secrets/server_private_key
 ```
 
 3. Place push credentials in `credentials/`:

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,9 +5,13 @@
 //! decrypts notification requests, and dispatches silent push notifications
 //! to APNs and FCM.
 
+use std::io::Write;
 use std::sync::Arc;
 use std::time::Duration;
-use std::{fs, path::Path};
+use std::{
+    fs::{self, File, OpenOptions},
+    path::{Path, PathBuf},
+};
 
 use anyhow::{Context, Result};
 use clap::Parser;
@@ -56,7 +60,15 @@ struct Args {
 #[derive(clap::Subcommand, Debug)]
 enum Command {
     /// Generate a new Nostr key pair for the server
-    GenerateKeys,
+    GenerateKeys {
+        /// Write the generated private key to this file with 0600 permissions
+        #[arg(short, long, value_name = "PATH")]
+        output: Option<PathBuf>,
+
+        /// Print the generated private key to stdout
+        #[arg(long)]
+        show_private_key: bool,
+    },
     /// Probe a running Transponder instance for container health checks
     Healthcheck {
         /// Health endpoint URL to probe
@@ -130,7 +142,10 @@ async fn main() -> Result<()> {
     // Handle subcommands
     if let Some(command) = args.command {
         return match command {
-            Command::GenerateKeys => generate_keys(),
+            Command::GenerateKeys {
+                output,
+                show_private_key,
+            } => generate_keys(output.as_deref(), show_private_key),
             Command::Healthcheck { url } => run_healthcheck(&url).await,
         };
     }
@@ -385,24 +400,65 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-/// Generate a new Nostr key pair and print to stdout.
-fn generate_keys() -> Result<()> {
+fn create_private_key_file(path: &Path) -> Result<File> {
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+
+    options
+        .open(path)
+        .with_context(|| format!("Failed to create private key file {}", path.display()))
+}
+
+fn write_private_key_file(path: &Path, secret_hex: &str) -> Result<()> {
+    let mut file = create_private_key_file(path)?;
+    file.write_all(secret_hex.as_bytes())
+        .with_context(|| format!("Failed to write private key file {}", path.display()))?;
+    file.write_all(b"\n")
+        .with_context(|| format!("Failed to write private key file {}", path.display()))?;
+    file.sync_all()
+        .with_context(|| format!("Failed to sync private key file {}", path.display()))
+}
+
+/// Generate a new Nostr key pair.
+fn generate_keys(output: Option<&Path>, show_private_key: bool) -> Result<()> {
     let keys = Keys::generate();
+    let secret_hex = Zeroizing::new(keys.secret_key().to_secret_hex());
+
+    if let Some(path) = output {
+        write_private_key_file(path, secret_hex.as_str())?;
+    }
 
     println!("Generated new Nostr key pair:\n");
-    println!("Private key (hex): {}", keys.secret_key().to_secret_hex());
     println!("Public key (hex):  {}", keys.public_key().to_hex());
     println!("Public key (npub): {}", keys.public_key().to_bech32()?);
     println!();
-    println!("Add the private key to your configuration:");
-    println!("  [server]");
-    println!("  private_key = \"{}\"", keys.secret_key().to_secret_hex());
-    println!();
-    println!("Or set via environment variable:");
-    println!(
-        "  export TRANSPONDER_SERVER_PRIVATE_KEY=\"{}\"",
-        keys.secret_key().to_secret_hex()
-    );
+
+    if show_private_key {
+        eprintln!(
+            "WARNING: The private key below enables decryption of ALL notification tokens. Do not share, log, or commit it."
+        );
+        println!("Private key (hex): {}", secret_hex.as_str());
+        println!();
+    }
+
+    if let Some(path) = output {
+        println!("Secret written to: {}", path.display());
+        println!("Configure the server with:");
+        println!("  [server]");
+        println!("  private_key_file = \"{}\"", path.display());
+    } else if !show_private_key {
+        println!("Secret material was not printed.");
+        println!("Store a fresh secret directly in a restricted file:");
+        println!("  transponder generate-keys --output /path/to/transponder-server.key");
+        println!("Use --show-private-key only in a secure, non-logged terminal.");
+    }
+
     println!();
     println!("Share the public key (hex or npub) with clients so they can");
     println!("encrypt notification tokens for your server.");

--- a/tests/generate_keys.rs
+++ b/tests/generate_keys.rs
@@ -1,0 +1,131 @@
+use std::{fs, process::Command};
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
+fn transponder() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_transponder"))
+}
+
+fn hex_64_tokens(text: &str) -> Vec<&str> {
+    text.split(|ch: char| !ch.is_ascii_hexdigit())
+        .filter(|token| token.len() == 64)
+        .collect()
+}
+
+fn is_hex_64(value: &str) -> bool {
+    value.len() == 64 && value.chars().all(|ch| ch.is_ascii_hexdigit())
+}
+
+#[test]
+fn generate_keys_hides_private_key_by_default() {
+    let output = transponder()
+        .arg("generate-keys")
+        .output()
+        .expect("generate-keys should run");
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be utf-8");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf-8");
+
+    assert!(stderr.is_empty());
+    assert!(stdout.contains("Generated new Nostr key pair"));
+    assert!(stdout.contains("Public key (hex):"));
+    assert!(stdout.contains("Public key (npub):"));
+    assert!(!stdout.contains("Private key"));
+    assert!(!stdout.contains("private_key ="));
+    assert!(!stdout.contains("TRANSPONDER_SERVER_PRIVATE_KEY"));
+    assert_eq!(
+        hex_64_tokens(&stdout).len(),
+        1,
+        "default output should only expose the public hex key"
+    );
+}
+
+#[test]
+fn generate_keys_writes_private_key_to_restricted_output_file() {
+    let dir = tempfile::tempdir().expect("temp dir should be created");
+    let key_path = dir.path().join("server.key");
+
+    let output = transponder()
+        .args(["generate-keys", "--output"])
+        .arg(&key_path)
+        .output()
+        .expect("generate-keys should run");
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be utf-8");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf-8");
+    let secret = fs::read_to_string(&key_path).expect("private key file should be readable");
+    let secret = secret.trim();
+
+    assert!(stderr.is_empty());
+    assert!(is_hex_64(secret));
+    assert!(!stdout.contains(secret));
+    assert!(!stdout.contains("private_key ="));
+    assert!(!stdout.contains("TRANSPONDER_SERVER_PRIVATE_KEY"));
+    assert!(stdout.contains("private_key_file ="));
+    assert_eq!(
+        hex_64_tokens(&stdout).len(),
+        1,
+        "file output should only expose the public hex key on stdout"
+    );
+
+    #[cfg(unix)]
+    {
+        let mode = fs::metadata(&key_path)
+            .expect("private key file metadata should be readable")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600);
+    }
+}
+
+#[test]
+fn generate_keys_requires_explicit_opt_in_to_print_private_key() {
+    let output = transponder()
+        .args(["generate-keys", "--show-private-key"])
+        .output()
+        .expect("generate-keys should run");
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be utf-8");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf-8");
+
+    assert!(stderr.contains("WARNING"));
+    assert!(stderr.contains("ALL notification tokens"));
+    assert!(stdout.contains("Private key (hex):"));
+    assert!(!stdout.contains("private_key ="));
+    assert!(!stdout.contains("TRANSPONDER_SERVER_PRIVATE_KEY"));
+    assert_eq!(
+        hex_64_tokens(&stdout).len(),
+        2,
+        "explicit display should print one public key and one private key"
+    );
+}
+
+#[test]
+fn generate_keys_refuses_to_overwrite_existing_private_key_file() {
+    let dir = tempfile::tempdir().expect("temp dir should be created");
+    let key_path = dir.path().join("server.key");
+    fs::write(&key_path, "already here\n").expect("existing file should be writable");
+
+    let output = transponder()
+        .args(["generate-keys", "--output"])
+        .arg(&key_path)
+        .output()
+        .expect("generate-keys should run");
+
+    assert!(!output.status.success());
+    assert_eq!(
+        fs::read_to_string(&key_path).expect("existing file should be readable"),
+        "already here\n"
+    );
+
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf-8");
+    assert!(stderr.contains("Failed to create private key file"));
+}


### PR DESCRIPTION
## Summary
- hide generated server private keys from default generate-keys stdout
- add --output for 0600 private-key files and --show-private-key for explicit display with a warning
- update docs to prefer mounted private-key files over env-var copy/paste

## Security
Addresses marmot-protocol/marmot-security#77.

## Testing
- just ci

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/transponder/pull/51">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->