### PR TITLE
fix: obtain relay notification receiver before subscribing (#67)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -275,6 +275,17 @@ async fn main() -> Result<()> {
         .await
         .context("Failed to connect to relays")?;
 
+    // Obtain the broadcast receiver BEFORE issuing the subscription REQ.
+    //
+    // `notifications()` returns a fresh `tokio::sync::broadcast::Receiver`, which
+    // only observes messages broadcast after it is created. The subscription uses a
+    // 2-day lookback, so relays immediately stream the stored backlog of gift wraps.
+    // If the receiver were created after `subscribe()` (e.g. inside the spawned event
+    // task), any backlog delivered before the task is first polled would be broadcast
+    // to zero receivers and silently dropped — broadcast channels do not replay
+    // history. Creating the receiver first closes that startup window entirely.
+    let mut notifications = relay_client.notifications();
+
     // Subscribe to events
     relay_client
         .subscribe(keys.public_key())
@@ -318,12 +329,9 @@ async fn main() -> Result<()> {
     // Start event processing loop
     let mut event_shutdown = shutdown.subscribe();
     let event_processor_clone = event_processor.clone();
-    let relay_client_clone = relay_client.clone();
     let event_metrics = metrics.clone();
 
     let event_handle = tokio::spawn(async move {
-        let mut notifications = relay_client_clone.notifications();
-
         loop {
             tokio::select! {
                 _ = event_shutdown.changed() => {


### PR DESCRIPTION
Closes #67

## Summary

On startup the server sent the subscription `REQ` to relays **before** the spawned event task obtained the `broadcast::Receiver` it reads from. The `nostr-sdk` notification channel is a `tokio::sync::broadcast`, which only delivers messages broadcast *after* a receiver is created and does **not** replay history. Combined with the 2-day lookback (`NIP59_TIMESTAMP_TWEAK_WINDOW_SECS`), relays stream the stored backlog of kind-1059 gift wraps immediately after the REQ — so any backlog event arriving before the spawned task was first polled (and called `notifications()`) was broadcast to zero relevant receivers and silently dropped. A latent, timing-dependent correctness race (hence LOW).

## Fix

Obtain the receiver in `main()` **before** issuing the subscription, then move it into the event task. This removes the window where events can be broadcast without a live consumer. Pure ordering change — no behavioral difference otherwise.

```
let mut notifications = relay_client.notifications();   // receiver live first
relay_client.subscribe(keys.public_key()).await?;       // then send REQ
// ... notifications moved into the spawned event task
```

Diff: `src/main.rs` only — 11 insertions, 3 deletions (net +8 is an explanatory comment).

## Verification (local, CI's exact commands)

- `cargo fmt --all -- --check` — pass
- `cargo clippy --all-targets -- -D warnings` (RUSTFLAGS=-Dwarnings) — pass
- `cargo test --all-targets` — 317 + 4 integration tests pass, 0 failed
- `cargo check --all-targets` — covered by clippy all-targets compile
- audit (`./scripts/cargo-audit.sh`): `Cargo.lock` unchanged from master, so the dependency advisory status is identical — not re-run locally (cargo-audit not installed on this host; CI installs and runs it).
- `tor` feature / `doc` jobs unaffected (no feature-gated code, no doc-comment/public-API change).

## Sensitive paths

None. Only `src/main.rs` is touched. `src/nostr/**` (sensitive) is untouched — the fix is a reordering in startup wiring, not a change to the `RelayClient` API or crypto/nostr internals.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/transponder/pull/73">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->