### PR TITLE
fix: preserve refreshed push auth tokens

### DIFF
--- a/src/push/apns.rs
+++ b/src/push/apns.rs
@@ -317,9 +317,21 @@ impl ApnsClient {
             .json(&request_parts.payload)
     }
 
-    async fn invalidate_cached_token(&self) {
+    /// Invalidate the cached token only if it still matches the one the failing
+    /// request used.
+    ///
+    /// Under concurrency another task may have already refreshed the cache with
+    /// a fresh token between the time this request read its token and the time
+    /// the authentication rejection came back. Evicting unconditionally would
+    /// discard that valid token and force redundant JWT regeneration, so the
+    /// eviction is gated on the cached entry still being the failing token.
+    async fn invalidate_cached_token(&self, failing_token: &str) {
         let mut cached = self.cached_token.write().await;
-        if cached.take().is_some() {
+        if cached
+            .as_ref()
+            .is_some_and(|token| token.token.as_str() == failing_token)
+        {
+            *cached = None;
             debug!("Invalidated cached APNs JWT after authentication rejection");
         }
     }
@@ -328,6 +340,7 @@ impl ApnsClient {
         &self,
         start: Instant,
         response: reqwest::Response,
+        auth_token: &str,
     ) -> SendAttemptResult {
         let status = response.status();
 
@@ -357,7 +370,7 @@ impl ApnsClient {
                 SendAttemptResult::Success(false)
             }
             403 => {
-                self.invalidate_cached_token().await;
+                self.invalidate_cached_token(auth_token).await;
                 let error: ApnsErrorResponse = response.json().await.unwrap_or(ApnsErrorResponse {
                     reason: "Unknown".to_string(),
                 });
@@ -459,7 +472,7 @@ impl ApnsClient {
             Err(e) => return SendAttemptResult::Permanent(e),
         };
 
-        self.handle_response(start, response).await
+        self.handle_response(start, response, token.as_str()).await
     }
 
     /// Check if the client is properly configured.
@@ -963,7 +976,9 @@ mod tests {
             .await
             .unwrap();
 
-        let result = client.handle_response(Instant::now(), response).await;
+        let result = client
+            .handle_response(Instant::now(), response, "poisoned-jwt")
+            .await;
 
         assert!(matches!(
             result,
@@ -971,6 +986,56 @@ mod tests {
                 if message.contains("BadJwtToken")
         ));
         assert!(client.cached_token.read().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_auth_error_keeps_token_refreshed_by_concurrent_task() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path_regex(r"/3/device/[a-f0-9]+"))
+            .respond_with(ResponseTemplate::new(403).set_body_json(serde_json::json!({
+                "reason": "InvalidProviderToken"
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let client = ApnsClient::mock(test_config(), false);
+
+        // Simulate a concurrent task having already refreshed the cache to a
+        // newer token after the failing request read its (now stale) token.
+        {
+            let mut cached = client.cached_token.write().await;
+            *cached = Some(CachedToken {
+                token: Zeroizing::new("fresh-jwt".to_string()),
+                expires_at: SystemTime::now() + TOKEN_LIFETIME,
+            });
+        }
+
+        let response = Client::new()
+            .post(format!("{}/3/device/{}", mock_server.uri(), "deadbeef1234"))
+            .send()
+            .await
+            .unwrap();
+
+        // The failing request used the older, now-replaced token.
+        let result = client
+            .handle_response(Instant::now(), response, "stale-jwt")
+            .await;
+
+        assert!(matches!(
+            result,
+            SendAttemptResult::Permanent(Error::Apns(ref message))
+                if message.contains("InvalidProviderToken")
+        ));
+
+        // The freshly refreshed token must survive the stale rejection.
+        let cached = client.cached_token.read().await;
+        assert_eq!(
+            cached.as_ref().map(|token| token.token.as_str()),
+            Some("fresh-jwt")
+        );
     }
 
     #[test]

--- a/src/push/fcm.rs
+++ b/src/push/fcm.rs
@@ -331,9 +331,21 @@ impl FcmClient {
             .json(&request)
     }
 
-    async fn invalidate_cached_token(&self) {
+    /// Invalidate the cached token only if it still matches the one the failing
+    /// request used.
+    ///
+    /// Under concurrency another task may have already refreshed the cache with
+    /// a fresh token between the time this request read its token and the time
+    /// the authentication rejection came back. Evicting unconditionally would
+    /// discard that valid token and force a redundant OAuth round-trip, so the
+    /// eviction is gated on the cached entry still being the failing token.
+    async fn invalidate_cached_token(&self, failing_token: &str) {
         let mut cached = self.cached_token.write().await;
-        if cached.take().is_some() {
+        if cached
+            .as_ref()
+            .is_some_and(|token| token.token.as_str() == failing_token)
+        {
+            *cached = None;
             debug!("Invalidated cached FCM OAuth token after authentication rejection");
         }
     }
@@ -342,6 +354,7 @@ impl FcmClient {
         &self,
         start: Instant,
         response: reqwest::Response,
+        access_token: &str,
     ) -> SendAttemptResult {
         let status = response.status();
 
@@ -372,7 +385,7 @@ impl FcmClient {
             }
             401 => {
                 // Auth error - permanent for this request, refresh on the next one.
-                self.invalidate_cached_token().await;
+                self.invalidate_cached_token(access_token).await;
                 error!("FCM authentication error");
                 SendAttemptResult::Permanent(Error::Fcm("Authentication error".to_string()))
             }
@@ -445,7 +458,8 @@ impl FcmClient {
             Err(e) => return SendAttemptResult::Permanent(e),
         };
 
-        self.handle_response(start, response).await
+        self.handle_response(start, response, access_token.as_str())
+            .await
     }
 
     /// Check if the client is properly configured.
@@ -840,7 +854,9 @@ mod tests {
             .await
             .unwrap();
 
-        let result = client.handle_response(Instant::now(), response).await;
+        let result = client
+            .handle_response(Instant::now(), response, "poisoned-access-token")
+            .await;
 
         assert!(matches!(
             result,
@@ -848,6 +864,68 @@ mod tests {
                 if message.contains("Authentication error")
         ));
         assert!(client.cached_token.read().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_auth_error_keeps_token_refreshed_by_concurrent_task() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path_regex(r"/v1/projects/.+/messages:send"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "error": {
+                    "code": 401,
+                    "message": "Request had invalid authentication credentials.",
+                    "status": "UNAUTHENTICATED"
+                }
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let config = FcmConfig {
+            enabled: true,
+            service_account_path: String::new(),
+            project_id: "test-project".to_string(),
+        };
+        let client = FcmClient::mock(config, false);
+
+        // Simulate a concurrent task having already refreshed the cache to a
+        // newer token after the failing request read its (now stale) token.
+        {
+            let mut cached = client.cached_token.write().await;
+            *cached = Some(CachedToken {
+                token: Zeroizing::new("fresh-access-token".to_string()),
+                expires_at: SystemTime::now() + TOKEN_LIFETIME,
+            });
+        }
+
+        let response = Client::new()
+            .post(format!(
+                "{}/v1/projects/test-project/messages:send",
+                mock_server.uri()
+            ))
+            .send()
+            .await
+            .unwrap();
+
+        // The failing request used the older, now-replaced token.
+        let result = client
+            .handle_response(Instant::now(), response, "stale-access-token")
+            .await;
+
+        assert!(matches!(
+            result,
+            SendAttemptResult::Permanent(Error::Fcm(ref message))
+                if message.contains("Authentication error")
+        ));
+
+        // The freshly refreshed token must survive the stale rejection.
+        let cached = client.cached_token.read().await;
+        assert_eq!(
+            cached.as_ref().map(|token| token.token.as_str()),
+            Some("fresh-access-token")
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #117

## Summary
- Make APNs and FCM auth-token invalidation conditional on the cached token still matching the token used by the rejected request.
- Pass the request's auth token into response handling so a stale 403/401 cannot evict a newer token installed by a concurrent refresh.
- Add APNs and FCM regression tests proving stale auth failures preserve a refreshed cached token while same-token failures still invalidate.

## Verification
- `cargo fmt --all -- --check` — pass
- `RUSTFLAGS=-Dwarnings cargo check --all-targets` — pass
- `RUSTFLAGS=-Dwarnings cargo clippy --all-targets -- -D warnings` — pass
- `RUSTFLAGS=-Dwarnings cargo test --all-targets push::` — pass, 120 push tests + 0 integration filtered tests
- `RUSTFLAGS=-Dwarnings cargo test --all-targets` — pass, 335 unit tests + 4 integration tests
- `RUSTFLAGS=-Dwarnings cargo check --all-targets --features tor` — pass
- `RUSTFLAGS=-Dwarnings cargo test --all-targets --features tor` — pass, 336 unit tests + 4 integration tests
- `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --document-private-items` — pass
- `./scripts/cargo-audit.sh` — pass with 3 existing allowed warnings (`memmap2`, `rand` 0.8, `rand` 0.9)

Note: first tor test attempt hit `No space left on device`; I freed stale Rust target artifacts from inactive worktrees and reran the remaining gates successfully.

## Sensitive paths
- `src/push/apns.rs` — APNs auth-token cache invalidation logic and tests
- `src/push/fcm.rs` — FCM auth-token cache invalidation logic and tests


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/transponder/pull/135">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->