### PR TITLE
fix: scan stale dedup entries first

### DIFF
--- a/src/nostr/events.rs
+++ b/src/nostr/events.rs
@@ -618,6 +618,7 @@ impl EventProcessor {
 
             let expired_keys: Vec<_> = seen
                 .iter()
+                .rev()
                 .take(CLEANUP_BATCH_SIZE)
                 .filter(|(_, seen_at)| now.duration_since(**seen_at) >= DEDUP_WINDOW)
                 .map(|(id, _)| *id)
@@ -1611,6 +1612,54 @@ mod tests {
             0,
             "Expected all expired entries to be removed after two cleanup cycles"
         );
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_scans_stale_lru_entries_first() {
+        tokio::time::pause();
+
+        let server_keys = Keys::generate();
+        let processor = create_processor(&server_keys);
+        let old_time = Instant::now() - DEDUP_WINDOW - Duration::from_secs(1);
+        let recent_time = Instant::now();
+        let stale_count = 10;
+        let recent_count = CLEANUP_BATCH_SIZE;
+
+        let event_id = |i: usize| {
+            let mut bytes = [0u8; 32];
+            bytes[0..4].copy_from_slice(&(i as u32).to_le_bytes());
+            EventId::from_byte_array(bytes)
+        };
+        let stale_ids: Vec<_> = (0..stale_count).map(event_id).collect();
+        let recent_ids: Vec<_> = (stale_count..stale_count + recent_count)
+            .map(event_id)
+            .collect();
+
+        {
+            let mut seen = processor.seen_events.write().await;
+            for event_id in &stale_ids {
+                seen.put(*event_id, old_time);
+            }
+            for event_id in &recent_ids {
+                seen.put(*event_id, recent_time);
+            }
+        }
+
+        assert_eq!(processor.cache_len(), stale_count + recent_count);
+
+        processor.cleanup().await;
+
+        assert_eq!(
+            processor.cache_len(),
+            recent_count,
+            "Expected cleanup to reclaim stale entries from the LRU end"
+        );
+        for event_id in stale_ids {
+            assert!(!processor.is_duplicate(&event_id).await);
+        }
+        for event_id in recent_ids {
+            assert!(processor.is_duplicate(&event_id).await);
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- scan the dedup LRU from the stale end before applying the cleanup batch limit
- add a regression test with expired entries older than a full batch of recent entries

## Test Plan
- cargo test test_cleanup_scans_stale_lru_entries_first -- --nocapture (fails before fix, passes after)
- cargo fmt -- --check
- cargo clippy -- -D warnings
- cargo test
- ./scripts/cargo-audit.sh

Note: `just ci` could not run because `just` is not installed on this worker; ran the underlying recipe manually.

Closes #60

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/transponder/pull/82">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated how expired entries are prioritized during cleanup operations to process stale entries more efficiently.

* **Tests**
  * Added test to validate cleanup behavior when handling a mix of stale and recent entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->