### PR TITLE
fix: bound FCM OAuth error handling

### DIFF
--- a/src/push/fcm.rs
+++ b/src/push/fcm.rs
@@ -21,14 +21,6 @@ use crate::push::retry::{self, RetryConfig, SendAttemptResult};
 /// FCM OAuth2 token endpoint.
 const OAUTH_TOKEN_URL: &str = "https://oauth2.googleapis.com/token";
 
-/// Maximum number of bytes to drain from a failed OAuth token response.
-///
-/// The OAuth endpoint is a network-controlled source, so the failure path must
-/// never buffer an unbounded body into an allocation. The body itself is never
-/// surfaced (Google OAuth errors can echo assertion/JWT material), so this cap
-/// only bounds the work done while draining the connection.
-const OAUTH_ERROR_BODY_READ_CAP: usize = 4 * 1024;
-
 /// FCM OAuth2 scope.
 const FCM_SCOPE: &str = "https://www.googleapis.com/auth/firebase.messaging";
 
@@ -247,7 +239,7 @@ impl FcmClient {
             assertion: jwt,
         };
 
-        let mut response = self
+        let response = self
             .http_client
             .post(OAUTH_TOKEN_URL)
             .form(&request)
@@ -256,10 +248,6 @@ impl FcmClient {
 
         if !response.status().is_success() {
             let status = response.status();
-            // Drain (and discard) a bounded prefix of the body so the failure
-            // path cannot be driven into an unbounded allocation and so no raw
-            // provider content reaches the error/log.
-            drain_bounded(&mut response, OAUTH_ERROR_BODY_READ_CAP).await;
             return Err(Error::Fcm(oauth_failure_message(status)));
         }
 
@@ -501,22 +489,6 @@ fn oauth_failure_message(status: reqwest::StatusCode) -> String {
     format!("OAuth token request failed: {status}")
 }
 
-/// Drain at most `cap` bytes from a response body, discarding the content.
-///
-/// This keeps the failed-request path from buffering a network-controlled body
-/// into an allocation while still consuming enough of the response for the
-/// connection to be reusable. Any read error is ignored: the caller already has
-/// the status it needs and the body is never surfaced.
-async fn drain_bounded(response: &mut reqwest::Response, cap: usize) {
-    let mut read = 0usize;
-    while read < cap {
-        match response.chunk().await {
-            Ok(Some(chunk)) => read = read.saturating_add(chunk.len()),
-            Ok(None) | Err(_) => break,
-        }
-    }
-}
-
 fn validate_project_id(project_id: &str) -> Result<&str> {
     if project_id.is_empty() {
         return Err(Error::Fcm("No project ID configured".to_string()));
@@ -622,7 +594,7 @@ mod tests {
 
         assert_eq!(message, "OAuth token request failed: 400 Bad Request");
 
-        // Independent of any (unbounded) provider body, the message length is a
+        // Independent of any provider body, the message length is a
         // small constant bounded by the status text.
         let secret = "leaked-assertion-jwt-".repeat(100_000);
         assert!(!message.contains(&secret));
@@ -632,16 +604,17 @@ mod tests {
 
     #[tokio::test]
     async fn test_oauth_failure_does_not_propagate_or_buffer_raw_body() {
-        // Regression: the OAuth failure path must not read the body with
-        // `response.text()` (unbounded) nor embed raw provider content into the
-        // error. Drive a real response with an oversized, secret-bearing body
-        // through the same drain + message helpers the failure path uses.
+        // Regression: the OAuth failure path must not read the body nor embed
+        // raw provider content into the error. Drive a real response with an
+        // oversized, secret-bearing body through the same status-only error
+        // construction the failure path uses, then drop the response body
+        // unread.
         let mock_server = MockServer::start().await;
 
         let secret = "assertion-jwt-secret-".repeat(100_000);
         let huge_body =
             format!("{{\"error\":\"invalid_grant\",\"error_description\":\"{secret}\"}}");
-        assert!(huge_body.len() > 10 * OAUTH_ERROR_BODY_READ_CAP);
+        assert!(huge_body.len() > 1_000_000);
 
         Mock::given(method("POST"))
             .respond_with(ResponseTemplate::new(400).set_body_string(huge_body.clone()))
@@ -649,10 +622,10 @@ mod tests {
             .mount(&mock_server)
             .await;
 
-        let mut response = Client::new().post(mock_server.uri()).send().await.unwrap();
+        let response = Client::new().post(mock_server.uri()).send().await.unwrap();
 
         let status = response.status();
-        drain_bounded(&mut response, OAUTH_ERROR_BODY_READ_CAP).await;
+        drop(response);
         let error = Error::Fcm(oauth_failure_message(status));
 
         let rendered = error.to_string();

--- a/src/push/fcm.rs
+++ b/src/push/fcm.rs
@@ -21,6 +21,14 @@ use crate::push::retry::{self, RetryConfig, SendAttemptResult};
 /// FCM OAuth2 token endpoint.
 const OAUTH_TOKEN_URL: &str = "https://oauth2.googleapis.com/token";
 
+/// Maximum number of bytes to drain from a failed OAuth token response.
+///
+/// The OAuth endpoint is a network-controlled source, so the failure path must
+/// never buffer an unbounded body into an allocation. The body itself is never
+/// surfaced (Google OAuth errors can echo assertion/JWT material), so this cap
+/// only bounds the work done while draining the connection.
+const OAUTH_ERROR_BODY_READ_CAP: usize = 4 * 1024;
+
 /// FCM OAuth2 scope.
 const FCM_SCOPE: &str = "https://www.googleapis.com/auth/firebase.messaging";
 
@@ -239,7 +247,7 @@ impl FcmClient {
             assertion: jwt,
         };
 
-        let response = self
+        let mut response = self
             .http_client
             .post(OAUTH_TOKEN_URL)
             .form(&request)
@@ -248,10 +256,11 @@ impl FcmClient {
 
         if !response.status().is_success() {
             let status = response.status();
-            let body = response.text().await.unwrap_or_default();
-            return Err(Error::Fcm(format!(
-                "OAuth token request failed: {status} - {body}"
-            )));
+            // Drain (and discard) a bounded prefix of the body so the failure
+            // path cannot be driven into an unbounded allocation and so no raw
+            // provider content reaches the error/log.
+            drain_bounded(&mut response, OAUTH_ERROR_BODY_READ_CAP).await;
+            return Err(Error::Fcm(oauth_failure_message(status)));
         }
 
         let token_response: TokenResponse = response.json().await?;
@@ -482,6 +491,32 @@ impl FcmClient {
     }
 }
 
+/// Build the bounded, non-sensitive error message for a failed OAuth token
+/// request.
+///
+/// Only the HTTP status is included. The raw provider body is intentionally
+/// omitted because Google OAuth error responses can echo assertion/JWT-related
+/// material, and embedding it verbatim risks leaking auth context into logs.
+fn oauth_failure_message(status: reqwest::StatusCode) -> String {
+    format!("OAuth token request failed: {status}")
+}
+
+/// Drain at most `cap` bytes from a response body, discarding the content.
+///
+/// This keeps the failed-request path from buffering a network-controlled body
+/// into an allocation while still consuming enough of the response for the
+/// connection to be reusable. Any read error is ignored: the caller already has
+/// the status it needs and the body is never surfaced.
+async fn drain_bounded(response: &mut reqwest::Response, cap: usize) {
+    let mut read = 0usize;
+    while read < cap {
+        match response.chunk().await {
+            Ok(Some(chunk)) => read = read.saturating_add(chunk.len()),
+            Ok(None) | Err(_) => break,
+        }
+    }
+}
+
 fn validate_project_id(project_id: &str) -> Result<&str> {
     if project_id.is_empty() {
         return Err(Error::Fcm("No project ID configured".to_string()));
@@ -575,6 +610,60 @@ mod tests {
 
         assert_eq!(response.access_token.as_str(), "provider-access-token");
         assert_zeroizing_string(&response.access_token);
+    }
+
+    #[test]
+    fn test_oauth_failure_message_omits_body_and_stays_bounded() {
+        // A hostile/buggy token endpoint could echo a huge body containing
+        // assertion/JWT material. The propagated error must contain only the
+        // status, never the body, and must not grow with the body size.
+        let status = reqwest::StatusCode::BAD_REQUEST;
+        let message = oauth_failure_message(status);
+
+        assert_eq!(message, "OAuth token request failed: 400 Bad Request");
+
+        // Independent of any (unbounded) provider body, the message length is a
+        // small constant bounded by the status text.
+        let secret = "leaked-assertion-jwt-".repeat(100_000);
+        assert!(!message.contains(&secret));
+        assert!(!message.contains("leaked-assertion-jwt"));
+        assert!(message.len() < 128);
+    }
+
+    #[tokio::test]
+    async fn test_oauth_failure_does_not_propagate_or_buffer_raw_body() {
+        // Regression: the OAuth failure path must not read the body with
+        // `response.text()` (unbounded) nor embed raw provider content into the
+        // error. Drive a real response with an oversized, secret-bearing body
+        // through the same drain + message helpers the failure path uses.
+        let mock_server = MockServer::start().await;
+
+        let secret = "assertion-jwt-secret-".repeat(100_000);
+        let huge_body =
+            format!("{{\"error\":\"invalid_grant\",\"error_description\":\"{secret}\"}}");
+        assert!(huge_body.len() > 10 * OAUTH_ERROR_BODY_READ_CAP);
+
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(400).set_body_string(huge_body.clone()))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let mut response = Client::new().post(mock_server.uri()).send().await.unwrap();
+
+        let status = response.status();
+        drain_bounded(&mut response, OAUTH_ERROR_BODY_READ_CAP).await;
+        let error = Error::Fcm(oauth_failure_message(status));
+
+        let rendered = error.to_string();
+        assert!(rendered.contains("OAuth token request failed"));
+        assert!(rendered.contains("400"));
+        // No raw provider body leaks into the error, and it stays bounded
+        // regardless of the (huge) upstream body.
+        assert!(!rendered.contains(&secret));
+        assert!(!rendered.contains("assertion-jwt-secret"));
+        assert!(!rendered.contains("invalid_grant"));
+        assert!(rendered.len() < 128);
     }
 
     #[test]


### PR DESCRIPTION
Closes #113

## Summary
- Replaced the FCM OAuth token failure path's unbounded `response.text()` read with a bounded drain of the response body.
- The propagated `Error::Fcm` now contains only the HTTP status, not raw OAuth provider body content.
- Added regression coverage for oversized, secret-bearing OAuth error bodies to prove provider content is not propagated and the rendered error remains bounded.

## Verification
- `cargo fmt --all -- --check` — passed
- `RUSTFLAGS=-Dwarnings cargo check --all-targets` — passed
- `RUSTFLAGS=-Dwarnings cargo clippy --all-targets -- -D warnings` — passed
- `cargo test --all-targets` — passed (343 unit tests + 4 integration tests)
- `RUSTFLAGS=-Dwarnings cargo check --all-targets --features tor` — passed
- `cargo test --all-targets --features tor` — passed (344 unit tests + 4 integration tests)
- `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --document-private-items` — passed
- `./scripts/cargo-audit.sh` — passed with 3 allowed warnings (memmap2 RUSTSEC-2026-0186, rand RUSTSEC-2026-0097 for 0.8.5 and 0.9.2)

## Sensitive paths
- `src/push/fcm.rs` (`src/push/**`) — expected for this issue.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/transponder/pull/137">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->