### PR TITLE
Invalidate push auth cache on upstream auth rejection

### DIFF
--- a/src/push/apns.rs
+++ b/src/push/apns.rs
@@ -234,37 +234,18 @@ impl ApnsClient {
             .json(&ApnsPayload::default())
     }
 
-    /// Send a single push notification attempt without retry.
-    ///
-    /// Returns a `SendAttemptResult` indicating success, retriable error, or permanent error.
-    async fn send_once(&self, device_token: &str) -> SendAttemptResult {
-        let start = Instant::now();
-        let url = format!("{}/3/device/{}", self.config.base_url(), device_token);
+    async fn invalidate_cached_token(&self) {
+        let mut cached = self.cached_token.write().await;
+        if cached.take().is_some() {
+            debug!("Invalidated cached APNs JWT after authentication rejection");
+        }
+    }
 
-        // Add authorization header
-        let token = match self.get_token().await {
-            Ok(t) => t,
-            Err(e) => return SendAttemptResult::Permanent(e),
-        };
-
-        let transport_retry = RetryConfig::default();
-        let response = match retry::with_transport_retry(
-            &transport_retry,
-            "APNs",
-            || async {
-                self.build_request(&url, token.as_str())
-                    .send()
-                    .await
-                    .map_err(Error::from)
-            },
-            self.metrics.as_ref(),
-        )
-        .await
-        {
-            Ok(r) => r,
-            Err(e) => return SendAttemptResult::Permanent(e),
-        };
-
+    async fn handle_response(
+        &self,
+        start: Instant,
+        response: reqwest::Response,
+    ) -> SendAttemptResult {
         let status = response.status();
 
         if let Some(metrics) = &self.metrics {
@@ -285,6 +266,7 @@ impl ApnsClient {
                 SendAttemptResult::Success(false)
             }
             403 => {
+                self.invalidate_cached_token().await;
                 let error: ApnsErrorResponse = response.json().await.unwrap_or(ApnsErrorResponse {
                     reason: "Unknown".to_string(),
                 });
@@ -326,6 +308,40 @@ impl ApnsClient {
                 SendAttemptResult::Success(false)
             }
         }
+    }
+
+    /// Send a single push notification attempt without retry.
+    ///
+    /// Returns a `SendAttemptResult` indicating success, retriable error, or permanent error.
+    async fn send_once(&self, device_token: &str) -> SendAttemptResult {
+        let start = Instant::now();
+        let url = format!("{}/3/device/{}", self.config.base_url(), device_token);
+
+        // Add authorization header
+        let token = match self.get_token().await {
+            Ok(t) => t,
+            Err(e) => return SendAttemptResult::Permanent(e),
+        };
+
+        let transport_retry = RetryConfig::default();
+        let response = match retry::with_transport_retry(
+            &transport_retry,
+            "APNs",
+            || async {
+                self.build_request(&url, token.as_str())
+                    .send()
+                    .await
+                    .map_err(Error::from)
+            },
+            self.metrics.as_ref(),
+        )
+        .await
+        {
+            Ok(r) => r,
+            Err(e) => return SendAttemptResult::Permanent(e),
+        };
+
+        self.handle_response(start, response).await
     }
 
     /// Check if the client is properly configured.
@@ -706,6 +722,44 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), 403);
+    }
+
+    #[tokio::test]
+    async fn test_auth_error_invalidates_cached_token() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path_regex(r"/3/device/[a-f0-9]+"))
+            .respond_with(ResponseTemplate::new(403).set_body_json(serde_json::json!({
+                "reason": "BadJwtToken"
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let client = ApnsClient::mock(test_config(), false);
+        {
+            let mut cached = client.cached_token.write().await;
+            *cached = Some(CachedToken {
+                token: Zeroizing::new("poisoned-jwt".to_string()),
+                expires_at: SystemTime::now() + TOKEN_LIFETIME,
+            });
+        }
+
+        let response = Client::new()
+            .post(format!("{}/3/device/{}", mock_server.uri(), "deadbeef1234"))
+            .send()
+            .await
+            .unwrap();
+
+        let result = client.handle_response(Instant::now(), response).await;
+
+        assert!(matches!(
+            result,
+            SendAttemptResult::Permanent(Error::Apns(ref message))
+                if message.contains("BadJwtToken")
+        ));
+        assert!(client.cached_token.read().await.is_none());
     }
 
     #[test]

--- a/src/push/fcm.rs
+++ b/src/push/fcm.rs
@@ -329,6 +329,85 @@ impl FcmClient {
             .json(&request)
     }
 
+    async fn invalidate_cached_token(&self) {
+        let mut cached = self.cached_token.write().await;
+        if cached.take().is_some() {
+            debug!("Invalidated cached FCM OAuth token after authentication rejection");
+        }
+    }
+
+    async fn handle_response(
+        &self,
+        start: Instant,
+        response: reqwest::Response,
+    ) -> SendAttemptResult {
+        let status = response.status();
+
+        if let Some(metrics) = &self.metrics {
+            metrics.observe_push_duration("fcm", start.elapsed().as_secs_f64());
+            metrics.record_push_response_status("fcm", status.as_u16());
+        }
+
+        match status.as_u16() {
+            200 => {
+                trace!("FCM notification sent successfully");
+                SendAttemptResult::Success(true)
+            }
+            400 => {
+                let error: FcmErrorResponse = response.json().await.unwrap_or(FcmErrorResponse {
+                    error: FcmError {
+                        code: 400,
+                        message: "Unknown".to_string(),
+                        status: "INVALID_ARGUMENT".to_string(),
+                    },
+                });
+                warn!(
+                    status = %error.error.status,
+                    message = %error.error.message,
+                    "FCM bad request"
+                );
+                SendAttemptResult::Success(false)
+            }
+            401 => {
+                // Auth error - permanent for this request, refresh on the next one.
+                self.invalidate_cached_token().await;
+                error!("FCM authentication error");
+                SendAttemptResult::Permanent(Error::Fcm("Authentication error".to_string()))
+            }
+            404 => {
+                // Token not found (device unregistered)
+                debug!("FCM token not found (device unregistered)");
+                SendAttemptResult::Success(false)
+            }
+            429 => {
+                // Rate limited - retriable
+                let retry_after = response
+                    .headers()
+                    .get("retry-after")
+                    .and_then(|v| v.to_str().ok())
+                    .and_then(|v| retry::parse_retry_after(Some(v)));
+                SendAttemptResult::Retriable {
+                    status_code: 429,
+                    retry_after,
+                }
+            }
+            500..=599 => {
+                // Server error - retriable
+                let body = response.text().await.unwrap_or_default();
+                debug!(status = %status, body = %body, "FCM server error (retriable)");
+                SendAttemptResult::Retriable {
+                    status_code: status.as_u16(),
+                    retry_after: None,
+                }
+            }
+            _ => {
+                let body = response.text().await.unwrap_or_default();
+                warn!(status = %status, body = %body, "FCM unexpected response");
+                SendAttemptResult::Success(false)
+            }
+        }
+    }
+
     /// Send a single push notification attempt without retry.
     ///
     /// Returns a `SendAttemptResult` indicating success, retriable error, or permanent error.
@@ -366,70 +445,7 @@ impl FcmClient {
             Err(e) => return SendAttemptResult::Permanent(e),
         };
 
-        let status = response.status();
-
-        if let Some(metrics) = &self.metrics {
-            metrics.observe_push_duration("fcm", start.elapsed().as_secs_f64());
-            metrics.record_push_response_status("fcm", status.as_u16());
-        }
-
-        match status.as_u16() {
-            200 => {
-                trace!("FCM notification sent successfully");
-                SendAttemptResult::Success(true)
-            }
-            400 => {
-                let error: FcmErrorResponse = response.json().await.unwrap_or(FcmErrorResponse {
-                    error: FcmError {
-                        code: 400,
-                        message: "Unknown".to_string(),
-                        status: "INVALID_ARGUMENT".to_string(),
-                    },
-                });
-                warn!(
-                    status = %error.error.status,
-                    message = %error.error.message,
-                    "FCM bad request"
-                );
-                SendAttemptResult::Success(false)
-            }
-            401 => {
-                // Auth error - permanent, don't retry
-                error!("FCM authentication error");
-                SendAttemptResult::Permanent(Error::Fcm("Authentication error".to_string()))
-            }
-            404 => {
-                // Token not found (device unregistered)
-                debug!("FCM token not found (device unregistered)");
-                SendAttemptResult::Success(false)
-            }
-            429 => {
-                // Rate limited - retriable
-                let retry_after = response
-                    .headers()
-                    .get("retry-after")
-                    .and_then(|v| v.to_str().ok())
-                    .and_then(|v| retry::parse_retry_after(Some(v)));
-                SendAttemptResult::Retriable {
-                    status_code: 429,
-                    retry_after,
-                }
-            }
-            500..=599 => {
-                // Server error - retriable
-                let body = response.text().await.unwrap_or_default();
-                debug!(status = %status, body = %body, "FCM server error (retriable)");
-                SendAttemptResult::Retriable {
-                    status_code: status.as_u16(),
-                    retry_after: None,
-                }
-            }
-            _ => {
-                let body = response.text().await.unwrap_or_default();
-                warn!(status = %status, body = %body, "FCM unexpected response");
-                SendAttemptResult::Success(false)
-            }
-        }
+        self.handle_response(start, response).await
     }
 
     /// Check if the client is properly configured.
@@ -764,6 +780,56 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), 401);
+    }
+
+    #[tokio::test]
+    async fn test_auth_error_invalidates_cached_token() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path_regex(r"/v1/projects/.+/messages:send"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "error": {
+                    "code": 401,
+                    "message": "Request had invalid authentication credentials.",
+                    "status": "UNAUTHENTICATED"
+                }
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let config = FcmConfig {
+            enabled: true,
+            service_account_path: String::new(),
+            project_id: "test-project".to_string(),
+        };
+        let client = FcmClient::mock(config, false);
+        {
+            let mut cached = client.cached_token.write().await;
+            *cached = Some(CachedToken {
+                token: Zeroizing::new("poisoned-access-token".to_string()),
+                expires_at: SystemTime::now() + TOKEN_LIFETIME,
+            });
+        }
+
+        let response = Client::new()
+            .post(format!(
+                "{}/v1/projects/test-project/messages:send",
+                mock_server.uri()
+            ))
+            .send()
+            .await
+            .unwrap();
+
+        let result = client.handle_response(Instant::now(), response).await;
+
+        assert!(matches!(
+            result,
+            SendAttemptResult::Permanent(Error::Fcm(ref message))
+                if message.contains("Authentication error")
+        ));
+        assert!(client.cached_token.read().await.is_none());
     }
 
     #[tokio::test]


### PR DESCRIPTION
Addresses https://github.com/marmot-protocol/marmot-security/issues/99

## Summary
- clear the cached APNs JWT when APNs returns a 403 authentication rejection
- clear the cached FCM OAuth token when FCM returns a 401 authentication rejection
- route send_once response handling through tested helpers so the next send refreshes credentials instead of reusing a poisoned cache entry

## Tests
- cargo test test_auth_error_invalidates_cached_token
- cargo test push::
- just ci

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved push notification response handling for Apple and Google services to better manage authentication failures.

* **Tests**
  * Added tests verifying that cached authentication tokens are properly invalidated when authentication fails.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marmot-protocol/transponder/pull/55)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->