### PR TITLE
fix: keep Retry-After from inflating fallback backoff

### DIFF
--- a/src/push/retry.rs
+++ b/src/push/retry.rs
@@ -100,7 +100,9 @@ where
                 sleep(wait_duration).await;
 
                 // Exponential backoff for next iteration (if not using Retry-After)
-                backoff = (backoff * 2).min(MAX_BACKOFF);
+                if retry_after.is_none() {
+                    backoff = (backoff * 2).min(MAX_BACKOFF);
+                }
             }
             SendAttemptResult::Retriable { status_code, .. } => {
                 warn!(
@@ -399,6 +401,52 @@ mod tests {
         let elapsed = start.elapsed();
         // Should have used the short retry-after, not the long initial_backoff
         assert!(elapsed < Duration::from_secs(1));
+    }
+
+    #[tokio::test]
+    async fn test_with_retry_does_not_advance_backoff_while_retry_after_is_used() {
+        let config = RetryConfig {
+            max_retries: 4,
+            initial_backoff: Duration::from_millis(200),
+        };
+        let attempt_count = Arc::new(AtomicU32::new(0));
+        let attempt_count_clone = attempt_count.clone();
+
+        let result = tokio::time::timeout(
+            Duration::from_millis(700),
+            with_retry(
+                &config,
+                "test",
+                || {
+                    let count = attempt_count_clone.clone();
+                    async move {
+                        let attempts = count.fetch_add(1, Ordering::SeqCst) + 1;
+                        if attempts <= 3 {
+                            SendAttemptResult::Retriable {
+                                status_code: 429,
+                                retry_after: Some(Duration::from_millis(1)),
+                            }
+                        } else if attempts == 4 {
+                            SendAttemptResult::Retriable {
+                                status_code: 503,
+                                retry_after: None,
+                            }
+                        } else {
+                            SendAttemptResult::Success(true)
+                        }
+                    }
+                },
+                None,
+            ),
+        )
+        .await;
+
+        assert!(
+            result.is_ok(),
+            "fallback backoff was advanced by Retry-After retries"
+        );
+        assert!(result.unwrap().unwrap());
+        assert_eq!(attempt_count.load(Ordering::SeqCst), 5);
     }
 
     #[tokio::test]

--- a/src/push/retry.rs
+++ b/src/push/retry.rs
@@ -100,9 +100,7 @@ where
                 sleep(wait_duration).await;
 
                 // Exponential backoff for next iteration (if not using Retry-After)
-                if retry_after.is_none() {
-                    backoff = (backoff * 2).min(MAX_BACKOFF);
-                }
+                backoff = next_fallback_backoff(backoff, retry_after);
             }
             SendAttemptResult::Retriable { status_code, .. } => {
                 warn!(
@@ -115,6 +113,14 @@ where
             }
             SendAttemptResult::Permanent(e) => return Err(e),
         }
+    }
+}
+
+fn next_fallback_backoff(backoff: Duration, retry_after: Option<Duration>) -> Duration {
+    if retry_after.is_some() {
+        backoff
+    } else {
+        (backoff * 2).min(MAX_BACKOFF)
     }
 }
 
@@ -403,7 +409,22 @@ mod tests {
         assert!(elapsed < Duration::from_secs(1));
     }
 
-    #[tokio::test]
+    #[test]
+    fn test_retry_after_does_not_advance_fallback_backoff() {
+        let initial_backoff = Duration::from_millis(200);
+
+        let backoff_after_retry_after_retries = (0..3).fold(initial_backoff, |backoff, _| {
+            next_fallback_backoff(backoff, Some(Duration::from_millis(1)))
+        });
+
+        assert_eq!(backoff_after_retry_after_retries, initial_backoff);
+        assert_eq!(
+            next_fallback_backoff(backoff_after_retry_after_retries, None),
+            Duration::from_millis(400)
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
     async fn test_with_retry_does_not_advance_backoff_while_retry_after_is_used() {
         let config = RetryConfig {
             max_retries: 4,
@@ -413,7 +434,7 @@ mod tests {
         let attempt_count_clone = attempt_count.clone();
 
         let result = tokio::time::timeout(
-            Duration::from_millis(700),
+            Duration::from_millis(250),
             with_retry(
                 &config,
                 "test",


### PR DESCRIPTION
## Summary
- Keep the fallback exponential backoff unchanged for retries that slept via `Retry-After`.
- Advance the fallback backoff only after a header-less retry actually uses it.
- Add regression coverage for a sequence of `Retry-After` retries followed by a fallback retry.

## Test Plan
- `cargo test push::retry::tests::test_with_retry_does_not_advance_backoff_while_retry_after_is_used -- --nocapture` (fails before the fix; passes after)
- `cargo fmt --all -- --check`
- `RUSTFLAGS=-Dwarnings cargo check --all-targets`
- `RUSTFLAGS=-Dwarnings cargo clippy --all-targets -- -D warnings`
- `RUSTFLAGS=-Dwarnings cargo test --all-targets`
- `./scripts/cargo-audit.sh`
- `RUSTFLAGS=-Dwarnings cargo check --all-targets --features tor`
- `RUSTFLAGS=-Dwarnings cargo test --all-targets --features tor`
- `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --document-private-items`

Closes #116


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/transponder/pull/134">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retry behavior so fallback backoff now stays unchanged when a `Retry-After` value is provided, and only increases when no retry delay is given.
  * Preserved the existing exponential backoff cap while making repeated retry timing more consistent.
* **Tests**
  * Added coverage for retry delay handling to confirm fallback backoff does not advance when `Retry-After` is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->