### PR TITLE
fix: handle invalid logging filter config

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -596,10 +596,29 @@ async fn run_healthcheck(url: &str) -> Result<()> {
     anyhow::bail!("Healthcheck failed with status {}", response.status())
 }
 
+fn configured_logging_filter(level: &str) -> Result<EnvFilter> {
+    EnvFilter::try_new(level).with_context(|| format!("invalid logging.level filter: {level}"))
+}
+
+fn logging_filter(config: &config::LoggingConfig) -> Result<EnvFilter> {
+    logging_filter_from_env(config, std::env::var(EnvFilter::DEFAULT_ENV))
+}
+
+fn logging_filter_from_env(
+    config: &config::LoggingConfig,
+    env_filter: std::result::Result<String, std::env::VarError>,
+) -> Result<EnvFilter> {
+    match env_filter {
+        Ok(env_filter) => EnvFilter::try_new(&env_filter)
+            .with_context(|| format!("invalid RUST_LOG filter: {env_filter}")),
+        Err(std::env::VarError::NotPresent) => configured_logging_filter(&config.level),
+        Err(error) => Err(error).context("invalid RUST_LOG environment variable"),
+    }
+}
+
 /// Initialize the tracing subscriber based on configuration.
 fn init_logging(config: &config::LoggingConfig) -> Result<()> {
-    let filter =
-        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(&config.level));
+    let filter = logging_filter(config)?;
 
     match config.format.as_str() {
         "json" => {
@@ -739,6 +758,63 @@ mod tests {
 
         assert_eq!(metrics.relay_notifications_lagged_total.get(), 0);
         assert_eq!(metrics.relay_notifications_dropped_total.get(), 0);
+    }
+
+    fn test_logging_config(level: &str) -> config::LoggingConfig {
+        config::LoggingConfig {
+            level: level.to_string(),
+            format: "json".to_string(),
+        }
+    }
+
+    #[test]
+    fn logging_filter_uses_configured_filter_without_env_filter() {
+        assert!(
+            logging_filter_from_env(
+                &test_logging_config("info"),
+                Err(std::env::VarError::NotPresent)
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn logging_filter_rejects_invalid_configured_filter_without_panic() {
+        let config = test_logging_config("target=lvl");
+        let result = std::panic::catch_unwind(|| {
+            logging_filter_from_env(&config, Err(std::env::VarError::NotPresent))
+        });
+        let error = match result.expect("invalid logging.level should not panic") {
+            Ok(_) => panic!("invalid logging.level should return an error"),
+            Err(error) => error,
+        };
+
+        assert!(
+            error
+                .to_string()
+                .contains("invalid logging.level filter: target=lvl")
+        );
+    }
+
+    #[test]
+    fn logging_filter_prefers_env_filter_over_invalid_configured_filter() {
+        assert!(
+            logging_filter_from_env(&test_logging_config("target=lvl"), Ok("warn".to_string()))
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn logging_filter_rejects_invalid_env_filter_without_using_config() {
+        let error =
+            logging_filter_from_env(&test_logging_config("info"), Ok("target=lvl".to_string()))
+                .expect_err("invalid RUST_LOG should return an error");
+
+        assert!(
+            error
+                .to_string()
+                .contains("invalid RUST_LOG filter: target=lvl")
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- replace the panicking `EnvFilter::new` fallback with fallible parsing for configured `logging.level`
- return contextual startup errors for malformed `logging.level` and malformed `RUST_LOG` filters
- preserve `RUST_LOG` precedence while using configured `logging.level` when `RUST_LOG` is absent
- add regression coverage for valid config filters, invalid config filters, env override precedence, and invalid env filters

## Test Plan
- `cargo test logging_filter -- --nocapture`
- `cargo fmt --all -- --check`
- `RUSTFLAGS='-Dwarnings' cargo check --all-targets`
- `RUSTFLAGS='-Dwarnings' cargo clippy --all-targets -- -D warnings`
- `RUSTFLAGS='-Dwarnings' cargo test --all-targets`
- `RUSTFLAGS='-Dwarnings' cargo check --all-targets --features tor`
- `RUSTFLAGS='-Dwarnings' cargo test --all-targets --features tor`
- `RUSTDOCFLAGS='-Dwarnings' cargo doc --no-deps --document-private-items`
- `./scripts/cargo-audit.sh`
- `cargo llvm-cov --all-features --json --output-path /tmp/transponder-114-coverage.json` (94.16809605488851%)

Closes #114


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup logging configuration to handle invalid log filters gracefully instead of crashing.
  * The app now prefers a valid environment-based logging filter when available.
  * If a logging filter is invalid, a clear error message is shown and startup stops cleanly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->