### PR TITLE
Reject unencrypted clearnet relay URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ clearnet = [
     "wss://nos.lol"
 ]
 
+# Reject ws:// ClearNet relays by default. Enable only for local development
+# with loopback/mock relays that cannot serve TLS.
+allow_unencrypted_clearnet_relays = false
+
 # Tor/onion relays (optional)
 # Requires a build with `--features tor` and a host that can support Tor traffic
 onion = []
@@ -473,6 +477,7 @@ The server private key is critical:
 ### Network Security
 
 - **TLS everywhere**: All connections to relays, APNs, and FCM use TLS
+- **Relay TLS enforcement**: ClearNet relay URLs must use `wss://`; `ws://` requires an explicit local-development opt-in
 - **Health endpoint exposure**: Keep the default localhost bind (`127.0.0.1:8080`) unless an internal proxy, VPN, or load balancer needs it
 - **Firewall rules**: Only expose port 8080 if health checks are needed externally
 - **Prefer localhost binds** in Compose and publish through a reverse proxy only when needed

--- a/config/default.toml
+++ b/config/default.toml
@@ -53,6 +53,10 @@ clearnet = [
     "wss://nos.lol"
 ]
 
+# Reject ws:// ClearNet relays by default. Enable only for local development
+# with loopback/mock relays that cannot serve TLS.
+allow_unencrypted_clearnet_relays = false
+
 # Tor/onion relays (optional)
 # Requires a binary built with: cargo build --features tor
 onion = []

--- a/config/production.toml.example
+++ b/config/production.toml.example
@@ -25,6 +25,9 @@ clearnet = [
     "wss://nos.lol",
 ]
 
+# Keep false in production. ClearNet relay URLs must use wss://.
+allow_unencrypted_clearnet_relays = false
+
 # Add onion relays only if you intend to run a Tor-enabled build and can spare
 # additional memory/CPU for Tor circuits.
 # Build with: docker build --build-arg CARGO_FEATURES='--features tor' -t transponder:local .

