### PR TITLE
refactor(push): reuse APNs request parts across retries

### DIFF
--- a/src/push/apns.rs
+++ b/src/push/apns.rs
@@ -425,6 +425,15 @@ impl ApnsClient {
     ///
     /// Returns a `SendAttemptResult` indicating success, retriable error, or permanent error.
     async fn send_once(&self, device_token: &str) -> SendAttemptResult {
+        self.send_once_with_transport_retry_config(device_token, &RetryConfig::default())
+            .await
+    }
+
+    async fn send_once_with_transport_retry_config(
+        &self,
+        device_token: &str,
+        transport_retry: &RetryConfig,
+    ) -> SendAttemptResult {
         let start = Instant::now();
         let url = format!("{}/3/device/{}", self.config.base_url(), device_token);
 
@@ -444,9 +453,8 @@ impl ApnsClient {
         };
 
         let request_parts = ApnsRequestParts::for_mode(self.config.payload_mode);
-        let transport_retry = RetryConfig::default();
         let response = match retry::with_transport_retry(
-            &transport_retry,
+            transport_retry,
             "APNs",
             || async {
                 self.build_request(&url, token.as_str(), &request_parts)
@@ -731,7 +739,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_send_once_reuses_precomputed_request_parts_for_transport_attempts() {
+    async fn test_send_once_returns_transport_error_after_connect_retries() {
         let proxy_addr = {
             let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
             let addr = listener.local_addr().unwrap();
@@ -744,11 +752,9 @@ mod tests {
             .timeout(Duration::from_millis(50))
             .build()
             .unwrap();
-        let mut config = test_config();
-        config.payload_mode = ApnsPayloadMode::NsePrototypeAlert;
         let client = ApnsClient {
             http_client,
-            config,
+            config: test_config(),
             encoding_key: None,
             cached_token: Arc::new(RwLock::new(Some(CachedToken {
                 token: Zeroizing::new("cached-token".to_string()),
@@ -756,8 +762,14 @@ mod tests {
             }))),
             metrics: None,
         };
+        let retry_config = RetryConfig {
+            max_retries: 3,
+            initial_backoff: Duration::from_millis(1),
+        };
 
-        let result = client.send_once("aabbccdd11223344").await;
+        let result = client
+            .send_once_with_transport_retry_config("aabbccdd11223344", &retry_config)
+            .await;
 
         assert!(matches!(
             result,

--- a/src/push/apns.rs
+++ b/src/push/apns.rs
@@ -305,9 +305,12 @@ impl ApnsClient {
         .await
     }
 
-    fn build_request(&self, url: &str, auth_token: &str) -> reqwest::RequestBuilder {
-        let request_parts = ApnsRequestParts::for_mode(self.config.payload_mode);
-
+    fn build_request(
+        &self,
+        url: &str,
+        auth_token: &str,
+        request_parts: &ApnsRequestParts,
+    ) -> reqwest::RequestBuilder {
         self.http_client
             .post(url)
             .header("apns-push-type", request_parts.push_type)
@@ -424,12 +427,11 @@ impl ApnsClient {
     async fn send_once(&self, device_token: &str) -> SendAttemptResult {
         let start = Instant::now();
         let url = format!("{}/3/device/{}", self.config.base_url(), device_token);
-        let request_parts = ApnsRequestParts::for_mode(self.config.payload_mode);
 
         debug!(
             payload_mode = %self.config.payload_mode,
-            push_type = request_parts.push_type,
-            priority = request_parts.priority,
+            push_type = self.config.payload_mode.push_type(),
+            priority = self.config.payload_mode.priority(),
             topic = %self.config.bundle_id,
             device_token = redacted_device_token_id(device_token),
             "Sending APNs notification"
@@ -441,12 +443,13 @@ impl ApnsClient {
             Err(e) => return SendAttemptResult::Permanent(e),
         };
 
+        let request_parts = ApnsRequestParts::for_mode(self.config.payload_mode);
         let transport_retry = RetryConfig::default();
         let response = match retry::with_transport_retry(
             &transport_retry,
             "APNs",
             || async {
-                self.build_request(&url, token.as_str())
+                self.build_request(&url, token.as_str(), &request_parts)
                     .send()
                     .await
                     .map_err(Error::from)
@@ -549,11 +552,13 @@ mod tests {
         config.payload_mode = ApnsPayloadMode::Silent;
         config.bundle_id = "dev.ipf.whitenoise.staging".to_string();
         let client = ApnsClient::mock(config, false);
+        let request_parts = ApnsRequestParts::for_mode(client.config.payload_mode);
 
         let request = client
             .build_request(
                 "https://api.push.apple.com/3/device/aabbccdd11223344",
                 "test-token",
+                &request_parts,
             )
             .build()
             .unwrap();
@@ -580,11 +585,13 @@ mod tests {
         config.payload_mode = ApnsPayloadMode::NsePrototypeAlert;
         config.bundle_id = "dev.ipf.whitenoise.staging".to_string();
         let client = ApnsClient::mock(config, false);
+        let request_parts = ApnsRequestParts::for_mode(client.config.payload_mode);
 
         let request = client
             .build_request(
                 "https://api.push.apple.com/3/device/aabbccdd11223344",
                 "test-token",
+                &request_parts,
             )
             .build()
             .unwrap();
@@ -721,6 +728,41 @@ mod tests {
         // Test with empty token
         let result = client.send("").await.unwrap();
         assert!(!result, "Should return false for empty token");
+    }
+
+    #[tokio::test]
+    async fn test_send_once_reuses_precomputed_request_parts_for_transport_attempts() {
+        let proxy_addr = {
+            let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+            let addr = listener.local_addr().unwrap();
+            drop(listener);
+            addr
+        };
+        let http_client = Client::builder()
+            .proxy(reqwest::Proxy::all(format!("http://{proxy_addr}")).unwrap())
+            .connect_timeout(Duration::from_millis(50))
+            .timeout(Duration::from_millis(50))
+            .build()
+            .unwrap();
+        let mut config = test_config();
+        config.payload_mode = ApnsPayloadMode::NsePrototypeAlert;
+        let client = ApnsClient {
+            http_client,
+            config,
+            encoding_key: None,
+            cached_token: Arc::new(RwLock::new(Some(CachedToken {
+                token: Zeroizing::new("cached-token".to_string()),
+                expires_at: SystemTime::now() + Duration::from_secs(3600),
+            }))),
+            metrics: None,
+        };
+
+        let result = client.send_once("aabbccdd11223344").await;
+
+        assert!(matches!(
+            result,
+            SendAttemptResult::Permanent(Error::Http(_))
+        ));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Reuse a single `ApnsRequestParts` value for all APNs transport retry attempts in one send.
- Keep the send debug log on `ApnsPayloadMode` header accessors so logging no longer constructs the payload.
- Update APNs request-builder coverage for the precomputed request-parts flow.

## Testing
- `cargo fmt --check`
- `cargo test test_send_once_reuses_precomputed_request_parts_for_transport_attempts -- --nocapture`
- `cargo test apns`
- `cargo test`
- `cargo clippy -- -D warnings`

Closes #120
