### PR TITLE
fix: quiet hot-path Nostr event logging

### DIFF
--- a/src/nostr/events.rs
+++ b/src/nostr/events.rs
@@ -223,7 +223,11 @@ impl EventProcessor {
             m.record_event_received();
         }
 
-        info!(event_id = %event.id, "Received Nostr notification event");
+        // Logged at trace, not info: the kind:1059 event ID is a stable,
+        // public correlation handle. Emitting it per-event at info would
+        // persist delivery-timing metadata in logs (and downstream log
+        // shipping) — exactly what this privacy-preserving server avoids.
+        trace!(event_id = %event.id, "Received Nostr notification event");
 
         // Check for duplicates and atomically reserve the event ID.
         //
@@ -366,7 +370,7 @@ impl EventProcessor {
             }
         };
 
-        info!("Unwrapped notification request");
+        debug!("Unwrapped notification request");
 
         // Parse the encrypted tokens from the content
         let parse_started_at = StageTimer::start();
@@ -399,7 +403,7 @@ impl EventProcessor {
             return Ok(0);
         }
 
-        info!(token_count = token_bytes.len(), "Decrypting tokens");
+        debug!(token_count = token_bytes.len(), "Decrypting tokens");
 
         // Decrypt each token and dispatch notifications, with rate limiting.
         //


### PR DESCRIPTION
Closes #115

## Summary
- Moved the hot-path gift-wrap received log from `info!` to `trace!` so the stable public Nostr event ID is no longer emitted at INFO.
- Demoted the other per-event hot-path INFO logs (`Unwrapped notification request`, `Decrypting tokens`) to `debug!` to reduce log volume under load.
- Left the aggregate successful-processing INFO line intact because it carries only admitted count, not a durable event correlation handle.

## Verification
- `cargo fmt --all -- --check`
- `RUSTFLAGS='-Dwarnings' cargo check --all-targets`
- `RUSTFLAGS='-Dwarnings' cargo clippy --all-targets -- -D warnings`
- `RUSTFLAGS='-Dwarnings' cargo test --all-targets`
- `RUSTFLAGS='-Dwarnings' cargo check --all-targets --features tor`
- `RUSTFLAGS='-Dwarnings' cargo test --all-targets --features tor`
- `RUSTDOCFLAGS='-Dwarnings' cargo doc --no-deps --document-private-items`
- `./scripts/cargo-audit.sh` (passes with 3 allowed warnings from the repo audit script)

## Sensitive paths
- `src/nostr/events.rs` — repo-sensitive path. Change is limited to log levels/commentary; no crypto, key handling, dedup, rate-limiter, or push behavior changed.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/transponder/pull/136">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->