### PR TITLE
fix(push): honor provider Retry-After delays

### DIFF
--- a/src/push/retry.rs
+++ b/src/push/retry.rs
@@ -85,8 +85,9 @@ where
                     metrics.record_push_retry(service_name.to_lowercase().as_str());
                 }
 
-                // Use Retry-After header if provided, otherwise use exponential backoff
-                let wait_duration = retry_after.unwrap_or(backoff).min(MAX_BACKOFF);
+                // Honor Retry-After exactly when the provider supplies one. Only cap
+                // locally-computed exponential backoff to avoid runaway delays.
+                let wait_duration = retry_wait_duration(retry_after, backoff);
 
                 warn!(
                     service = service_name,
@@ -113,6 +114,13 @@ where
             }
             SendAttemptResult::Permanent(e) => return Err(e),
         }
+    }
+}
+
+fn retry_wait_duration(retry_after: Option<Duration>, backoff: Duration) -> Duration {
+    match retry_after {
+        Some(server_delay) => server_delay,
+        None => backoff.min(MAX_BACKOFF),
     }
 }
 
@@ -244,6 +252,22 @@ mod tests {
     fn test_parse_retry_after_invalid() {
         assert_eq!(parse_retry_after(Some("invalid")), None);
         assert_eq!(parse_retry_after(Some("not-a-number")), None);
+    }
+
+    #[test]
+    fn test_retry_wait_duration_honors_retry_after_above_max_backoff() {
+        assert_eq!(
+            retry_wait_duration(Some(Duration::from_secs(60)), Duration::from_millis(100)),
+            Duration::from_secs(60)
+        );
+    }
+
+    #[test]
+    fn test_retry_wait_duration_caps_exponential_backoff() {
+        assert_eq!(
+            retry_wait_duration(None, Duration::from_secs(60)),
+            MAX_BACKOFF
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Rebased onto current `origin/master` and resolved the `src/push/retry.rs` conflict against the newer transport-retry code.
- Honor provider-supplied `Retry-After` values even when they exceed the local exponential backoff cap.
- Keep `MAX_BACKOFF` applied only to locally computed exponential backoff.
- Add regression coverage for both provider `Retry-After` and exponential-backoff wait selection.

## Conflict / runtime notes
- Preserved the newer master-side `should_retry_transport` / `with_transport_retry` behavior while adding `retry_wait_duration` for the provider retry path.
- PR #74 / issue #65 is still open and not merged into `master`; this PR does not include its permit-release plumbing. The current patch is still scoped to wait-duration selection inside `with_retry` and remains compatible with master’s current push-runtime changes.
- The previous `Audit` failure for `quinn-proto 0.11.14` no longer reproduces after rebasing onto current `origin/master`; branch and master both pass `./scripts/cargo-audit.sh` with only configured allowed warnings.

## Test Plan
- `cargo fmt --all -- --check`
- `RUSTFLAGS='-Dwarnings' cargo check --all-targets --locked`
- `RUSTFLAGS='-Dwarnings' cargo clippy --all-targets --locked -- -D warnings`
- `RUSTFLAGS='-Dwarnings' cargo test --all-targets --locked`
- `RUSTFLAGS='-Dwarnings' cargo check --all-targets --locked --features tor`
- `RUSTFLAGS='-Dwarnings' cargo test --all-targets --locked --features tor`
- `RUSTFLAGS='-Dwarnings' RUSTDOCFLAGS='-Dwarnings' cargo doc --no-deps --document-private-items --locked`
- `./scripts/cargo-audit.sh`

Closes #66

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/transponder/pull/78">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->
