### PR TITLE
Tune Transponder logging levels and default filters

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -162,6 +162,7 @@ async fn main() -> Result<()> {
         match Metrics::new() {
             Ok(m) => {
                 m.init_server_info(env!("CARGO_PKG_VERSION"));
+                info!("Metrics initialized");
                 Some(m)
             }
             Err(e) => {
@@ -170,7 +171,7 @@ async fn main() -> Result<()> {
             }
         }
     } else {
-        debug!("Metrics disabled");
+        info!("Metrics disabled");
         None
     };
 
@@ -190,7 +191,7 @@ async fn main() -> Result<()> {
     let keys = Keys::new(secret_key);
     drop(server_private_key);
 
-    info!(
+    debug!(
         pubkey = %keys.public_key().to_hex(),
         "Server public key"
     );
@@ -208,7 +209,10 @@ async fn main() -> Result<()> {
         match ApnsClient::with_metrics(config.apns.clone(), metrics.clone()).await {
             Ok(client) => {
                 if client.is_configured() {
-                    info!("APNs client initialized");
+                    info!(
+                        environment = %config.apns.environment,
+                        "APNs push service configured"
+                    );
                     Some(client)
                 } else {
                     warn!("APNs enabled but not fully configured");
@@ -221,7 +225,7 @@ async fn main() -> Result<()> {
             }
         }
     } else {
-        debug!("APNs disabled");
+        info!("APNs push service disabled");
         None
     };
 
@@ -229,7 +233,7 @@ async fn main() -> Result<()> {
         match FcmClient::with_metrics(config.fcm.clone(), metrics.clone()).await {
             Ok(client) => {
                 if client.is_configured() {
-                    info!("FCM client initialized");
+                    info!("FCM push service configured");
                     Some(client)
                 } else {
                     warn!("FCM enabled but not fully configured");
@@ -242,7 +246,7 @@ async fn main() -> Result<()> {
             }
         }
     } else {
-        debug!("FCM disabled");
+        info!("FCM push service disabled");
         None
     };
 
@@ -521,8 +525,8 @@ async fn run_healthcheck(url: &str) -> Result<()> {
 
 /// Initialize the tracing subscriber based on configuration.
 fn init_logging(config: &config::LoggingConfig) -> Result<()> {
-    let filter =
-        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(&config.level));
+    let filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new(default_log_filter(&config.level)));
 
     match config.format.as_str() {
         "json" => {
@@ -551,6 +555,22 @@ fn init_logging(config: &config::LoggingConfig) -> Result<()> {
     Ok(())
 }
 
+/// Build the default log filter from config.
+///
+/// Simple levels apply to Transponder while keeping dependencies at `info`,
+/// which avoids noisy HTTP/2 frame logs from crates such as `h2` and `reqwest`.
+/// Operators can still use `RUST_LOG` or explicit directives for full control.
+fn default_log_filter(level: &str) -> String {
+    let level = level.trim();
+    if level.contains('=') || level.contains(',') {
+        level.to_string()
+    } else if level.eq_ignore_ascii_case("off") {
+        "off".to_string()
+    } else {
+        format!("info,transponder={level}")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -558,6 +578,24 @@ mod tests {
     use std::io::Write;
     use tempfile::NamedTempFile;
     use tokio::net::TcpListener;
+
+    #[test]
+    fn logging_filter_keeps_dependency_debug_logs_out_of_simple_debug_level() {
+        assert_eq!(default_log_filter("debug"), "info,transponder=debug");
+    }
+
+    #[test]
+    fn logging_filter_preserves_explicit_directives() {
+        assert_eq!(
+            default_log_filter("transponder=debug,h2=warn"),
+            "transponder=debug,h2=warn"
+        );
+    }
+
+    #[test]
+    fn logging_filter_preserves_off_level() {
+        assert_eq!(default_log_filter("off"), "off");
+    }
 
     #[test]
     fn notification_receive_lag_is_recoverable() {

--- a/src/nostr/client.rs
+++ b/src/nostr/client.rs
@@ -96,7 +96,7 @@ impl RelayClient {
         for url in &self.config.clearnet {
             match self.client.add_relay(url).await {
                 Ok(_) => {
-                    info!(relay = %url, "Added ClearNet relay");
+                    debug!(relay = %url, "Added ClearNet relay");
                 }
                 Err(e) => {
                     warn!(relay = %url, error = %e, "Failed to add ClearNet relay");
@@ -108,13 +108,19 @@ impl RelayClient {
         for url in &self.config.onion {
             match self.client.add_relay(url).await {
                 Ok(_) => {
-                    info!(relay = %url, "Added Tor relay");
+                    debug!(relay = %url, "Added Tor relay");
                 }
                 Err(e) => {
                     warn!(relay = %url, error = %e, "Failed to add Tor relay");
                 }
             }
         }
+
+        info!(
+            clearnet = self.config.clearnet.len(),
+            tor = self.config.onion.len(),
+            "Configured relay subscriptions"
+        );
 
         // Connect to all added relays (nostr-sdk connects in the background)
         self.client.connect().await;
@@ -281,7 +287,8 @@ impl RelayClient {
 
         match self.client.send_event_builder(builder).await {
             Ok(output) => {
-                info!(event_id = %output.id(), "Published kind 10050 inbox relay list");
+                debug!(event_id = %output.id(), "Published kind 10050 inbox relay list");
+                info!("Published kind 10050 inbox relay list");
             }
             Err(e) => {
                 error!(error = %e, "Failed to publish kind 10050 event");

--- a/src/nostr/events.rs
+++ b/src/nostr/events.rs
@@ -12,7 +12,7 @@ use nostr_sdk::prelude::*;
 use sha2::{Digest, Sha256};
 use tokio::sync::RwLock;
 use tokio::time::Instant;
-use tracing::{debug, trace, warn};
+use tracing::{debug, info, trace, warn};
 
 use crate::crypto::nip59::DEFAULT_MAX_TOKENS_PER_EVENT;
 use crate::crypto::token::ENCRYPTED_TOKEN_SIZE;
@@ -203,10 +203,11 @@ impl EventProcessor {
         if let Some(ref m) = self.metrics {
             m.record_event_received();
         }
+        info!("Received Nostr notification event");
 
         // Check for duplicates
         if self.is_duplicate(&event.id).await {
-            trace!(event_id = %event.id, "Skipping duplicate event");
+            trace!("Skipping duplicate event");
             if let Some(ref m) = self.metrics {
                 m.record_event_deduplicated();
                 m.observe_event_processing_duration(
@@ -224,9 +225,8 @@ impl EventProcessor {
                 // This avoids dropping events due to transient failures.
                 self.mark_seen(event.id).await;
 
-                debug!(
-                    event_id = %event.id,
-                    notifications_sent = count,
+                info!(
+                    notifications_admitted = count,
                     "Processed notification event"
                 );
 
@@ -246,7 +246,6 @@ impl EventProcessor {
 
                 // Log but don't propagate - we want to continue processing other events
                 warn!(
-                    event_id = %event.id,
                     error = %e,
                     "Failed to process event"
                 );
@@ -305,7 +304,7 @@ impl EventProcessor {
             }
         };
 
-        trace!("Unwrapped notification request");
+        info!("Unwrapped notification request");
 
         // Parse the encrypted tokens from the content
         let parse_started_at = StageTimer::start();
@@ -338,7 +337,7 @@ impl EventProcessor {
             return Ok(0);
         }
 
-        debug!(token_count = token_bytes.len(), "Decrypting tokens");
+        info!(token_count = token_bytes.len(), "Decrypting tokens");
 
         // Decrypt each token and dispatch notifications, with rate limiting.
         //

--- a/src/push/apns.rs
+++ b/src/push/apns.rs
@@ -9,7 +9,7 @@ use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
-use tracing::{debug, error, trace, warn};
+use tracing::{debug, error, info, trace, warn};
 use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
 use crate::config::ApnsConfig;
@@ -255,7 +255,7 @@ impl ApnsClient {
 
         match status.as_u16() {
             200 => {
-                trace!("APNs notification sent successfully");
+                info!("APNs notification accepted");
                 SendAttemptResult::Success(true)
             }
             400 => {
@@ -278,7 +278,7 @@ impl ApnsClient {
             }
             410 => {
                 // Token is no longer valid (device unregistered)
-                debug!("APNs token no longer valid (device unregistered)");
+                info!("APNs token no longer valid");
                 SendAttemptResult::Success(false)
             }
             429 => {
@@ -295,16 +295,14 @@ impl ApnsClient {
             }
             500..=599 => {
                 // Server error - retriable
-                let body = response.text().await.unwrap_or_default();
-                debug!(status = %status, body = %body, "APNs server error (retriable)");
+                debug!(status = %status, "APNs server error (retriable)");
                 SendAttemptResult::Retriable {
                     status_code: status.as_u16(),
                     retry_after: None,
                 }
             }
             _ => {
-                let body = response.text().await.unwrap_or_default();
-                warn!(status = %status, body = %body, "APNs unexpected response");
+                warn!(status = %status, "APNs unexpected response");
                 SendAttemptResult::Success(false)
             }
         }

--- a/src/push/fcm.rs
+++ b/src/push/fcm.rs
@@ -10,7 +10,7 @@ use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
-use tracing::{debug, error, trace, warn};
+use tracing::{debug, error, info, trace, warn};
 use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
 use crate::config::FcmConfig;
@@ -352,7 +352,7 @@ impl FcmClient {
 
         match status.as_u16() {
             200 => {
-                trace!("FCM notification sent successfully");
+                info!("FCM notification accepted");
                 SendAttemptResult::Success(true)
             }
             400 => {
@@ -378,7 +378,7 @@ impl FcmClient {
             }
             404 => {
                 // Token not found (device unregistered)
-                debug!("FCM token not found (device unregistered)");
+                info!("FCM token not found");
                 SendAttemptResult::Success(false)
             }
             429 => {
@@ -395,16 +395,14 @@ impl FcmClient {
             }
             500..=599 => {
                 // Server error - retriable
-                let body = response.text().await.unwrap_or_default();
-                debug!(status = %status, body = %body, "FCM server error (retriable)");
+                debug!(status = %status, "FCM server error (retriable)");
                 SendAttemptResult::Retriable {
                     status_code: status.as_u16(),
                     retry_after: None,
                 }
             }
             _ => {
-                let body = response.text().await.unwrap_or_default();
-                warn!(status = %status, body = %body, "FCM unexpected response");
+                warn!(status = %status, "FCM unexpected response");
                 SendAttemptResult::Success(false)
             }
         }


### PR DESCRIPTION
## Summary
- Promote startup, relay connection, push service readiness, and high-level Nostr event flow to `info`
- Keep identifiers and low-level transport details out of normal logs by demoting relay URLs, event IDs, and HTTP/2 frame noise
- Make simple config levels scope Transponder to the requested level while keeping dependencies at `info` unless `RUST_LOG` overrides it
- Reduce provider response noise by logging APNs/FCM successes and invalid-token outcomes at a higher level and trimming raw response bodies from routine paths

## Testing
- Added unit coverage for the default log filter behavior, including `debug`, explicit directives, and `off`
- Ran the full binary test suite and clippy with warnings denied

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit tests to validate logging filter configuration behavior.

* **Chores**
  * Refined logging levels across the application for improved message clarity and appropriate verbosity.
  * Simplified push notification response logging to reduce unnecessary output during error scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marmot-protocol/transponder/pull/57)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->