--- a/src/config.rs
+++ b/src/config.rs
@@ -182,6 +182,13 @@ pub struct RelayConfig {
     #[serde(default)]
     pub clearnet: Vec<String>,
 
+    /// Whether unencrypted ws:// ClearNet relay URLs are allowed.
+    ///
+    /// This should remain false in production. It exists for local development
+    /// and tests that use loopback mock relays without TLS.
+    #[serde(default)]
+    pub allow_unencrypted_clearnet_relays: bool,
+
     /// Tor/onion relay URLs.
     #[serde(default)]
     pub onion: Vec<String>,
@@ -348,6 +355,7 @@ fn base_config_builder() -> Result<ConfigBuilder<DefaultState>> {
             DEFAULT_RATE_LIMIT_PER_HOUR as i64,
         )?
         .set_default("relays.clearnet", Vec::<String>::new())?
+        .set_default("relays.allow_unencrypted_clearnet_relays", false)?
         .set_default("relays.onion", Vec::<String>::new())?
         .set_default("relays.reconnect_interval_secs", 5)?
         .set_default("relays.max_reconnect_attempts", 10)?
@@ -452,6 +460,7 @@ fn is_supported_config_key(config_key: &str) -> bool {
                 | "server.encrypted_token_rate_limit_per_hour"
                 | "server.device_token_rate_limit_per_minute"
                 | "server.device_token_rate_limit_per_hour"
+                | "relays.allow_unencrypted_clearnet_relays"
                 | "relays.reconnect_interval_secs"
                 | "relays.max_reconnect_attempts"
                 | "relays.connection_timeout_secs"
@@ -645,6 +654,7 @@ mod tests {
         assert_eq!(config.server.private_key.as_str(), "abc123");
         assert_eq!(config.server.shutdown_timeout_secs, 10); // default
         assert_eq!(config.relays.clearnet.len(), 1);
+        assert!(!config.relays.allow_unencrypted_clearnet_relays);
         assert!(!config.apns.enabled);
         assert!(!config.fcm.enabled);
         assert!(config.metrics.enabled);
@@ -747,6 +757,7 @@ mod tests {
         assert_eq!(config.server.shutdown_timeout_secs, 30);
         assert_eq!(config.relays.clearnet.len(), 2);
         assert_eq!(config.relays.onion.len(), 1);
+        assert!(!config.relays.allow_unencrypted_clearnet_relays);
         assert_eq!(config.relays.reconnect_interval_secs, 10);
         assert_eq!(config.relays.max_reconnect_attempts, 5);
         assert!(config.apns.enabled);
@@ -776,6 +787,7 @@ mod tests {
         assert_eq!(config.server.shutdown_timeout_secs, 10);
         assert!(config.relays.clearnet.is_empty());
         assert!(config.relays.onion.is_empty());
+        assert!(!config.relays.allow_unencrypted_clearnet_relays);
         assert_eq!(config.relays.reconnect_interval_secs, 5);
         assert_eq!(config.relays.max_reconnect_attempts, 10);
         assert_eq!(config.relays.connection_timeout_secs, 30);
@@ -806,6 +818,7 @@ mod tests {
         assert_eq!(config.server.shutdown_timeout_secs, 10);
         assert!(config.relays.clearnet.is_empty());
         assert!(config.relays.onion.is_empty());
+        assert!(!config.relays.allow_unencrypted_clearnet_relays);
         assert_eq!(config.relays.reconnect_interval_secs, 5);
         assert_eq!(config.relays.max_reconnect_attempts, 10);
         assert_eq!(config.relays.connection_timeout_secs, 30);
@@ -825,6 +838,10 @@ mod tests {
             ("TRANSPONDER_SERVER_SHUTDOWN_TIMEOUT_SECS", "30"),
             ("TRANSPONDER_SERVER_MAX_DEDUP_CACHE_SIZE", "50000"),
             ("TRANSPONDER_SERVER_MAX_TOKENS_PER_EVENT", "25"),
+            (
+                "TRANSPONDER_RELAYS_ALLOW_UNENCRYPTED_CLEARNET_RELAYS",
+                "true",
+            ),
             ("TRANSPONDER_APNS_KEY_ID", "KEY123"),
             ("TRANSPONDER_HEALTH_BIND_ADDRESS", "127.0.0.1:9090"),
         ])
@@ -834,6 +851,7 @@ mod tests {
         assert_eq!(config.server.shutdown_timeout_secs, 30);
         assert_eq!(config.server.max_dedup_cache_size, 50_000);
         assert_eq!(config.server.max_tokens_per_event, 25);
+        assert!(config.relays.allow_unencrypted_clearnet_relays);
         assert_eq!(config.apns.key_id, "KEY123");
         assert_eq!(config.health.bind_address, "127.0.0.1:9090");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -703,6 +703,7 @@ mod tests {
     fn validate_startup_config_rejects_missing_private_key() {
         let relays = config::RelayConfig {
             clearnet: vec!["wss://relay.example.com".to_string()],
+            allow_unencrypted_clearnet_relays: false,
             onion: Vec::new(),
             reconnect_interval_secs: 5,
             max_reconnect_attempts: 10,
@@ -718,6 +719,7 @@ mod tests {
     fn validate_startup_config_rejects_missing_relays() {
         let relays = config::RelayConfig {
             clearnet: Vec::new(),
+            allow_unencrypted_clearnet_relays: false,
             onion: Vec::new(),
             reconnect_interval_secs: 5,
             max_reconnect_attempts: 10,
@@ -734,6 +736,7 @@ mod tests {
     fn validate_startup_config_rejects_onion_relays_without_tor_feature() {
         let relays = config::RelayConfig {
             clearnet: vec!["wss://relay.example.com".to_string()],
+            allow_unencrypted_clearnet_relays: false,
             onion: vec!["wss://example.onion".to_string()],
             reconnect_interval_secs: 5,
             max_reconnect_attempts: 10,
@@ -750,6 +753,7 @@ mod tests {
     fn validate_startup_config_accepts_onion_only_relays() {
         let relays = config::RelayConfig {
             clearnet: Vec::new(),
+            allow_unencrypted_clearnet_relays: false,
             onion: vec!["wss://example.onion".to_string()],
             reconnect_interval_secs: 5,
             max_reconnect_attempts: 10,

--- a/src/nostr/client.rs
+++ b/src/nostr/client.rs
@@ -334,6 +334,30 @@ fn inbox_relay_tags(event: &Event) -> BTreeSet<String> {
 }
 
 fn validate_relay_config(config: &RelayConfig) -> Result<()> {
+    for url in &config.clearnet {
+        if clearnet_relay_uses_tls(url) {
+            continue;
+        }
+
+        if clearnet_relay_uses_plaintext_ws(url) {
+            if config.allow_unencrypted_clearnet_relays {
+                warn!(
+                    relay = %url,
+                    "Unencrypted ClearNet relay URL explicitly allowed; use only for local development"
+                );
+                continue;
+            }
+
+            return Err(Error::Nostr(format!(
+                "ClearNet relay '{url}' must use wss://; set relays.allow_unencrypted_clearnet_relays=true only for local development"
+            )));
+        }
+
+        return Err(Error::Nostr(format!(
+            "ClearNet relay '{url}' must use wss://"
+        )));
+    }
+
     if !TOR_FEATURE_ENABLED && !config.onion.is_empty() {
         return Err(Error::Nostr(
             "Onion relays are configured, but this build does not include Tor support. Rebuild with `--features tor`.".to_string(),
@@ -341,6 +365,18 @@ fn validate_relay_config(config: &RelayConfig) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn clearnet_relay_uses_tls(url: &str) -> bool {
+    clearnet_relay_scheme(url).is_some_and(|scheme| scheme.eq_ignore_ascii_case("wss"))
+}
+
+fn clearnet_relay_uses_plaintext_ws(url: &str) -> bool {
+    clearnet_relay_scheme(url).is_some_and(|scheme| scheme.eq_ignore_ascii_case("ws"))
+}
+
+fn clearnet_relay_scheme(url: &str) -> Option<&str> {
+    url.split_once("://").map(|(scheme, _)| scheme)
 }
 
 #[cfg(test)]
@@ -382,11 +418,57 @@ mod tests {
     fn test_relay_config(clearnet: Vec<String>) -> RelayConfig {
         RelayConfig {
             clearnet,
+            allow_unencrypted_clearnet_relays: true,
             onion: vec![],
             reconnect_interval_secs: 5,
             max_reconnect_attempts: 10,
             connection_timeout_secs: 5, // Short timeout for tests
         }
+    }
+
+    #[tokio::test]
+    async fn test_relay_client_rejects_unencrypted_clearnet_relays() {
+        let keys = Keys::generate();
+        let config = RelayConfig {
+            clearnet: vec!["ws://relay.example.com".to_string()],
+            allow_unencrypted_clearnet_relays: false,
+            onion: vec![],
+            reconnect_interval_secs: 5,
+            max_reconnect_attempts: 10,
+            connection_timeout_secs: 5,
+        };
+
+        let result = RelayClient::new(keys, config).await;
+
+        assert!(result.is_err());
+        let err = result
+            .err()
+            .expect("ws:// clearnet relay should be rejected");
+        assert!(err.to_string().contains("must use wss://"));
+    }
+
+    #[tokio::test]
+    async fn test_relay_client_allows_unencrypted_clearnet_relays_when_enabled() {
+        let keys = Keys::generate();
+        let config = test_relay_config(vec!["ws://127.0.0.1:12345".to_string()]);
+
+        let result = RelayClient::new(keys, config).await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_relay_client_rejects_malformed_clearnet_relay_even_when_unencrypted_enabled() {
+        let keys = Keys::generate();
+        let config = test_relay_config(vec!["relay.example.com".to_string()]);
+
+        let result = RelayClient::new(keys, config).await;
+
+        assert!(result.is_err());
+        let err = result
+            .err()
+            .expect("malformed clearnet relay should be rejected");
+        assert!(err.to_string().contains("must use wss://"));
     }
 
     #[tokio::test]
@@ -512,6 +594,7 @@ mod tests {
         let keys = Keys::generate();
         let config = RelayConfig {
             clearnet: vec![],
+            allow_unencrypted_clearnet_relays: false,
             onion: vec![],
             reconnect_interval_secs: 5,
             max_reconnect_attempts: 10,
@@ -641,6 +724,7 @@ mod tests {
         let keys = Keys::generate();
         let config = RelayConfig {
             clearnet: vec![],
+            allow_unencrypted_clearnet_relays: false,
             onion: vec![],
             reconnect_interval_secs: 5,
             max_reconnect_attempts: 10,
@@ -665,6 +749,7 @@ mod tests {
         let keys = Keys::generate();
         let config = RelayConfig {
             clearnet: vec![relay_url.to_string()],
+            allow_unencrypted_clearnet_relays: true,
             onion: vec![],
             reconnect_interval_secs: 5,
             max_reconnect_attempts: 10,
@@ -712,6 +797,7 @@ mod tests {
 
         let config = RelayConfig {
             clearnet: vec![relay_url_string],
+            allow_unencrypted_clearnet_relays: true,
             onion: vec![],
             reconnect_interval_secs: 5,
             max_reconnect_attempts: 10,
@@ -761,6 +847,7 @@ mod tests {
         let keys = Keys::generate();
         let config = RelayConfig {
             clearnet: vec![],
+            allow_unencrypted_clearnet_relays: false,
             onion: vec!["ws://example.onion".to_string()],
             reconnect_interval_secs: 5,
             max_reconnect_attempts: 10,
@@ -781,6 +868,7 @@ mod tests {
         let keys = Keys::generate();
         let config = RelayConfig {
             clearnet: vec![],
+            allow_unencrypted_clearnet_relays: false,
             onion: vec!["wss://example.onion".to_string()],
             reconnect_interval_secs: 5,
             max_reconnect_attempts: 10,
@@ -799,6 +887,7 @@ mod tests {
         let keys = Keys::generate();
         let config = RelayConfig {
             clearnet: vec![],
+            allow_unencrypted_clearnet_relays: false,
             onion: vec!["wss://example.onion".to_string()],
             reconnect_interval_secs: 5,
             max_reconnect_attempts: 10,
@@ -820,6 +909,7 @@ mod tests {
         let keys = Keys::generate();
         let config = RelayConfig {
             clearnet: vec![relay_url.to_string()],
+            allow_unencrypted_clearnet_relays: true,
             onion: vec![],
             reconnect_interval_secs: 5,
             max_reconnect_attempts: 10,
@@ -845,6 +935,7 @@ mod tests {
         let config = RelayConfig {
             // Use a relay URL that won't connect
             clearnet: vec!["ws://192.0.2.1:9999".to_string()], // TEST-NET address, won't route
+            allow_unencrypted_clearnet_relays: true,
             onion: vec![],
             reconnect_interval_secs: 5,
             max_reconnect_attempts: 10,

--- a/src/server/health.rs
+++ b/src/server/health.rs
@@ -209,6 +209,7 @@ mod tests {
         let keys = Keys::generate();
         let relay_config = RelayConfig {
             clearnet: vec![relay_url.to_string()],
+            allow_unencrypted_clearnet_relays: true,
             onion: vec![],
             reconnect_interval_secs: 5,
             max_reconnect_attempts: 10,
@@ -267,6 +268,7 @@ mod tests {
         let keys = Keys::generate();
         let relay_config = RelayConfig {
             clearnet: vec![relay_url.to_string()],
+            allow_unencrypted_clearnet_relays: true,
             onion: vec![],
             reconnect_interval_secs: 5,
             max_reconnect_attempts: 10,
@@ -324,6 +326,7 @@ mod tests {
         let keys = Keys::generate();
         let relay_config = RelayConfig {
             clearnet: vec![relay_url.to_string()],
+            allow_unencrypted_clearnet_relays: true,
             onion: vec![],
             reconnect_interval_secs: 5,
             max_reconnect_attempts: 10,
@@ -366,6 +369,7 @@ mod tests {
         let keys = Keys::generate();
         let relay_config = RelayConfig {
             clearnet: vec![relay_url.to_string()],
+            allow_unencrypted_clearnet_relays: true,
             onion: vec![],
             reconnect_interval_secs: 5,
             max_reconnect_attempts: 10,
@@ -410,6 +414,7 @@ mod tests {
         let keys = Keys::generate();
         let relay_config = RelayConfig {
             clearnet: vec![],
+            allow_unencrypted_clearnet_relays: false,
             onion: vec![],
             reconnect_interval_secs: 5,
             max_reconnect_attempts: 1,
@@ -464,6 +469,7 @@ mod tests {
         let keys = Keys::generate();
         let relay_config = RelayConfig {
             clearnet: vec![],
+            allow_unencrypted_clearnet_relays: false,
             onion: vec![],
             reconnect_interval_secs: 5,
             max_reconnect_attempts: 1,
@@ -523,6 +529,7 @@ mod tests {
         let keys = Keys::generate();
         let relay_config = RelayConfig {
             clearnet: vec![relay_url.to_string()],
+            allow_unencrypted_clearnet_relays: true,
             onion: vec![],
             reconnect_interval_secs: 5,
             max_reconnect_attempts: 10,


### PR DESCRIPTION
## Summary
- reject non-TLS ClearNet relay URLs during RelayClient initialization
- add an explicit `relays.allow_unencrypted_clearnet_relays` opt-in for local/mock `ws://` relays
- document the default TLS requirement in config examples and README

## Tests
- `cargo test unencrypted_clearnet_relays -- --nocapture`
- `cargo test malformed_clearnet_relay -- --nocapture`
- `cargo test config::tests::test_from_env_overrides_keys_with_underscores -- --nocapture`
- `cargo test`
- `cargo clippy -- -D warnings`
- `just ci`
- `cargo test --features tor relay_client_allows_onion_relays_with_tor_feature -- --nocapture`

Closes marmot-protocol/marmot-security#70

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/transponder/pull/52">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration control to restrict unencrypted relay connections by default, enhancing security posture
  * Enhanced relay validation to enforce encrypted connections for ClearNet relays

* **Documentation**
  * Updated configuration reference with new relay security setting
  * Added example production configuration with recommended encrypted relay URLs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
