### PR TITLE
Prevent Docker build context from including local secrets

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,8 @@
 target
 trees
 credentials
+secrets
+deploy/*.env
 .env
 .env.*
 config/local.toml


### PR DESCRIPTION
## Summary
- Exclude the local `secrets` directory from Docker build context
- Exclude real deploy env files (`deploy/*.env`) while keeping examples available
- Links marmot-protocol/marmot-security#73

## Verification
- Reproduced pre-fix context inclusion with disposable `secrets/server_private_key` and `deploy/production.env`
- Verified both files are excluded after the `.dockerignore` update
- `just ci`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configuration to exclude additional paths from the build context.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marmot-protocol/transponder/pull/53)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->