### PR TITLE
Add APNS NSE probe payload mode for staging

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ environment = "production"
 # Your iOS app's bundle identifier (e.g., "com.example.myapp")
 bundle_id = ""
 
+# APNs payload mode: "silent" or "nse_prototype_alert"
+# Keep production silent. Use nse_prototype_alert only for staging NSE prototype testing.
+payload_mode = "silent"
+
 [fcm]
 # Enable FCM for Android push notifications
 enabled = false
@@ -160,6 +164,7 @@ export TRANSPONDER_APNS_KEY_ID="ABCD123456"
 export TRANSPONDER_APNS_TEAM_ID="TEAM123456"
 export TRANSPONDER_APNS_PRIVATE_KEY_PATH="/path/to/AuthKey.p8"
 export TRANSPONDER_APNS_BUNDLE_ID="com.example.app"
+export TRANSPONDER_APNS_PAYLOAD_MODE="silent"
 
 export TRANSPONDER_FCM_ENABLED=true
 export TRANSPONDER_FCM_SERVICE_ACCOUNT_PATH="/path/to/service-account.json"

--- a/config/default.toml
+++ b/config/default.toml
@@ -86,6 +86,10 @@ environment = "production"
 # iOS app bundle identifier
 bundle_id = ""
 
+# APNs payload mode: "silent" or "nse_prototype_alert"
+# Keep production silent. Use nse_prototype_alert only for staging NSE prototype testing.
+payload_mode = "silent"
+
 [fcm]
 # Whether FCM (Android) push notifications are enabled
 enabled = false

--- a/config/production.toml.example
+++ b/config/production.toml.example
@@ -46,6 +46,7 @@ team_id = ""
 private_key_path = "/credentials/AuthKey_XXXXXXXXXX.p8"
 environment = "production"
 bundle_id = ""
+payload_mode = "silent"
 
 [fcm]
 enabled = false

