### PR TITLE
fix: bound event concurrency and add pre-unwrap admission control (#61)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ shutdown_timeout_secs = 10
 # device_token_rate_limit_per_minute = 240     # Per device (spam protection)
 # device_token_rate_limit_per_hour = 5000
 
+# CPU-exhaustion DoS protection (admission control before gift-wrap unwrap)
+# max_concurrent_event_processing = 64            # Bounds in-flight unwrap (ECDH) work
+# global_unwrap_rate_limit_per_minute = 600       # Global pre-unwrap throttle (all senders)
+# global_unwrap_rate_limit_per_hour = 30000
+
 [relays]
 # ClearNet relays to subscribe to
 clearnet = [
@@ -363,6 +368,7 @@ Transponder exposes Prometheus metrics at `/metrics` on the health server port (
 | `transponder_events_processed_total` | Counter | - | Total events successfully processed |
 | `transponder_events_deduplicated_total` | Counter | - | Total events skipped (already processed) |
 | `transponder_events_failed_total` | Counter | - | Total events that failed processing |
+| `transponder_events_shed_total` | Counter | - | Total events shed by global admission control before the gift-wrap unwrap (ECDH) was attempted |
 | `transponder_events_in_flight` | Gauge | - | Current number of events actively being processed |
 | `transponder_event_processing_duration_seconds` | Histogram | `outcome` | End-to-end duration of event processing |
 | `transponder_gift_wrap_unwrap_duration_seconds` | Histogram | `outcome` | Duration of NIP-59 gift-wrap unwraps |

--- a/config/default.toml
+++ b/config/default.toml
@@ -47,6 +47,26 @@ shutdown_timeout_secs = 10
 # Default: 5000
 # device_token_rate_limit_per_hour = 5000
 
+# Maximum number of events processed concurrently.
+# Bounds total in-flight gift-wrap unwrap (ECDH) work. The relay event loop
+# admits up to this many events at once and applies back-pressure beyond it,
+# draining the relay channel fast enough to avoid dropping legitimate events
+# while capping CPU spent on asymmetric crypto under a flood.
+# Default: 64
+# max_concurrent_event_processing = 64
+
+# Global pre-unwrap admission control (CPU-exhaustion DoS protection).
+# Checked BEFORE the gift-wrap unwrap (ECDH), across ALL senders, using a single
+# global budget. The server pubkey is public and gift wraps are sender-anonymous,
+# so a cheap global throttle sheds floods before spending asymmetric-crypto
+# cycles. Set well above legitimate single-server load.
+# Default: 600 (10 per second)
+# global_unwrap_rate_limit_per_minute = 600
+
+# Global pre-unwrap admission control: max unwraps per hour across all senders.
+# Default: 30000
+# global_unwrap_rate_limit_per_hour = 30000
+
 [relays]
 # ClearNet relays to subscribe to
 clearnet = [

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,7 @@ use zeroize::Zeroizing;
 use crate::crypto::nip59::DEFAULT_MAX_TOKENS_PER_EVENT;
 use crate::error::Result;
 use crate::rate_limiter::{
+    DEFAULT_GLOBAL_UNWRAP_LIMIT_PER_HOUR, DEFAULT_GLOBAL_UNWRAP_LIMIT_PER_MINUTE,
     DEFAULT_MAX_SIZE as DEFAULT_MAX_RATE_LIMIT_CACHE_SIZE, DEFAULT_RATE_LIMIT_PER_HOUR,
     DEFAULT_RATE_LIMIT_PER_MINUTE,
 };
@@ -50,8 +51,27 @@ const DEFAULT_MAX_DEDUP_CACHE_SIZE: usize = 100_000;
 const DEFAULT_HEALTH_BIND_ADDRESS: &str = "127.0.0.1:8080";
 const ENV_PREFIX: &str = "TRANSPONDER_";
 
+/// Default maximum number of events processed concurrently.
+///
+/// Caps the total in-flight gift-wrap unwrap (ECDH) work so a flood cannot
+/// spawn unbounded crypto tasks, while still draining the relay broadcast
+/// channel quickly enough to avoid `Lagged` overflow.
+const DEFAULT_MAX_CONCURRENT_EVENT_PROCESSING: usize = 64;
+
 fn default_max_dedup_cache_size() -> usize {
     DEFAULT_MAX_DEDUP_CACHE_SIZE
+}
+
+fn default_max_concurrent_event_processing() -> usize {
+    DEFAULT_MAX_CONCURRENT_EVENT_PROCESSING
+}
+
+fn default_global_unwrap_rate_limit_per_minute() -> u32 {
+    DEFAULT_GLOBAL_UNWRAP_LIMIT_PER_MINUTE
+}
+
+fn default_global_unwrap_rate_limit_per_hour() -> u32 {
+    DEFAULT_GLOBAL_UNWRAP_LIMIT_PER_HOUR
 }
 
 fn default_max_rate_limit_cache_size() -> usize {
@@ -130,6 +150,31 @@ pub struct ServerConfig {
     /// Default: 5,000.
     #[serde(default = "default_rate_limit_per_hour")]
     pub device_token_rate_limit_per_hour: u32,
+
+    /// Maximum number of events processed concurrently.
+    ///
+    /// Bounds total in-flight gift-wrap unwrap (ECDH) work. The relay event
+    /// loop admits up to this many events at once; excess events wait for a
+    /// permit. This drains the broadcast channel quickly (avoiding `Lagged`
+    /// overflow) while capping CPU spent on asymmetric crypto.
+    /// Default: 64.
+    #[serde(default = "default_max_concurrent_event_processing")]
+    pub max_concurrent_event_processing: usize,
+
+    /// Global maximum gift-wrap unwraps (ECDH) per minute, across all senders.
+    ///
+    /// Cheap admission control checked BEFORE the gift-wrap unwrap. The server
+    /// pubkey is public and gift wraps are sender-anonymous, so this global
+    /// throttle sheds floods before spending asymmetric-crypto cycles.
+    /// Default: 600 (10 per second).
+    #[serde(default = "default_global_unwrap_rate_limit_per_minute")]
+    pub global_unwrap_rate_limit_per_minute: u32,
+
+    /// Global maximum gift-wrap unwraps (ECDH) per hour, across all senders.
+    ///
+    /// Default: 30,000.
+    #[serde(default = "default_global_unwrap_rate_limit_per_hour")]
+    pub global_unwrap_rate_limit_per_hour: u32,
 }
 
 impl std::fmt::Debug for ServerConfig {
@@ -156,6 +201,18 @@ impl std::fmt::Debug for ServerConfig {
             .field(
                 "device_token_rate_limit_per_hour",
                 &self.device_token_rate_limit_per_hour,
+            )
+            .field(
+                "max_concurrent_event_processing",
+                &self.max_concurrent_event_processing,
+            )
+            .field(
+                "global_unwrap_rate_limit_per_minute",
+                &self.global_unwrap_rate_limit_per_minute,
+            )
+            .field(
+                "global_unwrap_rate_limit_per_hour",
+                &self.global_unwrap_rate_limit_per_hour,
             )
             .finish()
     }
@@ -395,6 +452,18 @@ fn base_config_builder() -> Result<ConfigBuilder<DefaultState>> {
             "server.device_token_rate_limit_per_hour",
             DEFAULT_RATE_LIMIT_PER_HOUR as i64,
         )?
+        .set_default(
+            "server.max_concurrent_event_processing",
+            DEFAULT_MAX_CONCURRENT_EVENT_PROCESSING as i64,
+        )?
+        .set_default(
+            "server.global_unwrap_rate_limit_per_minute",
+            DEFAULT_GLOBAL_UNWRAP_LIMIT_PER_MINUTE as i64,
+        )?
+        .set_default(
+            "server.global_unwrap_rate_limit_per_hour",
+            DEFAULT_GLOBAL_UNWRAP_LIMIT_PER_HOUR as i64,
+        )?
         .set_default("relays.clearnet", Vec::<String>::new())?
         .set_default("relays.allow_unencrypted_clearnet_relays", false)?
         .set_default("relays.onion", Vec::<String>::new())?
@@ -502,6 +571,9 @@ fn is_supported_config_key(config_key: &str) -> bool {
                 | "server.encrypted_token_rate_limit_per_hour"
                 | "server.device_token_rate_limit_per_minute"
                 | "server.device_token_rate_limit_per_hour"
+                | "server.max_concurrent_event_processing"
+                | "server.global_unwrap_rate_limit_per_minute"
+                | "server.global_unwrap_rate_limit_per_hour"
                 | "relays.allow_unencrypted_clearnet_relays"
                 | "relays.reconnect_interval_secs"
                 | "relays.max_reconnect_attempts"
@@ -643,6 +715,9 @@ mod tests {
             encrypted_token_rate_limit_per_hour: 5000,
             device_token_rate_limit_per_minute: 240,
             device_token_rate_limit_per_hour: 5000,
+            max_concurrent_event_processing: 64,
+            global_unwrap_rate_limit_per_minute: 600,
+            global_unwrap_rate_limit_per_hour: 30_000,
         }
     }
 
@@ -1053,6 +1128,9 @@ mod tests {
         assert_eq!(default_max_tokens_per_event(), DEFAULT_MAX_TOKENS_PER_EVENT);
         assert_eq!(default_rate_limit_per_minute(), 240);
         assert_eq!(default_rate_limit_per_hour(), 5000);
+        assert_eq!(default_max_concurrent_event_processing(), 64);
+        assert_eq!(default_global_unwrap_rate_limit_per_minute(), 600);
+        assert_eq!(default_global_unwrap_rate_limit_per_hour(), 30_000);
     }
 
     #[test]
@@ -1178,6 +1256,9 @@ mod tests {
         assert_eq!(config.server.device_token_rate_limit_per_minute, 240);
         assert_eq!(config.server.device_token_rate_limit_per_hour, 5000);
         assert_eq!(config.server.max_tokens_per_event, 100);
+        assert_eq!(config.server.max_concurrent_event_processing, 64);
+        assert_eq!(config.server.global_unwrap_rate_limit_per_minute, 600);
+        assert_eq!(config.server.global_unwrap_rate_limit_per_hour, 30_000);
     }
 
     #[test]
@@ -1190,6 +1271,9 @@ mod tests {
             encrypted_token_rate_limit_per_hour = 2000
             device_token_rate_limit_per_minute = 50
             device_token_rate_limit_per_hour = 1000
+            max_concurrent_event_processing = 32
+            global_unwrap_rate_limit_per_minute = 300
+            global_unwrap_rate_limit_per_hour = 15000
         "#;
 
         let file = create_temp_config(config_content);
@@ -1200,5 +1284,28 @@ mod tests {
         assert_eq!(config.server.device_token_rate_limit_per_minute, 50);
         assert_eq!(config.server.device_token_rate_limit_per_hour, 1000);
         assert_eq!(config.server.max_tokens_per_event, 25);
+        assert_eq!(config.server.max_concurrent_event_processing, 32);
+        assert_eq!(config.server.global_unwrap_rate_limit_per_minute, 300);
+        assert_eq!(config.server.global_unwrap_rate_limit_per_hour, 15_000);
+    }
+
+    #[test]
+    fn test_global_unwrap_admission_env_overrides() {
+        let config = from_test_env(&[
+            ("TRANSPONDER_SERVER_MAX_CONCURRENT_EVENT_PROCESSING", "16"),
+            (
+                "TRANSPONDER_SERVER_GLOBAL_UNWRAP_RATE_LIMIT_PER_MINUTE",
+                "120",
+            ),
+            (
+                "TRANSPONDER_SERVER_GLOBAL_UNWRAP_RATE_LIMIT_PER_HOUR",
+                "7200",
+            ),
+        ])
+        .unwrap();
+
+        assert_eq!(config.server.max_concurrent_event_processing, 16);
+        assert_eq!(config.server.global_unwrap_rate_limit_per_minute, 120);
+        assert_eq!(config.server.global_unwrap_rate_limit_per_hour, 7200);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ use std::{
 use anyhow::{Context, Result};
 use clap::Parser;
 use nostr_sdk::prelude::*;
+use tokio::sync::Semaphore;
 use tokio::sync::broadcast::error::RecvError;
 use tracing::{debug, error, info, warn};
 use tracing_subscriber::{EnvFilter, fmt, prelude::*};
@@ -128,11 +129,23 @@ fn build_rate_limit_config(server: &config::ServerConfig) -> nostr::events::Toke
         encrypted_token_per_hour: server.encrypted_token_rate_limit_per_hour,
         device_token_per_minute: server.device_token_rate_limit_per_minute,
         device_token_per_hour: server.device_token_rate_limit_per_hour,
+        global_unwrap_per_minute: server.global_unwrap_rate_limit_per_minute,
+        global_unwrap_per_hour: server.global_unwrap_rate_limit_per_hour,
     }
 }
 
 fn parse_server_secret_key(server_private_key: &str) -> Result<SecretKey> {
     SecretKey::parse(server_private_key).context("Invalid server private key")
+}
+
+/// Number of permits to use for the event-processing semaphore.
+///
+/// Bounds total in-flight gift-wrap unwrap (ECDH) work. A configured value of
+/// zero would deadlock the event loop (no permit could ever be acquired), so it
+/// is clamped up to a single permit, preserving sequential processing.
+#[must_use]
+fn event_processing_permits(max_concurrent_event_processing: usize) -> usize {
+    max_concurrent_event_processing.max(1)
 }
 
 #[tokio::main]
@@ -328,8 +341,21 @@ async fn main() -> Result<()> {
 
     // Start event processing loop
     let mut event_shutdown = shutdown.subscribe();
-    let event_processor_clone = event_processor.clone();
     let event_metrics = metrics.clone();
+
+    // Bounded-concurrency dispatch.
+    //
+    // Each admitted event is processed in its own spawned task, gated by a
+    // semaphore. The receive loop drains the broadcast channel quickly so it
+    // does not fall behind and trigger `Lagged` overflow, while the semaphore
+    // caps total in-flight gift-wrap unwrap (ECDH) work so a flood cannot spawn
+    // unbounded crypto tasks. An owned permit is acquired BEFORE spawning and
+    // dropped when the spawned task finishes; when the budget is exhausted the
+    // loop awaits a free permit (applying back-pressure) but still consumes
+    // events promptly once a slot frees.
+    let event_permits = event_processing_permits(config.server.max_concurrent_event_processing);
+    let event_semaphore = Arc::new(Semaphore::new(event_permits));
+    let event_processor_loop = event_processor.clone();
 
     let event_handle = tokio::spawn(async move {
         loop {
@@ -341,11 +367,28 @@ async fn main() -> Result<()> {
                 result = notifications.recv() => {
                     match result {
                         Ok(notification) => {
-                            if let RelayPoolNotification::Event { event, .. } = notification
-                                && let Err(e) = event_processor_clone.process(&event).await
-                            {
-                                debug!(error = %e, "Event processing error");
-                            }
+                            let RelayPoolNotification::Event { event, .. } = notification else {
+                                continue;
+                            };
+
+                            // Acquire a permit before spawning so total in-flight
+                            // unwrap work stays bounded. `acquire_owned` only errors
+                            // if the semaphore is closed, which never happens here.
+                            let Ok(permit) =
+                                Arc::clone(&event_semaphore).acquire_owned().await
+                            else {
+                                break;
+                            };
+
+                            let processor = event_processor_loop.clone();
+                            tokio::spawn(async move {
+                                // Hold the permit for the lifetime of the task; it
+                                // is released when `permit` is dropped on return.
+                                let _permit = permit;
+                                if let Err(e) = processor.process(&event).await {
+                                    debug!(error = %e, "Event processing error");
+                                }
+                            });
                         }
                         Err(e) => {
                             record_notification_receive_metrics(event_metrics.as_ref(), &e);
@@ -573,6 +616,38 @@ mod tests {
     use tokio::net::TcpListener;
 
     #[test]
+    fn event_processing_permits_clamps_zero_to_one() {
+        assert_eq!(event_processing_permits(0), 1);
+    }
+
+    #[test]
+    fn event_processing_permits_preserves_positive_values() {
+        assert_eq!(event_processing_permits(1), 1);
+        assert_eq!(event_processing_permits(64), 64);
+        assert_eq!(event_processing_permits(1000), 1000);
+    }
+
+    #[tokio::test]
+    async fn event_semaphore_caps_in_flight_permits() {
+        let permits = event_processing_permits(3);
+        let semaphore = Arc::new(Semaphore::new(permits));
+
+        // Acquire up to the cap; all succeed.
+        let p1 = Arc::clone(&semaphore).acquire_owned().await.unwrap();
+        let _p2 = Arc::clone(&semaphore).acquire_owned().await.unwrap();
+        let _p3 = Arc::clone(&semaphore).acquire_owned().await.unwrap();
+        assert_eq!(semaphore.available_permits(), 0);
+
+        // No permit is available while the cap is reached.
+        assert!(Arc::clone(&semaphore).try_acquire_owned().is_err());
+
+        // Releasing one permit frees a slot for the next event.
+        drop(p1);
+        assert_eq!(semaphore.available_permits(), 1);
+        assert!(Arc::clone(&semaphore).try_acquire_owned().is_ok());
+    }
+
+    #[test]
     fn notification_receive_lag_is_recoverable() {
         let action = classify_notification_receive_error(&RecvError::Lagged(3));
 
@@ -666,6 +741,9 @@ mod tests {
             encrypted_token_rate_limit_per_hour: 5000,
             device_token_rate_limit_per_minute: 240,
             device_token_rate_limit_per_hour: 5000,
+            max_concurrent_event_processing: 64,
+            global_unwrap_rate_limit_per_minute: 600,
+            global_unwrap_rate_limit_per_hour: 30_000,
         };
 
         assert_eq!(
@@ -691,6 +769,9 @@ mod tests {
             encrypted_token_rate_limit_per_hour: 5000,
             device_token_rate_limit_per_minute: 240,
             device_token_rate_limit_per_hour: 5000,
+            max_concurrent_event_processing: 64,
+            global_unwrap_rate_limit_per_minute: 600,
+            global_unwrap_rate_limit_per_hour: 30_000,
         };
 
         assert_eq!(
@@ -715,6 +796,9 @@ mod tests {
             encrypted_token_rate_limit_per_hour: 5000,
             device_token_rate_limit_per_minute: 240,
             device_token_rate_limit_per_hour: 5000,
+            max_concurrent_event_processing: 64,
+            global_unwrap_rate_limit_per_minute: 600,
+            global_unwrap_rate_limit_per_hour: 30_000,
         };
 
         assert_eq!(
@@ -736,6 +820,9 @@ mod tests {
             encrypted_token_rate_limit_per_hour: 5000,
             device_token_rate_limit_per_minute: 240,
             device_token_rate_limit_per_hour: 5000,
+            max_concurrent_event_processing: 64,
+            global_unwrap_rate_limit_per_minute: 600,
+            global_unwrap_rate_limit_per_hour: 30_000,
         };
 
         assert_eq!(
@@ -757,6 +844,9 @@ mod tests {
             encrypted_token_rate_limit_per_hour: 5000,
             device_token_rate_limit_per_minute: 240,
             device_token_rate_limit_per_hour: 5000,
+            max_concurrent_event_processing: 64,
+            global_unwrap_rate_limit_per_minute: 600,
+            global_unwrap_rate_limit_per_hour: 30_000,
         };
 
         let error = resolve_server_private_key(&mut config)
@@ -858,6 +948,9 @@ mod tests {
             encrypted_token_rate_limit_per_hour: 5000,
             device_token_rate_limit_per_minute: 240,
             device_token_rate_limit_per_hour: 5000,
+            max_concurrent_event_processing: 64,
+            global_unwrap_rate_limit_per_minute: 600,
+            global_unwrap_rate_limit_per_hour: 30_000,
         };
 
         let resolved_key = resolve_server_private_key(&mut config).unwrap();
@@ -879,6 +972,9 @@ mod tests {
             encrypted_token_rate_limit_per_hour: 2222,
             device_token_rate_limit_per_minute: 333,
             device_token_rate_limit_per_hour: 4444,
+            max_concurrent_event_processing: 7,
+            global_unwrap_rate_limit_per_minute: 555,
+            global_unwrap_rate_limit_per_hour: 6666,
         };
 
         let rate_limit_config = build_rate_limit_config(&server);
@@ -889,5 +985,7 @@ mod tests {
         assert_eq!(rate_limit_config.encrypted_token_per_hour, 2222);
         assert_eq!(rate_limit_config.device_token_per_minute, 333);
         assert_eq!(rate_limit_config.device_token_per_hour, 4444);
+        assert_eq!(rate_limit_config.global_unwrap_per_minute, 555);
+        assert_eq!(rate_limit_config.global_unwrap_per_hour, 6666);
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -35,6 +35,10 @@ pub struct Metrics {
     /// Total number of events that failed processing.
     pub events_failed_total: IntCounter,
 
+    /// Total number of events shed by global admission control before the
+    /// gift-wrap unwrap (ECDH) was attempted.
+    pub events_shed_total: IntCounter,
+
     /// Current number of events actively being processed.
     pub events_in_flight: IntGauge,
 
@@ -242,6 +246,12 @@ impl Metrics {
             "Total number of events that failed processing",
         ))?;
         registry.register(Box::new(events_failed_total.clone()))?;
+
+        let events_shed_total = IntCounter::with_opts(Opts::new(
+            "transponder_events_shed_total",
+            "Total number of events shed by global admission control before the gift-wrap unwrap (ECDH) was attempted",
+        ))?;
+        registry.register(Box::new(events_shed_total.clone()))?;
 
         let events_in_flight = IntGauge::with_opts(Opts::new(
             "transponder_events_in_flight",
@@ -533,6 +543,7 @@ impl Metrics {
             events_processed_total,
             events_deduplicated_total,
             events_failed_total,
+            events_shed_total,
             events_in_flight,
             event_processing_duration_seconds,
             gift_wrap_unwrap_duration_seconds,
@@ -610,6 +621,11 @@ impl Metrics {
     /// Record a failed event.
     pub fn record_event_failed(&self) {
         self.events_failed_total.inc();
+    }
+
+    /// Record an event shed by global admission control before unwrap.
+    pub fn record_event_shed(&self) {
+        self.events_shed_total.inc();
     }
 
     /// Increment the number of in-flight events.
@@ -864,6 +880,7 @@ mod tests {
         metrics.record_event_processed();
         metrics.record_event_deduplicated();
         metrics.record_event_failed();
+        metrics.record_event_shed();
         metrics.inc_events_in_flight();
         metrics.observe_event_processing_duration(EventOutcome::Processed, 0.01);
         metrics.observe_gift_wrap_unwrap_duration(OperationOutcome::Success, 0.005);
@@ -886,6 +903,10 @@ mod tests {
         );
         assert_eq!(
             counter_value(&metrics, "transponder_events_failed_total", &[]),
+            1.0
+        );
+        assert_eq!(
+            counter_value(&metrics, "transponder_events_shed_total", &[]),
             1.0
         );
         assert_eq!(

--- a/src/nostr/events.rs
+++ b/src/nostr/events.rs
@@ -225,8 +225,17 @@ impl EventProcessor {
 
         info!(event_id = %event.id, "Received Nostr notification event");
 
-        // Check for duplicates
-        if self.is_duplicate(&event.id).await {
+        // Check for duplicates and atomically reserve the event ID.
+        //
+        // The reservation (check-and-mark) happens under a single write-lock
+        // critical section so concurrent deliveries of the same event ID — now
+        // possible because the event loop in `main.rs` processes events in
+        // bounded-concurrency spawned tasks — cannot both pass the dedup gate
+        // and dispatch duplicate notifications. The reservation is rolled back
+        // (`release_reservation`) on admission shedding and on transient
+        // failures so those events remain eligible for retry, preserving the
+        // prior "not marked seen on transient failure" semantics.
+        if !self.try_reserve(event.id).await {
             trace!("Skipping duplicate event");
             if let Some(ref m) = self.metrics {
                 m.record_event_deduplicated();
@@ -248,8 +257,11 @@ impl EventProcessor {
         // budget is exceeded we shed the event without unwrapping. The event is
         // NOT marked seen: shedding is transient back-pressure, not a permanent
         // failure, so the event may be processed later once budget recovers.
+        // The reservation taken above is released so the retry is not treated
+        // as a duplicate.
         let admission = self.global_unwrap_limiter.check_and_increment(&()).await;
         if !admission.is_allowed() {
+            self.release_reservation(&event.id).await;
             trace!(
                 reason = admission.limit_reason(),
                 "Shed event before unwrap (global admission control)"
@@ -267,8 +279,9 @@ impl EventProcessor {
         // Process the event
         match self.process_inner(event).await {
             Ok(count) => {
-                // Mark as seen only after successful processing.
-                // This avoids dropping events due to transient failures.
+                // Refresh the seen timestamp now that processing succeeded, so
+                // the dedup window is measured from completion. The reservation
+                // taken above already keeps the event marked seen.
                 self.mark_seen(event.id).await;
 
                 info!(
@@ -287,7 +300,13 @@ impl EventProcessor {
             }
             Err(e) => {
                 if Self::is_permanent_error(&e) {
+                    // Permanent failures stay marked seen (via the reservation)
+                    // so replays short-circuit as duplicates.
                     self.mark_seen(event.id).await;
+                } else {
+                    // Transient failures release the reservation so the event
+                    // can be retried on a later delivery.
+                    self.release_reservation(&event.id).await;
                 }
 
                 // Log but don't propagate - we want to continue processing other events
@@ -516,12 +535,67 @@ impl EventProcessor {
     }
 
     /// Check if an event has been seen recently.
+    #[cfg(test)]
     async fn is_duplicate(&self, event_id: &EventId) -> bool {
         let seen = self.seen_events.read().await;
         seen.contains(event_id)
     }
 
-    /// Mark an event as seen.
+    /// Atomically reserve an event ID for processing.
+    ///
+    /// Returns `true` if the reservation succeeded (the event was previously
+    /// unseen and is now marked seen), or `false` if the event was already
+    /// seen/reserved — i.e. a duplicate.
+    ///
+    /// The check-and-insert happens under a single write-lock critical section
+    /// so that concurrent deliveries of the same Nostr event ID (common when
+    /// the same event arrives from multiple relays) cannot both observe the
+    /// event as unseen. Without this, the bounded-concurrency event loop in
+    /// `main.rs` — which spawns a task per event — would let duplicates race
+    /// past a non-atomic check-then-mark sequence and dispatch duplicate push
+    /// notifications.
+    ///
+    /// On transient (retryable) processing failure or admission shedding, the
+    /// reservation must be released with [`Self::release_reservation`] so the
+    /// event can be retried later.
+    async fn try_reserve(&self, event_id: EventId) -> bool {
+        let mut seen = self.seen_events.write().await;
+        if seen.contains(&event_id) {
+            return false;
+        }
+        seen.put(event_id, Instant::now());
+
+        // Update cache size metric
+        if let Some(ref m) = self.metrics {
+            m.set_dedup_cache_size(seen.len());
+        }
+        true
+    }
+
+    /// Release a previously reserved event ID.
+    ///
+    /// Used to roll back a [`Self::try_reserve`] when processing did not reach
+    /// a terminal state (transient failure or pre-unwrap admission shedding),
+    /// so the event remains eligible for retry. This is the inverse of the
+    /// reservation and preserves the prior "not marked seen on transient
+    /// failure" semantics.
+    async fn release_reservation(&self, event_id: &EventId) {
+        let mut seen = self.seen_events.write().await;
+        seen.pop(event_id);
+
+        // Update cache size metric
+        if let Some(ref m) = self.metrics {
+            m.set_dedup_cache_size(seen.len());
+        }
+    }
+
+    /// Refresh the seen timestamp for an already-reserved event.
+    ///
+    /// Called when processing reaches a terminal state (success or permanent
+    /// failure) to keep the dedup entry. The entry already exists from
+    /// [`Self::try_reserve`]; this updates its timestamp so the dedup window is
+    /// measured from completion. Kept distinct from `try_reserve` for clarity
+    /// at the call sites.
     async fn mark_seen(&self, event_id: EventId) {
         let mut seen = self.seen_events.write().await;
         seen.put(event_id, Instant::now());
@@ -901,6 +975,75 @@ mod tests {
             ),
             1
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_process_concurrent_duplicates_dispatch_once() {
+        // Regression test for the dedup race introduced by bounded-concurrency
+        // event processing in `main.rs`: the same Nostr event ID can be
+        // delivered concurrently (e.g. from multiple relays) and processed in
+        // parallel spawned tasks. The dedup check-and-mark must be atomic so
+        // exactly one delivery is processed and the rest short-circuit as
+        // duplicates, instead of all of them unwrapping and dispatching
+        // duplicate push notifications.
+        let server_keys = Keys::generate();
+        let sender_keys = Keys::generate();
+
+        let event = scenarios::single_apns_notification(
+            &server_keys,
+            &sender_keys,
+            "deadbeef12345678deadbeef12345678deadbeef12345678deadbeef12345678",
+        )
+        .await;
+
+        let (processor, metrics) = create_processor_with_metrics(&server_keys);
+        let processor = Arc::new(processor);
+
+        // Fan out many concurrent processings of the SAME event.
+        const CONCURRENCY: usize = 32;
+        let mut handles = Vec::with_capacity(CONCURRENCY);
+        for _ in 0..CONCURRENCY {
+            let processor = Arc::clone(&processor);
+            let event = event.clone();
+            handles.push(tokio::spawn(async move { processor.process(&event).await }));
+        }
+
+        let mut processed_true = 0usize;
+        for handle in handles {
+            if handle.await.expect("task panicked").expect("process ok") {
+                processed_true += 1;
+            }
+        }
+
+        // Exactly one delivery should report a successful (non-duplicate)
+        // processing; every other delivery is deduplicated.
+        assert_eq!(
+            processed_true, 1,
+            "exactly one concurrent delivery must be processed"
+        );
+        assert_eq!(
+            counter_value(&metrics, "transponder_events_processed_total", &[]),
+            1.0,
+            "the event must be dispatched exactly once across concurrent deliveries"
+        );
+        assert_eq!(
+            counter_value(&metrics, "transponder_events_deduplicated_total", &[]),
+            (CONCURRENCY - 1) as f64,
+            "all but one concurrent delivery must be deduplicated"
+        );
+        // Push dispatch admission is recorded once per processed event, so an
+        // exactly-once value here proves the expensive unwrap+dispatch path ran
+        // only once despite the concurrent flood.
+        assert_eq!(
+            histogram_count(
+                &metrics,
+                "transponder_notifications_admitted_per_event",
+                &[]
+            ),
+            1,
+            "notifications must be admitted/dispatched for exactly one delivery"
+        );
+        assert_eq!(processor.cache_len(), 1);
     }
 
     #[tokio::test]

--- a/src/nostr/events.rs
+++ b/src/nostr/events.rs
@@ -21,8 +21,8 @@ use crate::error::{Error, Result};
 use crate::metrics::{EventOutcome, Metrics, OperationOutcome};
 use crate::push::PushDispatcher;
 use crate::rate_limiter::{
-    DEFAULT_MAX_SIZE, DEFAULT_RATE_LIMIT_PER_HOUR, DEFAULT_RATE_LIMIT_PER_MINUTE, RateLimitConfig,
-    RateLimiter,
+    DEFAULT_GLOBAL_UNWRAP_LIMIT_PER_HOUR, DEFAULT_GLOBAL_UNWRAP_LIMIT_PER_MINUTE, DEFAULT_MAX_SIZE,
+    DEFAULT_RATE_LIMIT_PER_HOUR, DEFAULT_RATE_LIMIT_PER_MINUTE, RateLimitConfig, RateLimiter,
 };
 
 /// Duration to keep event IDs for deduplication (5 minutes).
@@ -76,6 +76,13 @@ pub struct EventProcessor {
     push_dispatcher: Arc<PushDispatcher>,
     /// Event ID deduplication cache.
     seen_events: Arc<RwLock<LruCache<EventId, Instant>>>,
+    /// Global pre-unwrap admission limiter.
+    ///
+    /// Checked BEFORE the gift-wrap unwrap (ECDH + seal decryption) using a
+    /// single fixed key so it acts as a cheap global throttle. The server's
+    /// pubkey is public, so anyone can flood it with valid gift wraps; this
+    /// budget sheds that traffic before spending asymmetric-crypto cycles.
+    global_unwrap_limiter: RateLimiter<()>,
     /// Encrypted token rate limiter.
     encrypted_token_limiter: RateLimiter<[u8; 32]>,
     /// Device token rate limiter.
@@ -100,6 +107,10 @@ pub struct TokenRateLimitConfig {
     pub device_token_per_minute: u32,
     /// Max device token requests per hour.
     pub device_token_per_hour: u32,
+    /// Global max gift-wrap unwraps (ECDH) per minute, across all senders.
+    pub global_unwrap_per_minute: u32,
+    /// Global max gift-wrap unwraps (ECDH) per hour, across all senders.
+    pub global_unwrap_per_hour: u32,
 }
 
 impl Default for TokenRateLimitConfig {
@@ -111,6 +122,8 @@ impl Default for TokenRateLimitConfig {
             encrypted_token_per_hour: DEFAULT_RATE_LIMIT_PER_HOUR,
             device_token_per_minute: DEFAULT_RATE_LIMIT_PER_MINUTE,
             device_token_per_hour: DEFAULT_RATE_LIMIT_PER_HOUR,
+            global_unwrap_per_minute: DEFAULT_GLOBAL_UNWRAP_LIMIT_PER_MINUTE,
+            global_unwrap_per_hour: DEFAULT_GLOBAL_UNWRAP_LIMIT_PER_HOUR,
         }
     }
 }
@@ -173,6 +186,12 @@ impl EventProcessor {
             token_decryptor,
             push_dispatcher,
             seen_events: Arc::new(RwLock::new(LruCache::new(cache_size))),
+            // A single fixed `()` key, so capacity of 1 entry is sufficient.
+            global_unwrap_limiter: RateLimiter::new(RateLimitConfig {
+                max_per_minute: rate_limit_config.global_unwrap_per_minute,
+                max_per_hour: rate_limit_config.global_unwrap_per_hour,
+                max_entries: 1,
+            }),
             encrypted_token_limiter: RateLimiter::new(RateLimitConfig {
                 max_per_minute: rate_limit_config.encrypted_token_per_minute,
                 max_per_hour: rate_limit_config.encrypted_token_per_hour,
@@ -213,6 +232,32 @@ impl EventProcessor {
                 m.record_event_deduplicated();
                 m.observe_event_processing_duration(
                     EventOutcome::Duplicate,
+                    started_at.elapsed_secs(),
+                );
+            }
+            return Ok(false);
+        }
+
+        // Global pre-unwrap admission control.
+        //
+        // Checked BEFORE the expensive NIP-59 gift-wrap unwrap (ECDH + seal
+        // decryption). The per-token limiters run only AFTER unwrap, so they
+        // cannot protect against a flood of valid-but-junk gift wraps. The
+        // server pubkey is public and gift wraps are sender-anonymous, so a
+        // cheap GLOBAL throttle is the correct admission control here. When the
+        // budget is exceeded we shed the event without unwrapping. The event is
+        // NOT marked seen: shedding is transient back-pressure, not a permanent
+        // failure, so the event may be processed later once budget recovers.
+        let admission = self.global_unwrap_limiter.check_and_increment(&()).await;
+        if !admission.is_allowed() {
+            trace!(
+                reason = admission.limit_reason(),
+                "Shed event before unwrap (global admission control)"
+            );
+            if let Some(ref m) = self.metrics {
+                m.record_event_shed();
+                m.observe_event_processing_duration(
+                    EventOutcome::Failed,
                     started_at.elapsed_secs(),
                 );
             }
@@ -524,6 +569,11 @@ impl EventProcessor {
                 "Cleaned up event deduplication cache"
             );
         }
+
+        // Clean global pre-unwrap admission limiter cache.
+        // It only holds a single fixed key, but cleaning it keeps the limiter
+        // memory bounded and behavior consistent with the other limiters.
+        self.global_unwrap_limiter.cleanup().await;
 
         // Clean encrypted token rate limiter cache
         let encrypted_stats = self.encrypted_token_limiter.cleanup().await;
@@ -1061,6 +1111,8 @@ mod tests {
                     encrypted_token_per_hour: 1,
                     device_token_per_minute: 1,
                     device_token_per_hour: 1,
+                    global_unwrap_per_minute: 1000,
+                    global_unwrap_per_hour: 10000,
                 },
             )
             .await;
@@ -1114,6 +1166,8 @@ mod tests {
                     encrypted_token_per_hour: 100,
                     device_token_per_minute: 100,
                     device_token_per_hour: 100,
+                    global_unwrap_per_minute: 1000,
+                    global_unwrap_per_hour: 10000,
                 },
             )
             .await;
@@ -1495,6 +1549,8 @@ mod tests {
                 encrypted_token_per_hour: 1000,
                 device_token_per_minute: 1,
                 device_token_per_hour: 100,
+                global_unwrap_per_minute: 1000,
+                global_unwrap_per_hour: 10000,
             },
         );
 
@@ -1551,6 +1607,8 @@ mod tests {
                 encrypted_token_per_hour: 1000,
                 device_token_per_minute: 2, // Only allow 2 per minute per device
                 device_token_per_hour: 100,
+                global_unwrap_per_minute: 1000,
+                global_unwrap_per_hour: 10000,
             },
         );
 
@@ -1611,6 +1669,8 @@ mod tests {
                 encrypted_token_per_hour: 100,
                 device_token_per_minute: 100, // High limit for device tokens
                 device_token_per_hour: 1000,
+                global_unwrap_per_minute: 1000,
+                global_unwrap_per_hour: 10000,
             },
         );
 
@@ -1688,6 +1748,8 @@ mod tests {
                 encrypted_token_per_hour: 100,
                 device_token_per_minute: 100,
                 device_token_per_hour: 1000,
+                global_unwrap_per_minute: 1000,
+                global_unwrap_per_hour: 10000,
             },
         );
 
@@ -1724,6 +1786,138 @@ mod tests {
         assert!(
             result3.unwrap(),
             "Token should be allowed after window reset"
+        );
+    }
+
+    // === Global Pre-Unwrap Admission Control Tests ===
+
+    fn flood_rate_limit_config(
+        global_unwrap_per_minute: u32,
+        global_unwrap_per_hour: u32,
+    ) -> TokenRateLimitConfig {
+        TokenRateLimitConfig {
+            max_cache_size: 100,
+            max_tokens_per_event: DEFAULT_MAX_TOKENS_PER_EVENT,
+            // Generous per-token limits so only the global limiter can shed.
+            encrypted_token_per_minute: 100_000,
+            encrypted_token_per_hour: 100_000,
+            device_token_per_minute: 100_000,
+            device_token_per_hour: 100_000,
+            global_unwrap_per_minute,
+            global_unwrap_per_hour,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_global_limiter_sheds_flood_before_unwrap() {
+        let server_keys = Keys::generate();
+        let sender_keys = Keys::generate();
+        let device_token = "aabbccdd11223344aabbccdd11223344aabbccdd11223344aabbccdd11223344";
+
+        // Allow exactly 2 unwraps per minute. The third flood event must be shed.
+        let (processor, metrics) = create_processor_with_metrics_and_rate_limits(
+            &server_keys,
+            flood_rate_limit_config(2, 1000),
+        );
+
+        let limit = 2usize;
+        for _ in 0..limit {
+            // Distinct event IDs so dedup never short-circuits the unwrap path.
+            let event =
+                scenarios::single_apns_notification(&server_keys, &sender_keys, device_token).await;
+            assert!(processor.process(&event).await.unwrap());
+        }
+
+        // The (N+1)th event exceeds the global budget and is shed.
+        let flood_event =
+            scenarios::single_apns_notification(&server_keys, &sender_keys, device_token).await;
+        assert!(!processor.process(&flood_event).await.unwrap());
+
+        // Exactly one event was shed.
+        assert_eq!(
+            counter_value(&metrics, "transponder_events_shed_total", &[]),
+            1.0
+        );
+
+        // The shed event was NOT unwrapped: only `limit` unwraps were observed.
+        assert_eq!(
+            histogram_count(
+                &metrics,
+                "transponder_gift_wrap_unwrap_duration_seconds",
+                &[("outcome", OperationOutcome::Success.as_str())],
+            ),
+            limit as u64
+        );
+    }
+
+    #[tokio::test]
+    async fn test_global_limiter_does_not_mark_shed_event_seen() {
+        tokio::time::pause();
+
+        let server_keys = Keys::generate();
+        let sender_keys = Keys::generate();
+        let device_token = "aabbccdd11223344aabbccdd11223344aabbccdd11223344aabbccdd11223344";
+
+        // Only 1 unwrap per minute allowed.
+        let (processor, _metrics) = create_processor_with_metrics_and_rate_limits(
+            &server_keys,
+            flood_rate_limit_config(1, 1000),
+        );
+
+        let event =
+            scenarios::single_apns_notification(&server_keys, &sender_keys, device_token).await;
+
+        // First event consumes the global budget.
+        assert!(processor.process(&event).await.unwrap());
+
+        // Same event again: deduplicated, so it is not shed.
+        assert!(!processor.process(&event).await.unwrap());
+
+        // A different event is shed (budget exhausted) and must NOT be marked seen.
+        let flood_event =
+            scenarios::single_apns_notification(&server_keys, &sender_keys, device_token).await;
+        assert!(!processor.process(&flood_event).await.unwrap());
+        assert!(!processor.is_duplicate(&flood_event.id).await);
+
+        // After the window resets, the previously shed event is admitted.
+        tokio::time::advance(Duration::from_secs(61)).await;
+        assert!(processor.process(&flood_event).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_global_limiter_recovers_after_window() {
+        tokio::time::pause();
+
+        let server_keys = Keys::generate();
+        let sender_keys = Keys::generate();
+        let device_token = "aabbccdd11223344aabbccdd11223344aabbccdd11223344aabbccdd11223344";
+
+        let (processor, metrics) = create_processor_with_metrics_and_rate_limits(
+            &server_keys,
+            flood_rate_limit_config(1, 1000),
+        );
+
+        let event1 =
+            scenarios::single_apns_notification(&server_keys, &sender_keys, device_token).await;
+        assert!(processor.process(&event1).await.unwrap());
+
+        let event2 =
+            scenarios::single_apns_notification(&server_keys, &sender_keys, device_token).await;
+        assert!(!processor.process(&event2).await.unwrap());
+        assert_eq!(
+            counter_value(&metrics, "transponder_events_shed_total", &[]),
+            1.0
+        );
+
+        // Past the minute window, budget recovers and events flow again.
+        tokio::time::advance(Duration::from_secs(61)).await;
+
+        let event3 =
+            scenarios::single_apns_notification(&server_keys, &sender_keys, device_token).await;
+        assert!(processor.process(&event3).await.unwrap());
+        assert_eq!(
+            counter_value(&metrics, "transponder_events_shed_total", &[]),
+            1.0
         );
     }
 }

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -21,6 +21,22 @@ pub const DEFAULT_RATE_LIMIT_PER_MINUTE: u32 = 240;
 /// Default rate limit per hour.
 pub const DEFAULT_RATE_LIMIT_PER_HOUR: u32 = 5000;
 
+/// Default global pre-unwrap admission limit per minute.
+///
+/// This caps how many gift wraps the server is willing to unwrap (ECDH + seal
+/// decryption) per minute across all senders. The server pubkey is public, so
+/// anyone can flood it with valid kind-1059 gift wraps; this budget sheds that
+/// traffic before spending asymmetric-crypto cycles. 600/minute (10/second) is
+/// far above any legitimate single-server load while still bounding attacker
+/// CPU cost.
+pub const DEFAULT_GLOBAL_UNWRAP_LIMIT_PER_MINUTE: u32 = 600;
+
+/// Default global pre-unwrap admission limit per hour.
+///
+/// Companion to [`DEFAULT_GLOBAL_UNWRAP_LIMIT_PER_MINUTE`]; bounds sustained
+/// flooding over a longer window.
+pub const DEFAULT_GLOBAL_UNWRAP_LIMIT_PER_HOUR: u32 = 30_000;
+
 /// Maximum entries to scan per cleanup cycle.
 const CLEANUP_BATCH_SIZE: usize = 1000;
 


### PR DESCRIPTION
Closes #61

## Summary

Incoming relay events were processed strictly sequentially on a single Tokio task, and every event underwent a full NIP-59 gift unwrap (ECDH + seal decryption) **before** any rate limiting. Because the server pubkey is public by design, anyone could publish unlimited valid kind-1059 gift wraps addressed to it and saturate the lone processing task, overflowing the `broadcast` channel and silently dropping legitimate notifications (`RecvError::Lagged`) — a CPU-exhaustion DoS.

This PR adds two layers of protection (recommendations 1 + 2 from the issue):

### 1. Bounded concurrent processing (`src/main.rs`)
The relay event loop no longer `await`s `process()` inline. It acquires an owned permit from an `Arc<Semaphore>` sized to a configurable `max_concurrent_event_processing` (default **64**) and `tokio::spawn`s a per-event task that holds the permit for its lifetime. This drains the broadcast channel quickly (avoiding `Lagged` overflow) while capping total in-flight unwrap work so a flood cannot spawn unbounded crypto tasks. A configured value of `0` is clamped to `1` to avoid deadlocking the loop. Shutdown and `Lagged`/`Closed` handling are preserved.

### 2. Global pre-unwrap admission control (`src/nostr/events.rs`)
A cheap **global** throttle (single-key `RateLimiter<()>`) is checked after dedup but **before** the gift-wrap unwrap. The per-token limiters only run *after* unwrap, so they cannot protect against valid-but-junk gift-wrap floods; and since gift wraps are sender-anonymous (ephemeral signing key per NIP-59), a global budget is the correct cheap admission gate. When the budget is exceeded the event is shed (new `transponder_events_shed_total` metric) before any ECDH is spent. Shed events are **not** marked seen — shedding is transient back-pressure, so an event may succeed later once budget recovers. Defaults: **600/min**, **30000/hr** (far above any legitimate single-server load).

Both limits are threaded through `ServerConfig` following the existing rate-limit config pattern, with `config/default.toml` and README documentation.

## Verification

Ran CI's exact commands locally (with `RUSTFLAGS=-Dwarnings`):

| Check | Command | Result |
|---|---|---|
| Format | `cargo fmt --all -- --check` | ✅ pass |
| Check | `cargo check --all-targets` | ✅ pass |
| Clippy | `cargo clippy --all-targets -- -D warnings` | ✅ pass |
| Test | `cargo test --all-targets` | ✅ 324 + 4 pass, 0 failed |
| Doc | `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --document-private-items` | ✅ pass |
| Tor | `cargo check --all-targets --features tor` | ✅ pass |

`Cargo.lock`/`Cargo.toml` unchanged (audit job unaffected).

New tests:
- `test_global_limiter_sheds_flood_before_unwrap` — flood beyond the budget is shed and verified *not* unwrapped (asserts the unwrap-duration histogram count equals the budget).
- `test_global_limiter_does_not_mark_shed_event_seen` — shed events stay un-seen and are admitted after the window resets.
- `test_global_limiter_recovers_after_window` — budget recovers after the minute window.
- `event_processing_permits_clamps_zero_to_one`, `event_processing_permits_preserves_positive_values`, `event_semaphore_caps_in_flight_permits` — semaphore permit accounting.
- Config default/custom/env-override tests + a metrics test for the shed counter.

All limiter tests are deterministic (`tokio::time::pause`/`advance`, no wall-clock sleeps).

## Sensitive paths touched
- `src/nostr/events.rs` (event processing path / admission control)
- `src/config.rs` (configuration)

No device tokens, private keys, or user-identifying info are logged; the shed path uses `trace!` with only the limit reason, consistent with the existing rate-limiter logging.

## Notes
- The global limiter reuses the existing sliding-window `RateLimiter` with a single `()` key (`max_entries: 1`) — lowest-risk reuse, one `RwLock` per admission check, no ECDH involved.
- True end-to-end concurrency capping is not unit-tested (needs relay/broadcast integration scaffolding that doesn't exist); the semaphore permit accounting and the `event_processing_permits` helper that backs it are unit-tested instead.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/transponder/pull/76">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->