### PR TITLE
fix: admit new rate-limit keys under cache pressure

### DIFF
--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -49,7 +49,7 @@ pub enum RateLimitResult {
     ExceededMinuteLimit,
     /// Exceeded per-hour limit.
     ExceededHourLimit,
-    /// Cache is full and cannot admit a new key safely.
+    /// Cache is full and no entry can be evicted safely for a new key.
     ExceededCapacityLimit,
 }
 
@@ -91,6 +91,15 @@ impl RateLimitEntry {
         prune_hits(&mut self.minute_hits, now, Duration::from_secs(60));
         prune_hits(&mut self.hour_hits, now, Duration::from_secs(3600));
     }
+
+    fn is_empty(&self) -> bool {
+        self.minute_hits.is_empty() && self.hour_hits.is_empty()
+    }
+
+    fn is_below_limits(&self, max_per_minute: u32, max_per_hour: u32) -> bool {
+        self.minute_hits.len() < max_per_minute as usize
+            && self.hour_hits.len() < max_per_hour as usize
+    }
 }
 
 fn prune_hits(hits: &mut VecDeque<Instant>, now: Instant, window: Duration) {
@@ -131,9 +140,9 @@ pub struct RateLimitConfig {
     /// timestamps. Each key may retain up to `max_per_minute + max_per_hour`
     /// admitted-hit timestamps until its windows expire, so worst-case
     /// timestamp storage per limiter is `max_entries * (max_per_minute +
-    /// max_per_hour)`. Unknown keys are rate limited once this capacity is
-    /// reached. Existing entries remain tracked until their windows expire and
-    /// cleanup removes them.
+    /// max_per_hour)`. When this key capacity is reached, admission evicts the
+    /// least-recently-used entry that is stale or still below its own rate
+    /// limits; if no safe victim is found, the unknown key is rejected.
     pub max_entries: usize,
 }
 
@@ -164,8 +173,9 @@ impl Default for RateLimitConfig {
 /// both caches.
 ///
 /// Uses a bounded cache to limit tracked key cardinality. When the cache is
-/// full, unknown keys are rejected until cleanup removes stale entries. This
-/// preserves existing counters under adversarial cache pressure.
+/// full, admission evicts the least-recently-used stale or still-unlimited entry
+/// before rejecting a new key, so one-hit junk cannot globally deny legitimate
+/// new tokens while keys already at their rate limit keep their counters.
 pub struct RateLimiter<K: Hash + Eq + Clone + Send + Sync + 'static> {
     entries: RwLock<LruCache<K, RateLimitEntry>>,
     max_per_minute: u32,
@@ -185,23 +195,61 @@ impl<K: Hash + Eq + Clone + Send + Sync + 'static> RateLimiter<K> {
         }
     }
 
+    fn evict_lru_admission_candidate(
+        entries: &mut LruCache<K, RateLimitEntry>,
+        now: Instant,
+        max_per_minute: u32,
+        max_per_hour: u32,
+    ) -> bool {
+        let candidate_keys: Vec<K> = entries
+            .iter()
+            .rev()
+            .take(CLEANUP_BATCH_SIZE)
+            .map(|(key, _)| key.clone())
+            .collect();
+
+        for key in candidate_keys {
+            let should_evict = entries.peek_mut(&key).is_some_and(|entry| {
+                entry.prune(now);
+                entry.is_empty() || entry.is_below_limits(max_per_minute, max_per_hour)
+            });
+
+            if should_evict {
+                entries.pop(&key);
+                return true;
+            }
+        }
+
+        false
+    }
+
     /// Checks if a request is allowed and increments counters if so.
     ///
     /// Returns:
     /// - `Allowed` if the request is within limits (counters are incremented)
     /// - `ExceededMinuteLimit` if per-minute limit is reached
     /// - `ExceededHourLimit` if per-hour limit is reached
