### PR TITLE
fix: classify push provider errors precisely

### DIFF
--- a/src/push/apns.rs
+++ b/src/push/apns.rs
@@ -9,7 +9,7 @@ use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
-use tracing::{debug, trace};
+use tracing::{debug, trace, warn};
 use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
 use crate::config::{ApnsConfig, ApnsPayloadMode};
@@ -149,6 +149,41 @@ impl ApnsRequestParts {
 #[derive(Debug, Deserialize)]
 struct ApnsErrorResponse {
     reason: String,
+}
+
+/// Classification of an APNs `400 Bad Request` `reason`.
+///
+/// APNs returns `400` both for a genuinely dead device token and for
+/// server-side misconfiguration (bad topic, bad priority, malformed payload,
+/// etc.). Collapsing every `400` into "token dead" would silently drop every
+/// notification on a single config mistake *and* unregister healthy device
+/// tokens, so the two cases must be distinguished. See issue #111.
+#[derive(Debug, PartialEq, Eq)]
+enum Apns400Classification {
+    /// The provider explicitly identified the device token as invalid for this
+    /// app; the token should be treated as dead (`Success(false)`).
+    TokenDead,
+    /// A configuration or request-construction error that is permanent for this
+    /// provider but unrelated to the device token; must surface as an error
+    /// rather than evicting the token.
+    Permanent,
+}
+
+/// Classify an APNs `400` `reason` as either a dead device token or a
+/// permanent provider/configuration error.
+///
+/// Only `BadDeviceToken`, `DeviceTokenNotForTopic`, and `Unregistered` indicate
+/// that the device token itself is invalid. Every other reason (and any
+/// unrecognised reason) is a permanent error so callers do not evict an
+/// otherwise-healthy token.
+#[must_use]
+fn classify_apns_400(reason: &str) -> Apns400Classification {
+    match reason {
+        "BadDeviceToken" | "DeviceTokenNotForTopic" | "Unregistered" => {
+            Apns400Classification::TokenDead
+        }
+        _ => Apns400Classification::Permanent,
+    }
 }
 
 /// Validate an APNs device token format.
@@ -374,12 +409,30 @@ impl ApnsClient {
                 let error: ApnsErrorResponse = response.json().await.unwrap_or(ApnsErrorResponse {
                     reason: "Unknown".to_string(),
                 });
-                debug!(
-                    payload_mode = %self.config.payload_mode,
-                    reason = %error.reason,
-                    "APNs bad request"
-                );
-                SendAttemptResult::Success(false)
+                match classify_apns_400(&error.reason) {
+                    Apns400Classification::TokenDead => {
+                        debug!(
+                            payload_mode = %self.config.payload_mode,
+                            reason = %error.reason,
+                            "APNs bad device token"
+                        );
+                        SendAttemptResult::Success(false)
+                    }
+                    Apns400Classification::Permanent => {
+                        // Configuration/request error (e.g. BadTopic, MissingTopic,
+                        // BadPriority): surface as a permanent error instead of
+                        // silently dropping the notification and evicting the token.
+                        warn!(
+                            payload_mode = %self.config.payload_mode,
+                            reason = %error.reason,
+                            "APNs rejected request (configuration or request error)"
+                        );
+                        SendAttemptResult::Permanent(Error::Apns(format!(
+                            "Bad request: {}",
+                            error.reason
+                        )))
+                    }
+                }
             }
             403 => {
                 self.invalidate_cached_token(auth_token).await;
@@ -914,6 +967,102 @@ mod tests {
         assert_eq!(response.status(), 400);
         let body: ApnsErrorResponse = response.json().await.unwrap();
         assert_eq!(body.reason, "BadDeviceToken");
+    }
+
+    #[test]
+    fn test_classify_apns_400_token_dead_reasons() {
+        // Only genuine device-token rejections should evict the token.
+        assert_eq!(
+            classify_apns_400("BadDeviceToken"),
+            Apns400Classification::TokenDead
+        );
+        assert_eq!(
+            classify_apns_400("DeviceTokenNotForTopic"),
+            Apns400Classification::TokenDead
+        );
+        assert_eq!(
+            classify_apns_400("Unregistered"),
+            Apns400Classification::TokenDead
+        );
+    }
+
+    #[test]
+    fn test_classify_apns_400_configuration_reasons_are_permanent() {
+        // Configuration / request-construction errors must NOT evict the token.
+        for reason in [
+            "BadTopic",
+            "MissingTopic",
+            "TopicDisallowed",
+            "BadPriority",
+            "BadExpirationDate",
+            "PayloadEmpty",
+            "BadMessageId",
+            "Unknown",
+            "SomeFutureReason",
+        ] {
+            assert_eq!(
+                classify_apns_400(reason),
+                Apns400Classification::Permanent,
+                "reason {reason} should be classified as a permanent error"
+            );
+        }
+    }
+
+    async fn apns_400_result(reason: &str) -> SendAttemptResult {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path_regex(r"/3/device/[a-f0-9]+"))
+            .respond_with(ResponseTemplate::new(400).set_body_json(serde_json::json!({
+                "reason": reason
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let client = ApnsClient::mock(test_config(), false);
+        let response = Client::new()
+            .post(format!("{}/3/device/{}", mock_server.uri(), "deadbeef1234"))
+            .send()
+            .await
+            .unwrap();
+
+        client
+            .handle_response(Instant::now(), response, "test-token")
+            .await
+    }
+
+    #[tokio::test]
+    async fn test_handle_response_400_bad_device_token_is_token_dead() {
+        // BadDeviceToken must continue to signal token death (Ok(false)).
+        let result = apns_400_result("BadDeviceToken").await;
+        assert!(matches!(result, SendAttemptResult::Success(false)));
+    }
+
+    #[tokio::test]
+    async fn test_handle_response_400_device_token_not_for_topic_is_token_dead() {
+        let result = apns_400_result("DeviceTokenNotForTopic").await;
+        assert!(matches!(result, SendAttemptResult::Success(false)));
+    }
+
+    #[tokio::test]
+    async fn test_handle_response_400_bad_topic_is_permanent_error() {
+        // Server-side misconfiguration must be a permanent error, not token death.
+        let result = apns_400_result("BadTopic").await;
+        assert!(matches!(
+            result,
+            SendAttemptResult::Permanent(Error::Apns(ref message))
+                if message.contains("BadTopic")
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_handle_response_400_missing_topic_is_permanent_error() {
+        let result = apns_400_result("MissingTopic").await;
+        assert!(matches!(
+            result,
+            SendAttemptResult::Permanent(Error::Apns(ref message))
+                if message.contains("MissingTopic")
+        ));
     }
 
     #[tokio::test]

--- a/src/push/fcm.rs
+++ b/src/push/fcm.rs
@@ -24,6 +24,12 @@ const OAUTH_TOKEN_URL: &str = "https://oauth2.googleapis.com/token";
 /// FCM OAuth2 scope.
 const FCM_SCOPE: &str = "https://www.googleapis.com/auth/firebase.messaging";
 
+/// Type URL used by FCM v1 to carry provider-specific error codes.
+const FCM_ERROR_DETAIL_TYPE: &str = "type.googleapis.com/google.firebase.fcm.v1.FcmError";
+
+/// FCM provider-specific error code for an unregistered/dead device token.
+const FCM_ERROR_UNREGISTERED: &str = "UNREGISTERED";
+
 /// Access token lifetime (50 minutes).
 const TOKEN_LIFETIME: Duration = Duration::from_secs(50 * 60);
 
@@ -118,6 +124,16 @@ struct FcmError {
     code: u32,
     message: String,
     status: String,
+    #[serde(default)]
+    details: Vec<FcmErrorDetail>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FcmErrorDetail {
+    #[serde(rename = "@type")]
+    type_url: Option<String>,
+    #[serde(rename = "errorCode")]
+    error_code: Option<String>,
 }
 
 /// Classification of an FCM error response.
@@ -140,18 +156,24 @@ enum FcmClassification {
     Permanent,
 }
 
-/// Classify an FCM error `status` as either an unregistered (dead) token or a
+/// Classify an FCM error response as either an unregistered (dead) token or a
 /// permanent provider/configuration error.
 ///
-/// Only the explicit `UNREGISTERED` status identifies the device token as dead.
-/// Every other status — including `INVALID_ARGUMENT`, `NOT_FOUND` (which can be
-/// a wrong project ID), and any unrecognised status — is a permanent error so
-/// callers do not evict an otherwise-healthy token.
+/// The provider-specific `google.firebase.fcm.v1.FcmError.errorCode` detail is
+/// the discriminator for token death. The generic top-level status can be
+/// `NOT_FOUND` for both unregistered tokens and wrong-project misconfiguration,
+/// so it is not enough by itself.
 #[must_use]
-fn classify_fcm_error(status: &str) -> FcmClassification {
-    match status {
-        "UNREGISTERED" => FcmClassification::TokenDead,
-        _ => FcmClassification::Permanent,
+fn classify_fcm_error(error: &FcmError) -> FcmClassification {
+    let token_unregistered = error.details.iter().any(|detail| {
+        detail.type_url.as_deref() == Some(FCM_ERROR_DETAIL_TYPE)
+            && detail.error_code.as_deref() == Some(FCM_ERROR_UNREGISTERED)
+    });
+
+    if token_unregistered {
+        FcmClassification::TokenDead
+    } else {
+        FcmClassification::Permanent
     }
 }
 
@@ -399,10 +421,11 @@ impl FcmClient {
     ///
     /// `default_status` is used when the body cannot be parsed (e.g. an empty
     /// or non-JSON body), preserving the provider's HTTP-status-implied default
-    /// classification. Only an explicit `UNREGISTERED` status is treated as a
-    /// dead device token; every other status — including `INVALID_ARGUMENT` and
-    /// `NOT_FOUND` (which can mean a misconfigured project ID) — is surfaced as
-    /// a permanent error so a healthy token is not evicted. See issue #111.
+    /// classification. Only a provider-specific FCM detail with
+    /// `errorCode: "UNREGISTERED"` is treated as a dead device token; every
+    /// other response — including `INVALID_ARGUMENT` and `NOT_FOUND` (which can
+    /// mean a misconfigured project ID) — is surfaced as a permanent error so a
+    /// healthy token is not evicted. See issue #111.
     async fn classify_error_response(
         &self,
         response: reqwest::Response,
@@ -414,10 +437,11 @@ impl FcmClient {
                 code: default_code,
                 message: "Unknown".to_string(),
                 status: default_status.to_string(),
+                details: Vec::new(),
             },
         });
 
-        match classify_fcm_error(&error.error.status) {
+        match classify_fcm_error(&error.error) {
             FcmClassification::TokenDead => {
                 info!(status = %error.error.status, "FCM token unregistered");
                 SendAttemptResult::Success(false)
@@ -843,17 +867,25 @@ mod tests {
     }
 
     #[test]
-    fn test_classify_fcm_error_unregistered_is_token_dead() {
-        assert_eq!(
-            classify_fcm_error("UNREGISTERED"),
-            FcmClassification::TokenDead
-        );
+    fn test_classify_fcm_error_unregistered_detail_is_token_dead() {
+        let error = FcmError {
+            code: 404,
+            message: "Requested entity was not found.".to_string(),
+            status: "NOT_FOUND".to_string(),
+            details: vec![FcmErrorDetail {
+                type_url: Some(FCM_ERROR_DETAIL_TYPE.to_string()),
+                error_code: Some(FCM_ERROR_UNREGISTERED.to_string()),
+            }],
+        };
+
+        assert_eq!(classify_fcm_error(&error), FcmClassification::TokenDead);
     }
 
     #[test]
     fn test_classify_fcm_error_other_statuses_are_permanent() {
         // INVALID_ARGUMENT, NOT_FOUND (wrong project), and unknown statuses must
-        // NOT evict the token.
+        // NOT evict the token unless FCM supplies the provider-specific
+        // UNREGISTERED detail.
         for status in [
             "INVALID_ARGUMENT",
             "NOT_FOUND",
@@ -862,29 +894,59 @@ mod tests {
             "Unknown",
             "SOME_FUTURE_STATUS",
         ] {
+            let error = FcmError {
+                code: 400,
+                message: "test error message".to_string(),
+                status: status.to_string(),
+                details: Vec::new(),
+            };
+
             assert_eq!(
-                classify_fcm_error(status),
+                classify_fcm_error(&error),
                 FcmClassification::Permanent,
                 "status {status} should be classified as a permanent error"
             );
         }
+
+        let wrong_detail_type = FcmError {
+            code: 404,
+            message: "Requested entity was not found.".to_string(),
+            status: "NOT_FOUND".to_string(),
+            details: vec![FcmErrorDetail {
+                type_url: Some("type.googleapis.com/google.rpc.BadRequest".to_string()),
+                error_code: Some(FCM_ERROR_UNREGISTERED.to_string()),
+            }],
+        };
+        assert_eq!(
+            classify_fcm_error(&wrong_detail_type),
+            FcmClassification::Permanent
+        );
+
+        let different_fcm_error_code = FcmError {
+            code: 403,
+            message: "Sender ID mismatch".to_string(),
+            status: "PERMISSION_DENIED".to_string(),
+            details: vec![FcmErrorDetail {
+                type_url: Some(FCM_ERROR_DETAIL_TYPE.to_string()),
+                error_code: Some("SENDER_ID_MISMATCH".to_string()),
+            }],
+        };
+        assert_eq!(
+            classify_fcm_error(&different_fcm_error_code),
+            FcmClassification::Permanent
+        );
     }
 
     /// Drive `handle_response` against a mock server returning `status_code`
-    /// with the given FCM error `status`, returning the classified result.
-    async fn fcm_error_result(status_code: u16, status: &str) -> SendAttemptResult {
+    /// with the given FCM error body, returning the classified result.
+    async fn fcm_error_result_with_body(
+        status_code: u16,
+        body: serde_json::Value,
+    ) -> SendAttemptResult {
         let mock_server = MockServer::start().await;
         Mock::given(method("POST"))
             .and(path_regex(r"/v1/projects/.+/messages:send"))
-            .respond_with(
-                ResponseTemplate::new(status_code).set_body_json(serde_json::json!({
-                    "error": {
-                        "code": status_code,
-                        "message": "test error message",
-                        "status": status
-                    }
-                })),
-            )
+            .respond_with(ResponseTemplate::new(status_code).set_body_json(body))
             .expect(1)
             .mount(&mock_server)
             .await;
@@ -910,6 +972,22 @@ mod tests {
             .await
     }
 
+    /// Drive `handle_response` against a mock server returning `status_code`
+    /// with the given FCM error `status`, returning the classified result.
+    async fn fcm_error_result(status_code: u16, status: &str) -> SendAttemptResult {
+        fcm_error_result_with_body(
+            status_code,
+            serde_json::json!({
+                "error": {
+                    "code": status_code,
+                    "message": "test error message",
+                    "status": status
+                }
+            }),
+        )
+        .await
+    }
+
     #[tokio::test]
     async fn test_handle_response_400_invalid_argument_is_permanent_error() {
         // INVALID_ARGUMENT is a malformed-payload/config error, not token death.
@@ -922,16 +1000,37 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_handle_response_400_unregistered_is_token_dead() {
-        // An explicit UNREGISTERED status, even on a 400, signals token death.
-        let result = fcm_error_result(400, "UNREGISTERED").await;
+    async fn test_handle_response_404_unregistered_detail_is_token_dead() {
+        let result = fcm_error_result_with_body(
+            404,
+            serde_json::json!({
+                "error": {
+                    "code": 404,
+                    "message": "Requested entity was not found.",
+                    "status": "NOT_FOUND",
+                    "details": [
+                        {
+                            "@type": "type.googleapis.com/google.firebase.fcm.v1.FcmError",
+                            "errorCode": "UNREGISTERED"
+                        }
+                    ]
+                }
+            }),
+        )
+        .await;
         assert!(matches!(result, SendAttemptResult::Success(false)));
     }
 
     #[tokio::test]
-    async fn test_handle_response_404_unregistered_is_token_dead() {
+    async fn test_handle_response_404_unregistered_status_without_detail_is_permanent_error() {
+        // The generic top-level status is not the FCM provider-specific token
+        // death discriminator; a 404 needs the FcmError detail to evict.
         let result = fcm_error_result(404, "UNREGISTERED").await;
-        assert!(matches!(result, SendAttemptResult::Success(false)));
+        assert!(matches!(
+            result,
+            SendAttemptResult::Permanent(Error::Fcm(ref message))
+                if message.contains("UNREGISTERED")
+        ));
     }
 
     #[tokio::test]

--- a/src/push/fcm.rs
+++ b/src/push/fcm.rs
@@ -120,6 +120,41 @@ struct FcmError {
     status: String,
 }
 
+/// Classification of an FCM error response.
+///
+/// FCM returns `400 INVALID_ARGUMENT` both for a genuinely malformed/expired
+/// token and for malformed payloads or other request-construction errors, and
+/// returns `404 NOT_FOUND` both for an unregistered token *and* for a
+/// wrong/typoed `project_id` in the `/v1/projects/{project_id}/messages:send`
+/// path. Collapsing those into "token dead" would silently drop every
+/// notification on a single config mistake *and* unregister healthy device
+/// tokens, so token death must be signalled explicitly. See issue #111.
+#[derive(Debug, PartialEq, Eq)]
+enum FcmClassification {
+    /// The provider explicitly reported the token as unregistered; the token
+    /// should be treated as dead (`Success(false)`).
+    TokenDead,
+    /// A configuration, payload, or path error that is permanent for this
+    /// provider but unrelated to the device token; must surface as an error
+    /// rather than evicting the token.
+    Permanent,
+}
+
+/// Classify an FCM error `status` as either an unregistered (dead) token or a
+/// permanent provider/configuration error.
+///
+/// Only the explicit `UNREGISTERED` status identifies the device token as dead.
+/// Every other status — including `INVALID_ARGUMENT`, `NOT_FOUND` (which can be
+/// a wrong project ID), and any unrecognised status — is a permanent error so
+/// callers do not evict an otherwise-healthy token.
+#[must_use]
+fn classify_fcm_error(status: &str) -> FcmClassification {
+    match status {
+        "UNREGISTERED" => FcmClassification::TokenDead,
+        _ => FcmClassification::Permanent,
+    }
+}
+
 /// FCM client for sending push notifications.
 pub struct FcmClient {
     pub(crate) http_client: Client,
@@ -359,6 +394,48 @@ impl FcmClient {
         }
     }
 
+    /// Parse an FCM error response and classify it as a dead token or a
+    /// permanent error.
+    ///
+    /// `default_status` is used when the body cannot be parsed (e.g. an empty
+    /// or non-JSON body), preserving the provider's HTTP-status-implied default
+    /// classification. Only an explicit `UNREGISTERED` status is treated as a
+    /// dead device token; every other status — including `INVALID_ARGUMENT` and
+    /// `NOT_FOUND` (which can mean a misconfigured project ID) — is surfaced as
+    /// a permanent error so a healthy token is not evicted. See issue #111.
+    async fn classify_error_response(
+        &self,
+        response: reqwest::Response,
+        default_code: u32,
+        default_status: &str,
+    ) -> SendAttemptResult {
+        let error: FcmErrorResponse = response.json().await.unwrap_or(FcmErrorResponse {
+            error: FcmError {
+                code: default_code,
+                message: "Unknown".to_string(),
+                status: default_status.to_string(),
+            },
+        });
+
+        match classify_fcm_error(&error.error.status) {
+            FcmClassification::TokenDead => {
+                info!(status = %error.error.status, "FCM token unregistered");
+                SendAttemptResult::Success(false)
+            }
+            FcmClassification::Permanent => {
+                warn!(
+                    status = %error.error.status,
+                    message = %error.error.message,
+                    "FCM rejected request (configuration or request error)"
+                );
+                SendAttemptResult::Permanent(Error::Fcm(format!(
+                    "Bad request: {} - {}",
+                    error.error.status, error.error.message
+                )))
+            }
+        }
+    }
+
     async fn handle_response(
         &self,
         start: Instant,
@@ -378,19 +455,8 @@ impl FcmClient {
                 SendAttemptResult::Success(true)
             }
             400 => {
-                let error: FcmErrorResponse = response.json().await.unwrap_or(FcmErrorResponse {
-                    error: FcmError {
-                        code: 400,
-                        message: "Unknown".to_string(),
-                        status: "INVALID_ARGUMENT".to_string(),
-                    },
-                });
-                warn!(
-                    status = %error.error.status,
-                    message = %error.error.message,
-                    "FCM bad request"
-                );
-                SendAttemptResult::Success(false)
+                self.classify_error_response(response, 400, "INVALID_ARGUMENT")
+                    .await
             }
             401 => {
                 // Auth error - permanent for this request, refresh on the next one.
@@ -399,9 +465,8 @@ impl FcmClient {
                 SendAttemptResult::Permanent(Error::Fcm("Authentication error".to_string()))
             }
             404 => {
-                // Token not found (device unregistered)
-                info!("FCM token not found");
-                SendAttemptResult::Success(false)
+                self.classify_error_response(response, 404, "NOT_FOUND")
+                    .await
             }
             429 => {
                 // Rate limited - retriable
@@ -775,6 +840,110 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), 404);
+    }
+
+    #[test]
+    fn test_classify_fcm_error_unregistered_is_token_dead() {
+        assert_eq!(
+            classify_fcm_error("UNREGISTERED"),
+            FcmClassification::TokenDead
+        );
+    }
+
+    #[test]
+    fn test_classify_fcm_error_other_statuses_are_permanent() {
+        // INVALID_ARGUMENT, NOT_FOUND (wrong project), and unknown statuses must
+        // NOT evict the token.
+        for status in [
+            "INVALID_ARGUMENT",
+            "NOT_FOUND",
+            "PERMISSION_DENIED",
+            "SENDER_ID_MISMATCH",
+            "Unknown",
+            "SOME_FUTURE_STATUS",
+        ] {
+            assert_eq!(
+                classify_fcm_error(status),
+                FcmClassification::Permanent,
+                "status {status} should be classified as a permanent error"
+            );
+        }
+    }
+
+    /// Drive `handle_response` against a mock server returning `status_code`
+    /// with the given FCM error `status`, returning the classified result.
+    async fn fcm_error_result(status_code: u16, status: &str) -> SendAttemptResult {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path_regex(r"/v1/projects/.+/messages:send"))
+            .respond_with(
+                ResponseTemplate::new(status_code).set_body_json(serde_json::json!({
+                    "error": {
+                        "code": status_code,
+                        "message": "test error message",
+                        "status": status
+                    }
+                })),
+            )
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let config = FcmConfig {
+            enabled: true,
+            service_account_path: String::new(),
+            project_id: "test-project".to_string(),
+        };
+        let client = FcmClient::mock(config, false);
+
+        let response = Client::new()
+            .post(format!(
+                "{}/v1/projects/test-project/messages:send",
+                mock_server.uri()
+            ))
+            .send()
+            .await
+            .unwrap();
+
+        client
+            .handle_response(Instant::now(), response, "test-access-token")
+            .await
+    }
+
+    #[tokio::test]
+    async fn test_handle_response_400_invalid_argument_is_permanent_error() {
+        // INVALID_ARGUMENT is a malformed-payload/config error, not token death.
+        let result = fcm_error_result(400, "INVALID_ARGUMENT").await;
+        assert!(matches!(
+            result,
+            SendAttemptResult::Permanent(Error::Fcm(ref message))
+                if message.contains("INVALID_ARGUMENT")
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_handle_response_400_unregistered_is_token_dead() {
+        // An explicit UNREGISTERED status, even on a 400, signals token death.
+        let result = fcm_error_result(400, "UNREGISTERED").await;
+        assert!(matches!(result, SendAttemptResult::Success(false)));
+    }
+
+    #[tokio::test]
+    async fn test_handle_response_404_unregistered_is_token_dead() {
+        let result = fcm_error_result(404, "UNREGISTERED").await;
+        assert!(matches!(result, SendAttemptResult::Success(false)));
+    }
+
+    #[tokio::test]
+    async fn test_handle_response_404_not_found_is_permanent_error() {
+        // A 404 without an explicit UNREGISTERED status (e.g. wrong project ID)
+        // must be a permanent error, not token death.
+        let result = fcm_error_result(404, "NOT_FOUND").await;
+        assert!(matches!(
+            result,
+            SendAttemptResult::Permanent(Error::Fcm(ref message))
+                if message.contains("NOT_FOUND")
+        ));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #111

## Summary
- Added explicit APNs 400 classification: only `BadDeviceToken`, `DeviceTokenNotForTopic`, and `Unregistered` signal token death; configuration/request errors now surface as permanent APNs errors instead of `Ok(false)`.
- Added explicit FCM 400/404 classification that decodes `details[]` and only treats `type.googleapis.com/google.firebase.fcm.v1.FcmError` with `errorCode: "UNREGISTERED"` as token death. Plain `INVALID_ARGUMENT`, `NOT_FOUND`, malformed/unknown bodies, and a top-level `UNREGISTERED` status without the FCM detail now surface as permanent FCM errors.
- Added regression coverage for the documented FCM unregistered-token response shape and for the wrong-project/plain-404 path that must not evict tokens.

## Verification
All run locally with `PATH=/home/jeff/.cargo/bin:$PATH CARGO_HOME=/home/jeff/.cargo RUSTUP_HOME=/home/jeff/.rustup`:
- `cargo test --bin transponder push::fcm::tests::test_handle_response_404_unregistered_detail_is_token_dead -- --exact --nocapture` — failed before the fix, passed after.
- `cargo test --bin transponder push::fcm::tests::test_handle_response_404_unregistered_status_without_detail_is_permanent_error -- --exact --nocapture` — pass.
- `cargo test --bin transponder push::fcm::tests::test_classify_fcm_error_unregistered_detail_is_token_dead -- --exact` — pass.
- `cargo test --bin transponder push::fcm::tests::test_classify_fcm_error_other_statuses_are_permanent -- --exact` — pass.
- `RUSTFLAGS=-Dwarnings cargo check --all-targets` — pass.
- `cargo fmt --all -- --check` — pass.
- `RUSTFLAGS=-Dwarnings cargo clippy --all-targets -- -D warnings` — pass.
- `RUSTFLAGS=-Dwarnings cargo test --all-targets` — pass (358 unit tests + 4 generate_keys tests).
- `./scripts/cargo-audit.sh` — pass with 3 allowed policy warnings.
- `RUSTFLAGS=-Dwarnings cargo check --all-targets --features tor` — pass.
- `RUSTFLAGS=-Dwarnings cargo test --all-targets --features tor` — pass (359 unit tests + 4 generate_keys tests).
- `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --document-private-items` — pass.
- `git diff --check` — pass.

## Sensitive paths
- `src/push/apns.rs` — provider error classification controls token eviction behavior.
- `src/push/fcm.rs` — provider error classification controls token eviction behavior.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/transponder/pull/138">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->