--- a/src/config.rs
+++ b/src/config.rs
@@ -246,6 +246,47 @@ pub struct ApnsConfig {
     /// Bundle ID for the iOS app.
     #[serde(default)]
     pub bundle_id: String,
+
+    /// APNs payload mode.
+    #[serde(default)]
+    pub payload_mode: ApnsPayloadMode,
+}
+
+/// APNs payload mode.
+#[derive(Debug, Clone, Copy, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ApnsPayloadMode {
+    /// Silent background push used by the normal MIP-05 flow.
+    #[default]
+    Silent,
+
+    /// Alert payload for exercising the iOS Notification Service Extension prototype.
+    NsePrototypeAlert,
+}
+
+impl ApnsPayloadMode {
+    pub(crate) fn push_type(self) -> &'static str {
+        match self {
+            Self::Silent => "background",
+            Self::NsePrototypeAlert => "alert",
+        }
+    }
+
+    pub(crate) fn priority(self) -> &'static str {
+        match self {
+            Self::Silent => "5",
+            Self::NsePrototypeAlert => "10",
+        }
+    }
+}
+
+impl std::fmt::Display for ApnsPayloadMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Silent => f.write_str("silent"),
+            Self::NsePrototypeAlert => f.write_str("nse_prototype_alert"),
+        }
+    }
 }
 
 fn default_apns_environment() -> String {
@@ -366,6 +407,7 @@ fn base_config_builder() -> Result<ConfigBuilder<DefaultState>> {
         .set_default("apns.private_key_path", "")?
         .set_default("apns.environment", "production")?
         .set_default("apns.bundle_id", "")?
+        .set_default("apns.payload_mode", "silent")?
         .set_default("fcm.enabled", false)?
         .set_default("fcm.service_account_path", "")?
         .set_default("fcm.project_id", "")?
@@ -470,6 +512,7 @@ fn is_supported_config_key(config_key: &str) -> bool {
                 | "apns.private_key_path"
                 | "apns.environment"
                 | "apns.bundle_id"
+                | "apns.payload_mode"
                 | "fcm.enabled"
                 | "fcm.service_account_path"
                 | "fcm.project_id"
@@ -687,6 +730,7 @@ mod tests {
             private_key_path: "/path/to/key.p8".to_string(),
             environment: "production".to_string(),
             bundle_id: "com.example.app".to_string(),
+            payload_mode: Default::default(),
         };
 
         assert!(config.is_production());
@@ -702,6 +746,7 @@ mod tests {
             private_key_path: String::new(),
             environment: "sandbox".to_string(),
             bundle_id: String::new(),
+            payload_mode: Default::default(),
         };
 
         assert!(!config.is_production());
@@ -944,6 +989,46 @@ mod tests {
     }
 
     #[test]
+    fn test_apns_payload_mode_defaults_to_silent() {
+        let config = from_test_env(&[]).unwrap();
+
+        assert_eq!(config.apns.payload_mode, ApnsPayloadMode::Silent);
+    }
+
+    #[test]
+    fn test_apns_payload_mode_parses_nse_prototype_alert() {
+        let config_content = r#"
+            [server]
+            private_key = "test"
+
+            [apns]
+            payload_mode = "nse_prototype_alert"
+        "#;
+
+        let file = create_temp_config(config_content);
+        let config = load_with_test_env(file.path(), &[]).unwrap();
+
+        assert_eq!(config.apns.payload_mode, ApnsPayloadMode::NsePrototypeAlert);
+    }
+
+    #[test]
+    fn test_apns_payload_mode_rejects_unknown_value() {
+        let config_content = r#"
+            [server]
+            private_key = "test"
+
+            [apns]
+            payload_mode = "loud_plaintext"
+        "#;
+
+        let file = create_temp_config(config_content);
+        let error = load_with_test_env(file.path(), &[]).unwrap_err();
+
+        assert!(error.to_string().contains("payload_mode"), "{error}");
+        assert!(error.to_string().contains("loud_plaintext"), "{error}");
+    }
+
+    #[test]
     fn test_health_config_defaults() {
         assert!(default_health_enabled());
         assert_eq!(default_health_bind_address(), "127.0.0.1:8080");
@@ -979,6 +1064,7 @@ mod tests {
             private_key_path: String::new(),
             environment: "production".to_string(),
             bundle_id: String::new(),
+            payload_mode: Default::default(),
         };
         assert!(config.is_production());
     }
@@ -992,6 +1078,7 @@ mod tests {
             private_key_path: String::new(),
             environment: "development".to_string(),
             bundle_id: String::new(),
+            payload_mode: Default::default(),
         };
         assert!(!config.is_production());
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -211,6 +211,7 @@ async fn main() -> Result<()> {
                 if client.is_configured() {
                     info!(
                         environment = %config.apns.environment,
+                        payload_mode = %config.apns.payload_mode,
                         "APNs push service configured"
                     );
                     Some(client)

--- a/src/nostr/events.rs
+++ b/src/nostr/events.rs
@@ -627,6 +627,7 @@ mod tests {
             private_key_path: String::new(),
             environment: "sandbox".to_string(),
             bundle_id: "com.example.app".to_string(),
+            payload_mode: Default::default(),
         };
         let metrics = Metrics::new().expect("metrics");
         let push_dispatcher = Arc::new(PushDispatcher::with_metrics(
@@ -673,6 +674,7 @@ mod tests {
             private_key_path: String::new(),
             environment: "sandbox".to_string(),
             bundle_id: "com.example.app".to_string(),
+            payload_mode: Default::default(),
         };
         let metrics = Metrics::new().expect("metrics");
         let push_dispatcher = Arc::new(PushDispatcher::with_metrics(

--- a/src/push/apns.rs
+++ b/src/push/apns.rs
@@ -8,11 +8,12 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use tokio::sync::RwLock;
 use tracing::{debug, error, info, trace, warn};
 use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
-use crate::config::ApnsConfig;
+use crate::config::{ApnsConfig, ApnsPayloadMode};
 use crate::error::{Error, Result};
 use crate::metrics::Metrics;
 use crate::push::retry::{self, RetryConfig, SendAttemptResult};
@@ -42,24 +43,106 @@ pub(crate) struct CachedToken {
     expires_at: SystemTime,
 }
 
-/// APNs silent notification payload.
+/// APNs notification payload.
 #[derive(Debug, Serialize)]
-struct ApnsPayload {
-    aps: ApnsAps,
+#[serde(untagged)]
+enum ApnsPayload {
+    Silent(ApnsSilentPayload),
+    NsePrototypeAlert(ApnsNsePrototypeAlertPayload),
 }
 
 #[derive(Debug, Serialize)]
-struct ApnsAps {
+struct ApnsSilentPayload {
+    aps: ApnsSilentAps,
+}
+
+#[derive(Debug, Serialize)]
+struct ApnsSilentAps {
     #[serde(rename = "content-available")]
     content_available: u8,
 }
 
 impl Default for ApnsPayload {
     fn default() -> Self {
-        Self {
-            aps: ApnsAps {
+        Self::Silent(ApnsSilentPayload {
+            aps: ApnsSilentAps {
                 content_available: 1,
             },
+        })
+    }
+}
+
+impl From<ApnsPayloadMode> for ApnsPayload {
+    fn from(mode: ApnsPayloadMode) -> Self {
+        match mode {
+            ApnsPayloadMode::Silent => Self::default(),
+            ApnsPayloadMode::NsePrototypeAlert => {
+                Self::NsePrototypeAlert(ApnsNsePrototypeAlertPayload::default())
+            }
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct ApnsNsePrototypeAlertPayload {
+    aps: ApnsNsePrototypeAps,
+    wn_nse_prototype: bool,
+}
+
+impl Default for ApnsNsePrototypeAlertPayload {
+    fn default() -> Self {
+        Self {
+            aps: ApnsNsePrototypeAps::default(),
+            wn_nse_prototype: true,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct ApnsNsePrototypeAps {
+    alert: ApnsAlert,
+    #[serde(rename = "mutable-content")]
+    mutable_content: u8,
+    sound: &'static str,
+}
+
+impl Default for ApnsNsePrototypeAps {
+    fn default() -> Self {
+        Self {
+            alert: ApnsAlert {
+                title: "White Noise",
+                body: "New encrypted message",
+            },
+            mutable_content: 1,
+            sound: "default",
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct ApnsAlert {
+    title: &'static str,
+    body: &'static str,
+}
+
+fn redacted_device_token_id(device_token: &str) -> String {
+    let digest = Sha256::digest(device_token.as_bytes());
+    format!("sha256:{}", hex::encode(&digest[..6]))
+}
+
+#[derive(Debug)]
+struct ApnsRequestParts {
+    push_type: &'static str,
+    priority: &'static str,
+    payload: ApnsPayload,
+}
+
+impl ApnsRequestParts {
+    fn for_mode(mode: ApnsPayloadMode) -> Self {
+        Self {
+            push_type: mode.push_type(),
+            priority: mode.priority(),
+            payload: ApnsPayload::from(mode),
         }
     }
 }
@@ -225,13 +308,15 @@ impl ApnsClient {
     }
 
     fn build_request(&self, url: &str, auth_token: &str) -> reqwest::RequestBuilder {
+        let request_parts = ApnsRequestParts::for_mode(self.config.payload_mode);
+
         self.http_client
             .post(url)
-            .header("apns-push-type", "background")
-            .header("apns-priority", "5")
+            .header("apns-push-type", request_parts.push_type)
+            .header("apns-priority", request_parts.priority)
             .header("apns-topic", &self.config.bundle_id)
             .header("authorization", format!("bearer {auth_token}"))
-            .json(&ApnsPayload::default())
+            .json(&request_parts.payload)
     }
 
     async fn invalidate_cached_token(&self) {
@@ -245,6 +330,7 @@ impl ApnsClient {
         &self,
         start: Instant,
         response: reqwest::Response,
+        device_token_id: &str,
     ) -> SendAttemptResult {
         let status = response.status();
 
@@ -255,14 +341,24 @@ impl ApnsClient {
 
         match status.as_u16() {
             200 => {
-                info!("APNs notification accepted");
+                info!(
+                    token_id = %device_token_id,
+                    payload_mode = %self.config.payload_mode,
+                    status = status.as_u16(),
+                    "APNs notification accepted"
+                );
                 SendAttemptResult::Success(true)
             }
             400 => {
                 let error: ApnsErrorResponse = response.json().await.unwrap_or(ApnsErrorResponse {
                     reason: "Unknown".to_string(),
                 });
-                warn!(reason = %error.reason, "APNs bad request");
+                warn!(
+                    token_id = %device_token_id,
+                    payload_mode = %self.config.payload_mode,
+                    reason = %error.reason,
+                    "APNs bad request"
+                );
                 SendAttemptResult::Success(false)
             }
             403 => {
@@ -270,7 +366,12 @@ impl ApnsClient {
                 let error: ApnsErrorResponse = response.json().await.unwrap_or(ApnsErrorResponse {
                     reason: "Unknown".to_string(),
                 });
-                error!(reason = %error.reason, "APNs authentication error");
+                error!(
+                    token_id = %device_token_id,
+                    payload_mode = %self.config.payload_mode,
+                    reason = %error.reason,
+                    "APNs authentication error"
+                );
                 SendAttemptResult::Permanent(Error::Apns(format!(
                     "Authentication error: {}",
                     error.reason
@@ -278,7 +379,11 @@ impl ApnsClient {
             }
             410 => {
                 // Token is no longer valid (device unregistered)
-                info!("APNs token no longer valid");
+                info!(
+                    token_id = %device_token_id,
+                    payload_mode = %self.config.payload_mode,
+                    "APNs token no longer valid"
+                );
                 SendAttemptResult::Success(false)
             }
             429 => {
@@ -288,6 +393,11 @@ impl ApnsClient {
                     .get("retry-after")
                     .and_then(|v| v.to_str().ok())
                     .and_then(|v| retry::parse_retry_after(Some(v)));
+                debug!(
+                    token_id = %device_token_id,
+                    payload_mode = %self.config.payload_mode,
+                    "APNs rate limited request"
+                );
                 SendAttemptResult::Retriable {
                     status_code: 429,
                     retry_after,
@@ -295,14 +405,24 @@ impl ApnsClient {
             }
             500..=599 => {
                 // Server error - retriable
-                debug!(status = %status, "APNs server error (retriable)");
+                debug!(
+                    token_id = %device_token_id,
+                    payload_mode = %self.config.payload_mode,
+                    status = %status,
+                    "APNs server error (retriable)"
+                );
                 SendAttemptResult::Retriable {
                     status_code: status.as_u16(),
                     retry_after: None,
                 }
             }
             _ => {
-                warn!(status = %status, "APNs unexpected response");
+                warn!(
+                    token_id = %device_token_id,
+                    payload_mode = %self.config.payload_mode,
+                    status = %status,
+                    "APNs unexpected response"
+                );
                 SendAttemptResult::Success(false)
             }
         }
@@ -314,6 +434,17 @@ impl ApnsClient {
     async fn send_once(&self, device_token: &str) -> SendAttemptResult {
         let start = Instant::now();
         let url = format!("{}/3/device/{}", self.config.base_url(), device_token);
+        let device_token_id = redacted_device_token_id(device_token);
+        let request_parts = ApnsRequestParts::for_mode(self.config.payload_mode);
+
+        debug!(
+            token_id = %device_token_id,
+            payload_mode = %self.config.payload_mode,
+            push_type = request_parts.push_type,
+            priority = request_parts.priority,
+            topic = %self.config.bundle_id,
+            "Sending APNs notification"
+        );
 
         // Add authorization header
         let token = match self.get_token().await {
@@ -339,7 +470,8 @@ impl ApnsClient {
             Err(e) => return SendAttemptResult::Permanent(e),
         };
 
-        self.handle_response(start, response).await
+        self.handle_response(start, response, &device_token_id)
+            .await
     }
 
     /// Check if the client is properly configured.
@@ -390,7 +522,17 @@ mod tests {
             private_key_path: String::new(),
             environment: "sandbox".to_string(),
             bundle_id: "com.example.app".to_string(),
+            payload_mode: Default::default(),
         }
+    }
+
+    fn header_value<'a>(request: &'a reqwest::Request, name: &str) -> &'a str {
+        request.headers().get(name).unwrap().to_str().unwrap()
+    }
+
+    fn request_json(request: &reqwest::Request) -> serde_json::Value {
+        let body = request.body().and_then(reqwest::Body::as_bytes).unwrap();
+        serde_json::from_slice(body).unwrap()
     }
 
     #[test]
@@ -399,6 +541,74 @@ mod tests {
         let json = serde_json::to_string(&payload).unwrap();
         assert!(json.contains("content-available"));
         assert!(json.contains("1"));
+    }
+
+    #[test]
+    fn test_silent_mode_builds_background_headers_and_payload() {
+        let mut config = test_config();
+        config.payload_mode = ApnsPayloadMode::Silent;
+        config.bundle_id = "dev.ipf.whitenoise.staging".to_string();
+        let client = ApnsClient::mock(config, false);
+
+        let request = client
+            .build_request(
+                "https://api.push.apple.com/3/device/aabbccdd11223344",
+                "test-token",
+            )
+            .build()
+            .unwrap();
+
+        assert_eq!(header_value(&request, "apns-push-type"), "background");
+        assert_eq!(header_value(&request, "apns-priority"), "5");
+        assert_eq!(
+            header_value(&request, "apns-topic"),
+            "dev.ipf.whitenoise.staging"
+        );
+        assert_eq!(
+            request_json(&request),
+            serde_json::json!({
+                "aps": {
+                    "content-available": 1
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn test_nse_prototype_alert_mode_builds_alert_headers_and_payload() {
+        let mut config = test_config();
+        config.payload_mode = ApnsPayloadMode::NsePrototypeAlert;
+        config.bundle_id = "dev.ipf.whitenoise.staging".to_string();
+        let client = ApnsClient::mock(config, false);
+
+        let request = client
+            .build_request(
+                "https://api.push.apple.com/3/device/aabbccdd11223344",
+                "test-token",
+            )
+            .build()
+            .unwrap();
+
+        assert_eq!(header_value(&request, "apns-push-type"), "alert");
+        assert_eq!(header_value(&request, "apns-priority"), "10");
+        assert_eq!(
+            header_value(&request, "apns-topic"),
+            "dev.ipf.whitenoise.staging"
+        );
+        assert_eq!(
+            request_json(&request),
+            serde_json::json!({
+                "aps": {
+                    "alert": {
+                        "title": "White Noise",
+                        "body": "New encrypted message"
+                    },
+                    "mutable-content": 1,
+                    "sound": "default"
+                },
+                "wn_nse_prototype": true
+            })
+        );
     }
 
     #[test]
@@ -477,6 +687,7 @@ mod tests {
             private_key_path: String::new(),
             environment: "sandbox".to_string(),
             bundle_id: "com.example.app".to_string(),
+            payload_mode: Default::default(),
         };
 
         let client = ApnsClient {
@@ -521,6 +732,7 @@ mod tests {
             private_key_path: String::new(),
             environment: "sandbox".to_string(),
             bundle_id: String::new(),
+            payload_mode: Default::default(),
         };
 
         let client = ApnsClient::new(config).await.unwrap();
@@ -560,6 +772,7 @@ mod tests {
                 private_key_path: String::new(),
                 environment: "sandbox".to_string(),
                 bundle_id: "com.example.app".to_string(),
+                payload_mode: Default::default(),
             },
             encoding_key: None,
             cached_token: Arc::new(RwLock::new(Some(CachedToken {
@@ -750,7 +963,9 @@ mod tests {
             .await
             .unwrap();
 
-        let result = client.handle_response(Instant::now(), response).await;
+        let result = client
+            .handle_response(Instant::now(), response, "sha256:test")
+            .await;
 
         assert!(matches!(
             result,
@@ -769,6 +984,7 @@ mod tests {
             private_key_path: String::new(),
             environment: "production".to_string(),
             bundle_id: "com.example.app".to_string(),
+            payload_mode: Default::default(),
         };
 
         let client = ApnsClient::mock(config, true);
@@ -784,6 +1000,7 @@ mod tests {
             private_key_path: String::new(),
             environment: "production".to_string(),
             bundle_id: "com.example.app".to_string(),
+            payload_mode: Default::default(),
         };
 
         let client = ApnsClient::mock(config, true);
@@ -799,6 +1016,7 @@ mod tests {
             private_key_path: String::new(),
             environment: "production".to_string(),
             bundle_id: "com.example.app".to_string(),
+            payload_mode: Default::default(),
         };
 
         let client = ApnsClient::mock(config, true);
@@ -814,6 +1032,7 @@ mod tests {
             private_key_path: String::new(),
             environment: "production".to_string(),
             bundle_id: String::new(), // Missing
+            payload_mode: Default::default(),
         };
 
         let client = ApnsClient::mock(config, true);
@@ -829,6 +1048,7 @@ mod tests {
             private_key_path: String::new(),
             environment: "production".to_string(),
             bundle_id: "com.example.app".to_string(),
+            payload_mode: Default::default(),
         };
 
         let client = ApnsClient::mock(config, false); // No encoding key
@@ -876,6 +1096,7 @@ mod tests {
             private_key_path: String::new(),
             environment: "production".to_string(),
             bundle_id: "com.example.app".to_string(),
+            payload_mode: Default::default(),
         };
 
         let client = ApnsClient::mock(config, false);
@@ -894,6 +1115,7 @@ mod tests {
             private_key_path: String::new(),
             environment: "production".to_string(),
             bundle_id: "com.example.app".to_string(),
+            payload_mode: Default::default(),
         };
 
         let client = ApnsClient::mock(config, true);
@@ -921,6 +1143,7 @@ mod tests {
             private_key_path: String::new(),
             environment: "production".to_string(),
             bundle_id: "com.example.app".to_string(),
+            payload_mode: Default::default(),
         };
 
         // Create a client without an encoding key to test the error case
@@ -949,6 +1172,7 @@ mod tests {
             private_key_path: String::new(),
             environment: "production".to_string(),
             bundle_id: "com.example.app".to_string(),
+            payload_mode: Default::default(),
         };
 
         let client = ApnsClient::mock(config, false); // No encoding key
@@ -976,6 +1200,7 @@ mod tests {
             private_key_path: String::new(), // Empty path
             environment: "production".to_string(),
             bundle_id: "com.example.app".to_string(),
+            payload_mode: Default::default(),
         };
 
         let client = ApnsClient::new(config).await.unwrap();
@@ -991,6 +1216,7 @@ mod tests {
             private_key_path: "/nonexistent/key.p8".to_string(),
             environment: "production".to_string(),
             bundle_id: "com.example.app".to_string(),
+            payload_mode: Default::default(),
         };
 
         let result = ApnsClient::new(config).await;
@@ -1031,6 +1257,7 @@ mod tests {
             private_key_path: String::new(),
             environment: "sandbox".to_string(),
             bundle_id: "com.example.app".to_string(),
+            payload_mode: Default::default(),
         };
 
         let client = ApnsClient {
@@ -1078,6 +1305,7 @@ mod tests {
             private_key_path: String::new(),
             environment: "production".to_string(),
             bundle_id: "com.example.app".to_string(),
+            payload_mode: Default::default(),
         };
 
         // Client without encoding key - should fail when trying to generate
@@ -1112,6 +1340,7 @@ OF/2NxApJCzGCEDdfSp6VQO30hyhRANCAAQRWz+jn65BtOMvdyHKcvjBeBSDZH2r
             private_key_path: file.path().to_string_lossy().to_string(),
             environment: "production".to_string(),
             bundle_id: "com.example.app".to_string(),
+            payload_mode: Default::default(),
         };
 
         let client = ApnsClient::new(config).await.unwrap();
@@ -1142,6 +1371,7 @@ OF/2NxApJCzGCEDdfSp6VQO30hyhRANCAAQRWz+jn65BtOMvdyHKcvjBeBSDZH2r
             private_key_path: file.path().to_string_lossy().to_string(),
             environment: "production".to_string(),
             bundle_id: "com.example.app".to_string(),
+            payload_mode: Default::default(),
         };
 
         let metrics = Metrics::default();
@@ -1233,6 +1463,7 @@ OF/2NxApJCzGCEDdfSp6VQO30hyhRANCAAQRWz+jn65BtOMvdyHKcvjBeBSDZH2r
             private_key_path: file.path().to_string_lossy().to_string(),
             environment: "production".to_string(),
             bundle_id: "com.example.app".to_string(),
+            payload_mode: Default::default(),
         };
 
         let client = ApnsClient::new(config).await.unwrap();
@@ -1283,6 +1514,7 @@ OF/2NxApJCzGCEDdfSp6VQO30hyhRANCAAQRWz+jn65BtOMvdyHKcvjBeBSDZH2r
             private_key_path: String::new(),
             environment: "sandbox".to_string(),
             bundle_id: "com.example.app".to_string(),
+            payload_mode: Default::default(),
         };
 
         let client = ApnsClient {

--- a/src/push/apns.rs
+++ b/src/push/apns.rs
@@ -8,9 +8,8 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 use tokio::sync::RwLock;
-use tracing::{debug, error, info, trace, warn};
+use tracing::{debug, trace};
 use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
 use crate::config::{ApnsConfig, ApnsPayloadMode};
@@ -125,9 +124,8 @@ struct ApnsAlert {
     body: &'static str,
 }
 
-fn redacted_device_token_id(device_token: &str) -> String {
-    let digest = Sha256::digest(device_token.as_bytes());
-    format!("sha256:{}", hex::encode(&digest[..6]))
+fn redacted_device_token_id(_device_token: &str) -> &'static str {
+    "<redacted_device_token>"
 }
 
 #[derive(Debug)]
@@ -330,7 +328,6 @@ impl ApnsClient {
         &self,
         start: Instant,
         response: reqwest::Response,
-        device_token_id: &str,
     ) -> SendAttemptResult {
         let status = response.status();
 
@@ -341,8 +338,7 @@ impl ApnsClient {
 
         match status.as_u16() {
             200 => {
-                info!(
-                    token_id = %device_token_id,
+                debug!(
                     payload_mode = %self.config.payload_mode,
                     status = status.as_u16(),
                     "APNs notification accepted"
@@ -353,8 +349,7 @@ impl ApnsClient {
                 let error: ApnsErrorResponse = response.json().await.unwrap_or(ApnsErrorResponse {
                     reason: "Unknown".to_string(),
                 });
-                warn!(
-                    token_id = %device_token_id,
+                debug!(
                     payload_mode = %self.config.payload_mode,
                     reason = %error.reason,
                     "APNs bad request"
@@ -366,8 +361,7 @@ impl ApnsClient {
                 let error: ApnsErrorResponse = response.json().await.unwrap_or(ApnsErrorResponse {
                     reason: "Unknown".to_string(),
                 });
-                error!(
-                    token_id = %device_token_id,
+                debug!(
                     payload_mode = %self.config.payload_mode,
                     reason = %error.reason,
                     "APNs authentication error"
@@ -379,8 +373,7 @@ impl ApnsClient {
             }
             410 => {
                 // Token is no longer valid (device unregistered)
-                info!(
-                    token_id = %device_token_id,
+                debug!(
                     payload_mode = %self.config.payload_mode,
                     "APNs token no longer valid"
                 );
@@ -394,7 +387,6 @@ impl ApnsClient {
                     .and_then(|v| v.to_str().ok())
                     .and_then(|v| retry::parse_retry_after(Some(v)));
                 debug!(
-                    token_id = %device_token_id,
                     payload_mode = %self.config.payload_mode,
                     "APNs rate limited request"
                 );
@@ -406,7 +398,6 @@ impl ApnsClient {
             500..=599 => {
                 // Server error - retriable
                 debug!(
-                    token_id = %device_token_id,
                     payload_mode = %self.config.payload_mode,
                     status = %status,
                     "APNs server error (retriable)"
@@ -417,8 +408,7 @@ impl ApnsClient {
                 }
             }
             _ => {
-                warn!(
-                    token_id = %device_token_id,
+                debug!(
                     payload_mode = %self.config.payload_mode,
                     status = %status,
                     "APNs unexpected response"
@@ -434,15 +424,14 @@ impl ApnsClient {
     async fn send_once(&self, device_token: &str) -> SendAttemptResult {
         let start = Instant::now();
         let url = format!("{}/3/device/{}", self.config.base_url(), device_token);
-        let device_token_id = redacted_device_token_id(device_token);
         let request_parts = ApnsRequestParts::for_mode(self.config.payload_mode);
 
         debug!(
-            token_id = %device_token_id,
             payload_mode = %self.config.payload_mode,
             push_type = request_parts.push_type,
             priority = request_parts.priority,
             topic = %self.config.bundle_id,
+            device_token = redacted_device_token_id(device_token),
             "Sending APNs notification"
         );
 
@@ -470,8 +459,7 @@ impl ApnsClient {
             Err(e) => return SendAttemptResult::Permanent(e),
         };
 
-        self.handle_response(start, response, &device_token_id)
-            .await
+        self.handle_response(start, response).await
     }
 
     /// Check if the client is properly configured.
@@ -541,6 +529,18 @@ mod tests {
         let json = serde_json::to_string(&payload).unwrap();
         assert!(json.contains("content-available"));
         assert!(json.contains("1"));
+    }
+
+    #[test]
+    fn test_device_token_redaction_is_not_token_derived() {
+        assert_eq!(
+            redacted_device_token_id("00112233445566778899aabbccddeeff"),
+            "<redacted_device_token>"
+        );
+        assert_eq!(
+            redacted_device_token_id("ffeeddccbbaa99887766554433221100"),
+            "<redacted_device_token>"
+        );
     }
 
     #[test]
@@ -963,9 +963,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = client
-            .handle_response(Instant::now(), response, "sha256:test")
-            .await;
+        let result = client.handle_response(Instant::now(), response).await;
 
         assert!(matches!(
             result,

--- a/src/push/dispatcher.rs
+++ b/src/push/dispatcher.rs
@@ -573,6 +573,7 @@ mod tests {
             private_key_path: String::new(),
             environment: "sandbox".to_string(),
             bundle_id: "com.example.app".to_string(),
+            payload_mode: Default::default(),
         };
 
         let apns_client = ApnsClient::mock(config, true);
@@ -639,6 +640,7 @@ mod tests {
             private_key_path: String::new(),
             environment: "sandbox".to_string(),
             bundle_id: "com.example.app".to_string(),
+            payload_mode: Default::default(),
         };
         let apns_client = ApnsClient::mock(apns_config, true);
         let dispatcher = PushDispatcher::new(Some(apns_client), None);
@@ -689,6 +691,7 @@ mod tests {
             private_key_path: String::new(),
             environment: "sandbox".to_string(),
             bundle_id: "com.example.app".to_string(),
+            payload_mode: Default::default(),
         };
         let apns_client = ApnsClient::mock(apns_config, true);
 
@@ -762,6 +765,7 @@ mod tests {
             private_key_path: String::new(),
             environment: "sandbox".to_string(),
             bundle_id: "com.example.app".to_string(),
+            payload_mode: Default::default(),
         };
 
         let metrics = Metrics::default();
@@ -806,6 +810,7 @@ mod tests {
             private_key_path: String::new(),
             environment: "sandbox".to_string(),
             bundle_id: "com.example.app".to_string(),
+            payload_mode: Default::default(),
         };
         let apns_client = ApnsClient::mock(apns_config, true);
 
@@ -836,6 +841,7 @@ mod tests {
             private_key_path: String::new(),
             environment: "sandbox".to_string(),
             bundle_id: String::new(),
+            payload_mode: Default::default(),
         };
         let apns_client = ApnsClient::mock(apns_config, false);
         let dispatcher = PushDispatcher::new(Some(apns_client), None);
@@ -885,6 +891,7 @@ mod tests {
                     private_key_path: String::new(),
                     environment: "sandbox".to_string(),
                     bundle_id: "com.example.app".to_string(),
+                    payload_mode: Default::default(),
                 },
                 true,
             )),
@@ -942,6 +949,7 @@ mod tests {
                     private_key_path: String::new(),
                     environment: "sandbox".to_string(),
                     bundle_id: "com.example.app".to_string(),
+                    payload_mode: Default::default(),
                 },
                 true,
             )),
@@ -980,6 +988,7 @@ mod tests {
                     private_key_path: String::new(),
                     environment: "sandbox".to_string(),
                     bundle_id: "com.example.app".to_string(),
+                    payload_mode: Default::default(),
                 },
                 true,
             )),
@@ -1036,6 +1045,7 @@ mod tests {
             private_key_path: String::new(),
             environment: "sandbox".to_string(),
             bundle_id: "com.example.app".to_string(),
+            payload_mode: Default::default(),
         };
         let apns_client = ApnsClient::mock(apns_config, true);
         let dispatcher = PushDispatcher::new(Some(apns_client), None);
@@ -1057,6 +1067,7 @@ mod tests {
             private_key_path: String::new(),
             environment: "sandbox".to_string(),
             bundle_id: "com.example.app".to_string(),
+            payload_mode: Default::default(),
         };
         let dispatcher = Arc::new(PushDispatcher::new(
             Some(ApnsClient::mock(apns_config, true)),
@@ -1115,6 +1126,7 @@ mod tests {
             private_key_path: String::new(),
             environment: "sandbox".to_string(),
             bundle_id: "com.example.app".to_string(),
+            payload_mode: Default::default(),
         };
         let apns_client = ApnsClient::mock(apns_config, true);
         let metrics = Metrics::default();

--- a/src/server/health.rs
+++ b/src/server/health.rs
@@ -549,6 +549,7 @@ mod tests {
             private_key_path: String::new(),
             environment: "sandbox".to_string(),
             bundle_id: "com.example.app".to_string(),
+            payload_mode: Default::default(),
         };
         let apns_client = ApnsClient::mock(apns_config, true);
         let push_dispatcher = Arc::new(PushDispatcher::new(Some(apns_client), None));


### PR DESCRIPTION
## Summary
- Added `apns.payload_mode` with a default of `silent` and explicit support for `nse_prototype_alert`.
- Preserved the existing silent APNS request shape exactly, while the NSE probe mode now sends an alert push with `mutable-content: 1`, `sound: default`, and the `wn_nse_prototype` marker.
- Kept the APNS topic on `config.apns.bundle_id`, added mode/response logs with redacted token identity, and left FCM untouched.
- Updated config docs/examples so production stays silent by default.

## Testing
- Added unit coverage for default parsing, explicit NSE mode parsing, and rejection of unknown payload modes.
- Added request-building tests for both silent and NSE probe APNS payloads and headers.
- Ran `cargo test` and `just ci` successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable APNs payload mode (default "silent") with an alternative NSE prototype alert mode for staging.

* **Documentation**
  * README updated with payload mode guidance and corresponding environment variable example.

* **Bug Fixes**
  * Device tokens redacted in debug logs to improve privacy.

* **Tests**
  * Updated and added tests covering payload mode behavior and request payloads.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marmot-protocol/transponder/pull/59)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->