-    /// - `ExceededCapacityLimit` if the cache is full and the key is unknown
+    /// - `ExceededCapacityLimit` if the cache is full and has no safe eviction
+    ///   victim for the unknown key
     pub async fn check_and_increment(&self, key: &K) -> RateLimitResult {
         let now = Instant::now();
         let mut entries = self.entries.write().await;
 
-        // Get or create entry (updates access position). Unknown keys are
-        // rejected at capacity so pressure cannot evict existing counters.
+        // Get or create entry (updates access position). At capacity, admit an
+        // unknown key by evicting an old stale or still-unlimited entry. Entries
+        // already sitting at their rate limit are protected so cache pressure
+        // cannot reset a limited key's counters.
         let entry = if let Some(entry) = entries.get_mut(key) {
             entry
         } else {
-            if entries.len() >= entries.cap().get() {
+            if entries.len() >= entries.cap().get()
+                && !Self::evict_lru_admission_candidate(
+                    &mut entries,
+                    now,
+                    self.max_per_minute,
+                    self.max_per_hour,
+                )
+            {
                 return RateLimitResult::ExceededCapacityLimit;
             }
             entries.put(key.clone(), RateLimitEntry::new());
@@ -542,9 +590,32 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_rejects_new_keys_at_capacity() {
+    async fn test_cache_pressure_evicts_oldest_unlimited_key_for_new_key() {
         let limiter: RateLimiter<u64> = RateLimiter::new(RateLimitConfig {
             max_per_minute: 10,
+            max_per_hour: 100,
+            max_entries: 3,
+        });
+
+        limiter.check_and_increment(&1u64).await;
+        limiter.check_and_increment(&2u64).await;
+        limiter.check_and_increment(&3u64).await;
+        assert_eq!(limiter.len().await, 3);
+
+        assert_eq!(
+            limiter.check_and_increment(&4u64).await,
+            RateLimitResult::Allowed
+        );
+        assert_eq!(limiter.len().await, 3);
+        assert_eq!(limiter.peek_counts(&1u64).await, None);
+        assert_eq!(limiter.peek_counts(&2u64).await, Some((1, 1)));
+        assert_eq!(limiter.peek_counts(&4u64).await, Some((1, 1)));
+    }
+
+    #[tokio::test]
+    async fn test_rejects_new_keys_at_capacity_when_no_safe_eviction_exists() {
+        let limiter: RateLimiter<u64> = RateLimiter::new(RateLimitConfig {
+            max_per_minute: 1,
             max_per_hour: 100,
             max_entries: 3,
         });

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -140,9 +140,10 @@ pub struct RateLimitConfig {
     /// timestamps. Each key may retain up to `max_per_minute + max_per_hour`
     /// admitted-hit timestamps until its windows expire, so worst-case
     /// timestamp storage per limiter is `max_entries * (max_per_minute +
-    /// max_per_hour)`. When this key capacity is reached, admission evicts the
-    /// least-recently-used entry that is stale or still below its own rate
-    /// limits; if no safe victim is found, the unknown key is rejected.
+    /// max_per_hour)`. When this key capacity is reached, admission first looks
+    /// for a least-recently-used stale entry to evict, then falls back to the
+    /// least-recently-used entry that is still below its own rate limits; if no
+    /// safe victim is found, the unknown key is rejected.
     pub max_entries: usize,
 }
 
@@ -173,9 +174,11 @@ impl Default for RateLimitConfig {
 /// both caches.
 ///
 /// Uses a bounded cache to limit tracked key cardinality. When the cache is
-/// full, admission evicts the least-recently-used stale or still-unlimited entry
-/// before rejecting a new key, so one-hit junk cannot globally deny legitimate
-/// new tokens while keys already at their rate limit keep their counters.
+/// full, admission first evicts the least-recently-used stale entry; if none is
+/// found in the bounded scan window, it falls back to a least-recently-used
+/// still-unlimited entry. This favors availability for legitimate new tokens
+/// over perfect accounting for below-limit keys under active cache pressure,
+/// while preserving counters for keys already at their rate limit.
 pub struct RateLimiter<K: Hash + Eq + Clone + Send + Sync + 'static> {
     entries: RwLock<LruCache<K, RateLimitEntry>>,
     max_per_minute: u32,
@@ -201,23 +204,26 @@ impl<K: Hash + Eq + Clone + Send + Sync + 'static> RateLimiter<K> {
         max_per_minute: u32,
         max_per_hour: u32,
     ) -> bool {
-        let candidate_keys: Vec<K> = entries
-            .iter()
-            .rev()
-            .take(CLEANUP_BATCH_SIZE)
-            .map(|(key, _)| key.clone())
-            .collect();
+        let mut stale_candidate = None;
+        let mut below_limit_candidate = None;
 
-        for key in candidate_keys {
-            let should_evict = entries.peek_mut(&key).is_some_and(|entry| {
-                entry.prune(now);
-                entry.is_empty() || entry.is_below_limits(max_per_minute, max_per_hour)
-            });
-
-            if should_evict {
-                entries.pop(&key);
-                return true;
+        for (key, entry) in entries.iter_mut().rev().take(CLEANUP_BATCH_SIZE) {
+            entry.prune(now);
+            if entry.is_empty() {
+                stale_candidate = Some(key.clone());
+                break;
             }
+
+            if below_limit_candidate.is_none()
+                && entry.is_below_limits(max_per_minute, max_per_hour)
+            {
+                below_limit_candidate = Some(key.clone());
+            }
+        }
+
+        if let Some(key) = stale_candidate.or(below_limit_candidate) {
+            entries.pop(&key);
+            return true;
         }
 
         false
@@ -610,6 +616,68 @@ mod tests {
         assert_eq!(limiter.peek_counts(&1u64).await, None);
         assert_eq!(limiter.peek_counts(&2u64).await, Some((1, 1)));
         assert_eq!(limiter.peek_counts(&4u64).await, Some((1, 1)));
+    }
+
+    #[test]
+    fn test_admission_eviction_prefers_stale_victim_over_below_limit_victim() {
+        let now = Instant::now();
+        let stale_hit = now
+            .checked_sub(Duration::from_secs(3601))
+            .expect("test instant should support one-hour subtraction");
+        let mut below_limit_entry = RateLimitEntry::new();
+        below_limit_entry.minute_hits.push_back(now);
+        below_limit_entry.hour_hits.push_back(now);
+        let mut stale_entry = RateLimitEntry::new();
+        stale_entry.minute_hits.push_back(stale_hit);
+        stale_entry.hour_hits.push_back(stale_hit);
+
+        let mut entries = LruCache::new(NonZeroUsize::new(3).expect("non-zero test capacity"));
+        entries.put(1u64, below_limit_entry);
+        entries.put(2u64, stale_entry);
+        entries.put(3u64, RateLimitEntry::new());
+
+        assert!(RateLimiter::evict_lru_admission_candidate(
+            &mut entries,
+            now,
+            10,
+            100
+        ));
+
+        assert!(entries.contains(&1u64));
+        assert!(!entries.contains(&2u64));
+        assert!(entries.contains(&3u64));
+    }
+
+    #[tokio::test]
+    async fn test_admission_scan_prunes_stale_candidate_when_cache_exceeds_batch_size() {
+        tokio::time::pause();
+
+        let limiter: RateLimiter<u64> = RateLimiter::new(RateLimitConfig {
+            max_per_minute: 10,
+            max_per_hour: 100,
+            max_entries: CLEANUP_BATCH_SIZE + 1,
+        });
+
+        for key in 0..=CLEANUP_BATCH_SIZE as u64 {
+            assert!(limiter.check_and_increment(&key).await.is_allowed());
+        }
+        assert_eq!(limiter.len().await, CLEANUP_BATCH_SIZE + 1);
+
+        tokio::time::advance(Duration::from_secs(3601)).await;
+
+        let new_key = CLEANUP_BATCH_SIZE as u64 + 1;
+        assert_eq!(
+            limiter.check_and_increment(&new_key).await,
+            RateLimitResult::Allowed
+        );
+
+        assert_eq!(limiter.len().await, CLEANUP_BATCH_SIZE + 1);
+        assert_eq!(limiter.peek_counts(&0u64).await, None);
+        assert_eq!(
+            limiter.peek_counts(&(CLEANUP_BATCH_SIZE as u64)).await,
+            Some((1, 1))
+        );
+        assert_eq!(limiter.peek_counts(&new_key).await, Some((1, 1)));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Admit new rate-limit keys under cache pressure by evicting a safe entry instead of failing closed for every unknown key.
- Prefer least-recently-used stale victims before falling back to least-recently-used below-limit victims, preserving below-limit accounting whenever a stale entry is available.
- Keep entries already at their minute/hour limit protected so cache churn does not reset active limited counters.
- Avoid cloning the full admission scan window; the bounded scan now clones only the selected candidate key.
- Update rate-limiter docs and add regression coverage for graceful admission, no-safe-eviction fallback, stale-victim preference, and the `CLEANUP_BATCH_SIZE` admission boundary.

Closes #62

## Root Cause

`RateLimiter::check_and_increment` rejected every unknown key once the LRU cache reached `max_entries`. Attackers could fill the encrypted-token or device-token limiter with unique one-hit keys, causing all new legitimate tokens to return `ExceededCapacityLimit` until cleanup drained the cache.

## Validation

- RED: `cargo test rate_limiter::tests::test_cache_pressure_evicts_oldest_unlimited_key_for_new_key -- --nocapture` failed with `ExceededCapacityLimit` before the original fix.
- RED: `cargo test rate_limiter::tests::test_admission_eviction_prefers_stale_victim_over_below_limit_victim -- --nocapture` failed before the review-followup refinement.
- `cargo test rate_limiter::tests -- --nocapture`
- `cargo fmt --all -- --check`
- `RUSTFLAGS='-Dwarnings' cargo check --all-targets`
- `RUSTFLAGS='-Dwarnings' cargo clippy --all-targets -- -D warnings`
- `RUSTFLAGS='-Dwarnings' cargo test --all-targets`
- `./scripts/cargo-audit.sh` (passed with existing allowed warnings for memmap2/rand advisories)
- `RUSTFLAGS='-Dwarnings' cargo check --all-targets --features tor`
- `RUSTFLAGS='-Dwarnings' cargo test --all-targets --features tor`
- `RUSTDOCFLAGS='-Dwarnings' cargo doc --no-deps --document-private-items`

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/transponder/pull/80">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->
