### PR TITLE
docs(rate-limiter): document aggregate timestamp memory bound

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1094,7 +1094,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b48e8e38a4aa565da767322b5ca55fb0f8347983c5bc7f7647db069405420479"
 dependencies = [
  "heck",
- "indexmap 2.13.0",
+ "indexmap 1.9.3",
  "itertools",
  "proc-macro-crate",
  "proc-macro2",
@@ -3136,7 +3136,7 @@ dependencies = [
  "derive-deftly",
  "libc",
  "paste",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3161,9 +3161,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ shutdown_timeout_secs = 10
 # max_dedup_cache_size = 100000
 
 # Rate limiting to prevent spam and replay attacks
-# max_rate_limit_cache_size = 100000           # Tracked keys per limiter
+# max_rate_limit_cache_size = 100000           # Tracked keys per limiter, not total timestamps
 # max_tokens_per_event = 100                   # Per notification event
 # encrypted_token_rate_limit_per_minute = 240  # Per encrypted token (replay protection)
 # encrypted_token_rate_limit_per_hour = 5000
@@ -144,6 +144,14 @@ level = "info"
 # Log format: "json" (structured, for production) or "pretty" (human-readable)
 format = "json"
 ```
+
+Rate-limit memory scales with admitted hits, not just tracked keys. Each active
+key can retain up to `per_minute + per_hour` `Instant` timestamps for precise
+sliding-window enforcement. Worst-case timestamp storage is therefore
+`max_rate_limit_cache_size × (per_minute + per_hour)` per limiter: with the
+defaults, `100000 × (240 + 5000) ≈ 524M` timestamps for the encrypted-token
+limiter, and the same bound again for the device-token limiter. Lower
+`max_rate_limit_cache_size` on memory-constrained deployments.
 
 ### Environment Variables
 
@@ -381,7 +389,7 @@ Transponder exposes Prometheus metrics at `/metrics` on the health server port (
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
 | `transponder_tokens_rate_limited_total` | Counter | `type`, `reason` | Tokens skipped due to rate limiting |
-| `transponder_rate_limit_cache_size` | Gauge | `type` | Current rate limit cache size |
+| `transponder_rate_limit_cache_size` | Gauge | `type` | Current rate limit cache size in tracked keys, not stored timestamps |
 | `transponder_rate_limit_evictions_total` | Counter | `type` | Stale rate limit entries removed during cleanup |
 
 Label values: `type` = `encrypted_token` or `device_token`; `reason` = `minute`, `hour`, or `capacity`

--- a/README.md
+++ b/README.md
@@ -150,7 +150,8 @@ key can retain up to `per_minute + per_hour` `Instant` timestamps for precise
 sliding-window enforcement. Worst-case timestamp storage is therefore
 `max_rate_limit_cache_size × (per_minute + per_hour)` per limiter: with the
 defaults, `100000 × (240 + 5000) ≈ 524M` timestamps for the encrypted-token
-limiter, and the same bound again for the device-token limiter. Lower
+limiter (about 8.4 GB at 16 bytes per timestamp, before `VecDeque` overhead),
+and the same bound again for the device-token limiter. Lower
 `max_rate_limit_cache_size` on memory-constrained deployments.
 
 ### Environment Variables

--- a/config/default.toml
+++ b/config/default.toml
@@ -20,7 +20,10 @@ shutdown_timeout_secs = 10
 # Default: 100000
 # max_dedup_cache_size = 100000
 
-# Maximum size for rate limit caches (encrypted_token and device_token).
+# Maximum tracked keys for each rate limit cache (encrypted_token and device_token).
+# This caps key count, not timestamp storage: worst-case timestamps per limiter
+# are max_rate_limit_cache_size * (per_minute + per_hour), or ~524M Instant
+# values with the defaults. Transponder has two such limiters.
 # Unknown keys are rate limited at capacity until cleanup removes stale entries.
 # Default: 100000 entries per cache
 # max_rate_limit_cache_size = 100000

--- a/config/default.toml
+++ b/config/default.toml
@@ -23,7 +23,8 @@ shutdown_timeout_secs = 10
 # Maximum tracked keys for each rate limit cache (encrypted_token and device_token).
 # This caps key count, not timestamp storage: worst-case timestamps per limiter
 # are max_rate_limit_cache_size * (per_minute + per_hour), or ~524M Instant
-# values with the defaults. Transponder has two such limiters.
+# values with the defaults (~8.4 GB at 16 B/timestamp before overhead).
+# Transponder has two such limiters.
 # Unknown keys are rate limited at capacity until cleanup removes stale entries.
 # Default: 100000 entries per cache
 # max_rate_limit_cache_size = 100000

--- a/config/production.toml.example
+++ b/config/production.toml.example
@@ -13,6 +13,9 @@ shutdown_timeout_secs = 20
 # These defaults are reasonable for small to medium deployments.
 # Reduce them if you are running on a very small VM.
 # max_dedup_cache_size = 100000
+# Rate-limit cache size caps tracked keys, not stored timestamps. Worst-case
+# timestamps per limiter are max_rate_limit_cache_size * (per_minute + per_hour),
+# or ~524M Instant values with the defaults; Transponder has two limiters.
 # Unknown rate-limit keys are rejected at capacity until stale entries are cleaned up.
 # max_rate_limit_cache_size = 100000
 # max_tokens_per_event = 100

--- a/config/production.toml.example
+++ b/config/production.toml.example
@@ -15,7 +15,8 @@ shutdown_timeout_secs = 20
 # max_dedup_cache_size = 100000
 # Rate-limit cache size caps tracked keys, not stored timestamps. Worst-case
 # timestamps per limiter are max_rate_limit_cache_size * (per_minute + per_hour),
-# or ~524M Instant values with the defaults; Transponder has two limiters.
+# or ~524M Instant values with the defaults (~8.4 GB at 16 B/timestamp before
+# overhead); Transponder has two limiters.
 # Unknown rate-limit keys are rejected at capacity until stale entries are cleaned up.
 # max_rate_limit_cache_size = 100000
 # max_tokens_per_event = 100

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -23,7 +23,8 @@ Why these numbers make sense today:
 - the dispatcher allows up to 100 concurrent outbound push requests
 - the push queue is bounded at 10,000 pending notifications
 - the event deduplication and rate-limit caches default to 100,000 entries each
-- new rate-limit keys are rejected at capacity, so size these caches with headroom for legitimate unique devices and adversarial noise
+- rate-limit cache entries retain admitted-hit timestamps for sliding-window precision; worst-case timestamp storage is `max_rate_limit_cache_size × (per_minute + per_hour)` per limiter, and Transponder runs separate encrypted-token and device-token limiters
+- new rate-limit keys are rejected at capacity, so size these caches with headroom for legitimate unique devices, adversarial noise, and process memory limits
 - Tor adds noticeable memory and connection-management overhead, which is why the default build leaves it disabled
 
 If you need to run on a smaller VM, lower the cache sizes in `config/production.toml`.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -23,7 +23,7 @@ Why these numbers make sense today:
 - the dispatcher allows up to 100 concurrent outbound push requests
 - the push queue is bounded at 10,000 pending notifications
 - the event deduplication and rate-limit caches default to 100,000 entries each
-- rate-limit cache entries retain admitted-hit timestamps for sliding-window precision; worst-case timestamp storage is `max_rate_limit_cache_size × (per_minute + per_hour)` per limiter, and Transponder runs separate encrypted-token and device-token limiters
+- rate-limit cache entries retain admitted-hit timestamps for sliding-window precision; worst-case timestamp storage is `max_rate_limit_cache_size × (per_minute + per_hour)` per limiter (about 8.4 GB at 16 bytes per timestamp with the defaults, before `VecDeque` overhead), and Transponder runs separate encrypted-token and device-token limiters
 - new rate-limit keys are rejected at capacity, so size these caches with headroom for legitimate unique devices, adversarial noise, and process memory limits
 - Tor adds noticeable memory and connection-management overhead, which is why the default build leaves it disabled
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -92,10 +92,18 @@ pub struct ServerConfig {
     #[serde(default = "default_max_dedup_cache_size")]
     pub max_dedup_cache_size: usize,
 
-    /// Maximum size for rate limit caches (encrypted token and device token).
+    /// Maximum tracked keys for each rate limit cache (encrypted token and
+    /// device token).
     ///
-    /// Each cache uses LRU eviction to prevent unbounded memory growth.
-    /// Default: 100,000 entries per cache.
+    /// This caps key cardinality, not total timestamp storage. Each tracked key
+    /// can retain up to `per_minute + per_hour` admitted-hit timestamps, so
+    /// worst-case timestamp storage is `max_rate_limit_cache_size *
+    /// (per_minute + per_hour)` per limiter. With the defaults, that is roughly
+    /// 524,000,000 `Instant` values per limiter, and Transponder creates two
+    /// such limiters.
+    ///
+    /// Unknown keys are rate limited at capacity until cleanup removes stale
+    /// entries. Default: 100,000 entries per cache.
     #[serde(default = "default_max_rate_limit_cache_size")]
     pub max_rate_limit_cache_size: usize,
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -99,8 +99,9 @@ pub struct ServerConfig {
     /// can retain up to `per_minute + per_hour` admitted-hit timestamps, so
     /// worst-case timestamp storage is `max_rate_limit_cache_size *
     /// (per_minute + per_hour)` per limiter. With the defaults, that is roughly
-    /// 524,000,000 `Instant` values per limiter, and Transponder creates two
-    /// such limiters.
+    /// 524,000,000 `Instant` values per limiter (about 8.4 GB at 16 bytes per
+    /// timestamp, before `VecDeque` overhead), and Transponder creates two such
+    /// limiters.
     ///
     /// Unknown keys are rate limited at capacity until cleanup removes stale
     /// entries. Default: 100,000 entries per cache.

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -111,9 +111,13 @@ pub struct RateLimitConfig {
     pub max_per_hour: u32,
     /// Maximum entries in the cache.
     ///
-    /// Unknown keys are rate limited once this capacity is reached. Existing
-    /// entries remain tracked until their windows expire and cleanup removes
-    /// them.
+    /// This caps the number of tracked keys, not the total number of stored
+    /// timestamps. Each key may retain up to `max_per_minute + max_per_hour`
+    /// admitted-hit timestamps until its windows expire, so worst-case
+    /// timestamp storage per limiter is `max_entries * (max_per_minute +
+    /// max_per_hour)`. Unknown keys are rate limited once this capacity is
+    /// reached. Existing entries remain tracked until their windows expire and
+    /// cleanup removes them.
     pub max_entries: usize,
 }
 
@@ -134,8 +138,16 @@ impl Default for RateLimitConfig {
 /// the defaults, a hot key can hold up to roughly 5,240 `Instant` values across
 /// the minute and hour windows before older hits are pruned.
 ///
-/// Uses a bounded cache to limit memory usage. When the cache is full,
-/// unknown keys are rejected until cleanup removes stale entries. This
+/// The aggregate bound is the per-key bound multiplied by the configured cache
+/// size: `max_entries * (max_per_minute + max_per_hour)` timestamp values per
+/// limiter. With the default 100,000-key cache and 240/minute plus 5,000/hour
+/// limits, one fully saturated limiter can retain roughly 524,000,000 `Instant`
+/// values before pruning; production event processing owns separate encrypted-
+/// token and device-token limiters, so size `max_entries` and process memory for
+/// both caches.
+///
+/// Uses a bounded cache to limit tracked key cardinality. When the cache is
+/// full, unknown keys are rejected until cleanup removes stale entries. This
 /// preserves existing counters under adversarial cache pressure.
 pub struct RateLimiter<K: Hash + Eq + Clone + Send + Sync + 'static> {
     entries: RwLock<LruCache<K, RateLimitEntry>>,

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -142,7 +142,8 @@ impl Default for RateLimitConfig {
 /// size: `max_entries * (max_per_minute + max_per_hour)` timestamp values per
 /// limiter. With the default 100,000-key cache and 240/minute plus 5,000/hour
 /// limits, one fully saturated limiter can retain roughly 524,000,000 `Instant`
-/// values before pruning; production event processing owns separate encrypted-
+/// values before pruning (about 8.4 GB at 16 bytes per timestamp, before
+/// `VecDeque` overhead). Production event processing owns separate encrypted-
 /// token and device-token limiters, so size `max_entries` and process memory for
 /// both caches.
 ///


### PR DESCRIPTION
Closes #68

## Summary

- Document that `max_rate_limit_cache_size` caps tracked keys, not total timestamp storage.
- Add the aggregate bound next to the `RateLimiter` struct docs and operator-facing config/deployment docs: `max_entries × (max_per_minute + max_per_hour)` timestamps per limiter, with separate encrypted-token and device-token limiters.
- Clarify the existing `transponder_rate_limit_cache_size` metric as tracked keys, not stored timestamps.
- Refresh `quinn-proto` to 0.11.15 in `Cargo.lock` so the audit gate stays green after the new RUSTSEC-2026-0185 advisory; `origin/master` failed the same audit before this lockfile bump.

## Verification

`just ci` could not be invoked on this worker because `just` is not installed, so I ran the CI recipes directly:

- `cargo fmt --all -- --check` — pass
- `cargo check --all-targets` — pass
- `cargo clippy --all-targets -- -D warnings` — pass
- `cargo test --all-targets` — pass (317 unit tests + 4 integration tests)
- `./scripts/cargo-audit.sh` — pass after the `quinn-proto` lockfile refresh; only the existing policy-allowed warnings remain

## Sensitive paths touched

- `src/rate_limiter.rs` — documentation-only clarification of aggregate timestamp storage.
- `src/config.rs` — documentation-only clarification of rate-limit cache sizing.

No limiter behavior, key handling, crypto, token contents, or push delivery logic changed.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/transponder/pull/77">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->