### PR TITLE
Accept kind 446 triggers without encoding tag

### DIFF
--- a/src/crypto/nip59.rs
+++ b/src/crypto/nip59.rs
@@ -93,7 +93,7 @@ impl Nip59Handler {
 pub struct UnwrappedNotification {
     /// Content containing encrypted tokens as a single base64 blob.
     pub content: String,
-    /// Rumor tags used for versioning and content encoding validation.
+    /// Rumor tags used for versioning and optional content encoding validation.
     pub tags: Tags,
     /// When the rumor was created.
     pub created_at: Timestamp,
@@ -134,6 +134,26 @@ impl UnwrappedNotification {
         Ok(())
     }
 
+    /// Returns the value of the first `encoding` tag, if present.
+    fn find_encoding_tag_value(&self) -> Option<&str> {
+        self.tags
+            .iter()
+            .find(|tag| tag.kind() == TagKind::custom(TAG_ENCODING))
+            .and_then(|tag| tag.content())
+    }
+
+    /// Validates an optional `encoding` tag.
+    ///
+    /// Absent tag defaults to base64 (current MIP-05 / Darkmatter spec).
+    fn validate_encoding_tag(&self) -> Result<()> {
+        match self.find_encoding_tag_value() {
+            None | Some(ENCODING_BASE64) => Ok(()),
+            Some(value) => Err(Error::InvalidToken(format!(
+                "Unsupported encoding tag value: {value}"
+            ))),
+        }
+    }
+
     /// Parse the encrypted tokens from the content.
     ///
     /// The content is expected to be a single RFC 4648 standard base64 string
@@ -153,7 +173,7 @@ impl UnwrappedNotification {
         use base64::prelude::*;
 
         self.require_tag_value(TAG_VERSION, VERSION_MIP05_V1)?;
-        self.require_tag_value(TAG_ENCODING, ENCODING_BASE64)?;
+        self.validate_encoding_tag()?;
 
         let max_encoded_len = max_encoded_token_blob_len(max_tokens);
         if self.content.len() > max_encoded_len {
@@ -195,7 +215,11 @@ mod tests {
         format!("exceeds maximum of {max_tokens} tokens")
     }
 
-    fn valid_tags() -> Tags {
+    fn version_only_tags() -> Tags {
+        Tags::parse([[TAG_VERSION, VERSION_MIP05_V1]]).unwrap()
+    }
+
+    fn valid_tags_with_encoding() -> Tags {
         Tags::parse([
             [TAG_VERSION, VERSION_MIP05_V1],
             [TAG_ENCODING, ENCODING_BASE64],
@@ -206,7 +230,15 @@ mod tests {
     fn notification(content: String) -> UnwrappedNotification {
         UnwrappedNotification {
             content,
-            tags: valid_tags(),
+            tags: version_only_tags(),
+            created_at: Timestamp::now(),
+        }
+    }
+
+    fn notification_with_encoding(content: String) -> UnwrappedNotification {
+        UnwrappedNotification {
+            content,
+            tags: valid_tags_with_encoding(),
             created_at: Timestamp::now(),
         }
     }
@@ -398,6 +430,26 @@ mod tests {
         let result = notification.parse_tokens();
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("not a multiple"));
+    }
+
+    #[test]
+    fn test_parse_succeeds_without_encoding_tag() {
+        let token = vec![0x01; ENCRYPTED_TOKEN_SIZE];
+        let notification = notification(BASE64_STANDARD.encode(&token));
+
+        let tokens = notification.parse_tokens().unwrap();
+        assert_eq!(tokens.len(), 1);
+        assert_eq!(tokens[0], token);
+    }
+
+    #[test]
+    fn test_parse_succeeds_with_encoding_tag() {
+        let token = vec![0x01; ENCRYPTED_TOKEN_SIZE];
+        let notification = notification_with_encoding(BASE64_STANDARD.encode(&token));
+
+        let tokens = notification.parse_tokens().unwrap();
+        assert_eq!(tokens.len(), 1);
+        assert_eq!(tokens[0], token);
     }
 
     #[test]

--- a/src/crypto/nip59.rs
+++ b/src/crypto/nip59.rs
@@ -134,24 +134,32 @@ impl UnwrappedNotification {
         Ok(())
     }
 
-    /// Returns the value of the first `encoding` tag, if present.
-    fn find_encoding_tag_value(&self) -> Option<&str> {
-        self.tags
-            .iter()
-            .find(|tag| tag.kind() == TagKind::custom(TAG_ENCODING))
-            .and_then(|tag| tag.content())
-    }
-
     /// Validates an optional `encoding` tag.
     ///
-    /// Absent tag defaults to base64 (current MIP-05 / Darkmatter spec).
+    /// Zero `encoding` tags defaults to base64 (current Darkmatter / Marmot spec).
+    /// If present, every `encoding` tag must carry the value `base64`.
     fn validate_encoding_tag(&self) -> Result<()> {
-        match self.find_encoding_tag_value() {
-            None | Some(ENCODING_BASE64) => Ok(()),
-            Some(value) => Err(Error::InvalidToken(format!(
-                "Unsupported encoding tag value: {value}"
-            ))),
+        for tag in self
+            .tags
+            .iter()
+            .filter(|tag| tag.kind() == TagKind::custom(TAG_ENCODING))
+        {
+            match tag.content() {
+                Some(ENCODING_BASE64) => {}
+                Some(value) => {
+                    return Err(Error::InvalidToken(format!(
+                        "Unsupported encoding tag value: {value}"
+                    )));
+                }
+                None => {
+                    return Err(Error::InvalidToken(
+                        "Missing value for encoding tag".to_string(),
+                    ));
+                }
+            }
         }
+
+        Ok(())
     }
 
     /// Parse the encrypted tokens from the content.
@@ -450,6 +458,49 @@ mod tests {
         let tokens = notification.parse_tokens().unwrap();
         assert_eq!(tokens.len(), 1);
         assert_eq!(tokens[0], token);
+    }
+
+    #[test]
+    fn test_parse_rejects_malformed_encoding_tag_missing_value() {
+        let notification = UnwrappedNotification {
+            content: BASE64_STANDARD.encode(vec![0x01; ENCRYPTED_TOKEN_SIZE]),
+            tags: Tags::from_list(vec![
+                Tag::parse([TAG_VERSION, VERSION_MIP05_V1]).unwrap(),
+                Tag::parse([TAG_ENCODING]).unwrap(),
+            ]),
+            created_at: Timestamp::now(),
+        };
+
+        let result = notification.parse_tokens();
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Missing value for encoding tag")
+        );
+    }
+
+    #[test]
+    fn test_parse_rejects_duplicate_conflicting_encoding_tags() {
+        let notification = UnwrappedNotification {
+            content: BASE64_STANDARD.encode(vec![0x01; ENCRYPTED_TOKEN_SIZE]),
+            tags: Tags::from_list(vec![
+                Tag::parse([TAG_VERSION, VERSION_MIP05_V1]).unwrap(),
+                Tag::parse([TAG_ENCODING, ENCODING_BASE64]).unwrap(),
+                Tag::parse([TAG_ENCODING, "hex"]).unwrap(),
+            ]),
+            created_at: Timestamp::now(),
+        };
+
+        let result = notification.parse_tokens();
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Unsupported encoding tag value")
+        );
     }
 
     #[test]

--- a/src/test_vectors.rs
+++ b/src/test_vectors.rs
@@ -290,17 +290,19 @@ impl GiftWrapBuilder {
         }
     }
 
-    /// Build a gift-wrapped notification request event.
+    /// Build a gift-wrapped notification request event (MIP-05 spec shape).
     ///
     /// # Arguments
     /// * `content` - The base64 content (concatenated encrypted tokens)
     pub async fn build(&self, content: &str) -> Event {
-        self.build_with_tags(content, false).await
+        self.build_with_tags(content, true).await
     }
 
-    /// Build a gift-wrapped notification request with the legacy `encoding=base64` tag.
-    pub async fn build_with_legacy_encoding_tag(&self, content: &str) -> Event {
-        self.build_with_tags(content, true).await
+    /// Build a gift-wrapped notification request without the `encoding` tag.
+    ///
+    /// Matches the Darkmatter / Marmot compatibility shape.
+    pub async fn build_without_encoding_tag(&self, content: &str) -> Event {
+        self.build_with_tags(content, false).await
     }
 
     async fn build_with_tags(&self, content: &str, include_encoding_tag: bool) -> Event {
@@ -496,7 +498,7 @@ mod tests {
             .build();
 
         let gift_wrap = GiftWrapBuilder::new(server_keys.clone(), sender_keys.clone())
-            .build(&content)
+            .build_without_encoding_tag(&content)
             .await;
 
         let handler = Nip59Handler::new(server_keys.clone());
@@ -508,7 +510,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_gift_wrap_unwrap_roundtrip_with_legacy_encoding_tag() {
+    async fn test_gift_wrap_unwrap_roundtrip() {
         use crate::crypto::Nip59Handler;
 
         let server_keys = Keys::generate();
@@ -519,7 +521,7 @@ mod tests {
             .build();
 
         let gift_wrap = GiftWrapBuilder::new(server_keys.clone(), sender_keys.clone())
-            .build_with_legacy_encoding_tag(&content)
+            .build(&content)
             .await;
 
         let handler = Nip59Handler::new(server_keys.clone());

--- a/src/test_vectors.rs
+++ b/src/test_vectors.rs
@@ -294,6 +294,7 @@ impl GiftWrapBuilder {
     ///
     /// # Arguments
     /// * `content` - The base64 content (concatenated encrypted tokens)
+    #[must_use = "event must be used or creation effort is wasted"]
     pub async fn build(&self, content: &str) -> Event {
         self.build_with_tags(content, true).await
     }
@@ -301,6 +302,7 @@ impl GiftWrapBuilder {
     /// Build a gift-wrapped notification request without the `encoding` tag.
     ///
     /// Matches the Darkmatter / Marmot compatibility shape.
+    #[must_use = "event must be used or creation effort is wasted"]
     pub async fn build_without_encoding_tag(&self, content: &str) -> Event {
         self.build_with_tags(content, false).await
     }

--- a/src/test_vectors.rs
+++ b/src/test_vectors.rs
@@ -304,7 +304,8 @@ impl GiftWrapBuilder {
     }
 
     async fn build_with_tags(&self, content: &str, include_encoding_tag: bool) -> Event {
-        let mut tags = vec![Tag::parse([TAG_VERSION, VERSION_MIP05_V1]).expect("valid version tag")];
+        let mut tags =
+            vec![Tag::parse([TAG_VERSION, VERSION_MIP05_V1]).expect("valid version tag")];
         if include_encoding_tag {
             tags.push(Tag::parse([TAG_ENCODING, ENCODING_BASE64]).expect("valid encoding tag"));
         }

--- a/src/test_vectors.rs
+++ b/src/test_vectors.rs
@@ -295,12 +295,23 @@ impl GiftWrapBuilder {
     /// # Arguments
     /// * `content` - The base64 content (concatenated encrypted tokens)
     pub async fn build(&self, content: &str) -> Event {
+        self.build_with_tags(content, false).await
+    }
+
+    /// Build a gift-wrapped notification request with the legacy `encoding=base64` tag.
+    pub async fn build_with_legacy_encoding_tag(&self, content: &str) -> Event {
+        self.build_with_tags(content, true).await
+    }
+
+    async fn build_with_tags(&self, content: &str, include_encoding_tag: bool) -> Event {
+        let mut tags = vec![Tag::parse([TAG_VERSION, VERSION_MIP05_V1]).expect("valid version tag")];
+        if include_encoding_tag {
+            tags.push(Tag::parse([TAG_ENCODING, ENCODING_BASE64]).expect("valid encoding tag"));
+        }
+
         // Create the kind 446 rumor (unsigned event)
-        let rumor_builder = EventBuilder::new(Kind::Custom(KIND_NOTIFICATION_REQUEST), content)
-            .tags([
-                Tag::parse([TAG_VERSION, VERSION_MIP05_V1]).expect("valid version tag"),
-                Tag::parse([TAG_ENCODING, ENCODING_BASE64]).expect("valid encoding tag"),
-            ]);
+        let rumor_builder =
+            EventBuilder::new(Kind::Custom(KIND_NOTIFICATION_REQUEST), content).tags(tags);
 
         // Build the unsigned event (rumor)
         let rumor = rumor_builder.build(self.sender_keys.public_key());
@@ -473,27 +484,46 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_gift_wrap_unwrap_roundtrip() {
+    async fn test_gift_wrap_unwrap_roundtrip_without_encoding_tag() {
         use crate::crypto::Nip59Handler;
 
         let server_keys = Keys::generate();
         let sender_keys = Keys::generate();
 
-        // Create notification content
         let content = NotificationContentBuilder::new(&server_keys)
             .with_apns_token("deadbeef1234567890abcdefdeadbeef1234567890abcdefdeadbeef12345678")
             .build();
 
-        // Create gift wrap
         let gift_wrap = GiftWrapBuilder::new(server_keys.clone(), sender_keys.clone())
             .build(&content)
             .await;
 
-        // Unwrap it
         let handler = Nip59Handler::new(server_keys.clone());
         let unwrapped = handler.unwrap(&gift_wrap).await.unwrap();
 
-        // Verify content is parseable
+        let tokens = unwrapped.parse_tokens().unwrap();
+        assert_eq!(tokens.len(), 1);
+        assert_eq!(tokens[0].len(), ENCRYPTED_TOKEN_SIZE);
+    }
+
+    #[tokio::test]
+    async fn test_gift_wrap_unwrap_roundtrip_with_legacy_encoding_tag() {
+        use crate::crypto::Nip59Handler;
+
+        let server_keys = Keys::generate();
+        let sender_keys = Keys::generate();
+
+        let content = NotificationContentBuilder::new(&server_keys)
+            .with_apns_token("deadbeef1234567890abcdefdeadbeef1234567890abcdefdeadbeef12345678")
+            .build();
+
+        let gift_wrap = GiftWrapBuilder::new(server_keys.clone(), sender_keys.clone())
+            .build_with_legacy_encoding_tag(&content)
+            .await;
+
+        let handler = Nip59Handler::new(server_keys.clone());
+        let unwrapped = handler.unwrap(&gift_wrap).await.unwrap();
+
         let tokens = unwrapped.parse_tokens().unwrap();
         assert_eq!(tokens.len(), 1);
         assert_eq!(tokens[0].len(), ENCRYPTED_TOKEN_SIZE);


### PR DESCRIPTION
## Summary
- Make the `encoding` tag optional when parsing kind 446 notification rumors, defaulting to base64 per current MIP-05 / Darkmatter spec
- Keep backward compatibility for legacy senders that include `encoding=base64`
- Update test vectors to build Marmot-shaped gift wraps (version tag only) and add legacy encoding coverage

## Test plan
- [x] `cargo test` — all 315 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [ ] Deploy and send a message to a backgrounded iOS device; confirm transponder parses tokens and attempts APNS delivery (no "Missing required encoding tag" error)


Made with [Cursor](https://cursor.com)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/transponder/pull/69">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made the legacy `encoding` tag optional when parsing wrapped notifications; missing tags default to `base64`.
  * Rejects wrapped notifications with invalid `encoding` values, malformed tags, or conflicting duplicate `encoding` entries.

* **New Features**
  * Enhanced gift-wrap event generation to support a legacy `encoding=base64` tag:
    * Gift wraps can be built without the tag.
    * Added an option to include the legacy encoding tag.

* **Tests**
  * Split gift-wrap unwrap coverage into separate success cases with and without the `encoding` tag, plus added negative validation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->