### PR TITLE
fix: warn on degraded relay classes

### DIFF
--- a/src/nostr/client.rs
+++ b/src/nostr/client.rs
@@ -149,22 +149,7 @@ impl RelayClient {
                     "Connected to relays"
                 );
 
-                // A configured relay class with zero live connections silently
-                // degrades the deployment's guarantees: losing all Tor relays
-                // weakens the privacy property, losing all ClearNet relays
-                // weakens reachability. Warn prominently for each such class.
-                if degraded_relay_class(self.config.clearnet.len(), status.clearnet_connected) {
-                    warn!(
-                        configured = self.config.clearnet.len(),
-                        "No ClearNet relays connected at startup; configured ClearNet relays are all down"
-                    );
-                }
-                if degraded_relay_class(self.config.onion.len(), status.tor_connected) {
-                    warn!(
-                        configured = self.config.onion.len(),
-                        "No Tor relays connected at startup; privacy is degraded because configured Tor relays are all down"
-                    );
-                }
+                warn_on_degraded_relay_classes(&self.config, &status);
 
                 return Ok(());
             }
@@ -358,6 +343,35 @@ fn inbox_relay_tags(event: &Event) -> BTreeSet<String> {
         .collect()
 }
 
+fn warn_on_degraded_relay_classes(config: &RelayConfig, status: &RelayStatus) {
+    let (clearnet_degraded, tor_degraded) = degraded_relay_classes(config, status);
+
+    // A configured relay class with zero live connections silently degrades
+    // the deployment's guarantees: losing all Tor relays weakens the privacy
+    // property, losing all ClearNet relays weakens reachability. Warn
+    // prominently for each such class.
+    if clearnet_degraded {
+        warn!(
+            configured = config.clearnet.len(),
+            "No ClearNet relays connected at startup; configured ClearNet relays are all down"
+        );
+    }
+
+    if tor_degraded {
+        warn!(
+            configured = config.onion.len(),
+            "No Tor relays connected at startup; privacy is degraded because configured Tor relays are all down"
+        );
+    }
+}
+
+fn degraded_relay_classes(config: &RelayConfig, status: &RelayStatus) -> (bool, bool) {
+    (
+        degraded_relay_class(config.clearnet.len(), status.clearnet_connected),
+        degraded_relay_class(config.onion.len(), status.tor_connected),
+    )
+}
+
 /// Returns `true` when a relay class is configured but has zero live
 /// connections, signalling a degraded startup for that class.
 fn degraded_relay_class(configured: usize, connected: usize) -> bool {
@@ -445,6 +459,48 @@ mod tests {
         assert!(!degraded_relay_class(2, 1));
         // An unconfigured class is never considered degraded.
         assert!(!degraded_relay_class(0, 0));
+    }
+
+    #[test]
+    fn test_degraded_relay_classes_and_startup_warnings_cover_each_configured_class() {
+        let config = RelayConfig {
+            clearnet: vec!["wss://relay.example.com".to_string()],
+            allow_unencrypted_clearnet_relays: false,
+            onion: vec!["wss://example.onion".to_string()],
+            reconnect_interval_secs: 5,
+            max_reconnect_attempts: 10,
+            connection_timeout_secs: 5,
+        };
+
+        for (status, expected) in [
+            (
+                RelayStatus {
+                    clearnet_connected: 0,
+                    tor_connected: 1,
+                    total_configured: 2,
+                },
+                (true, false),
+            ),
+            (
+                RelayStatus {
+                    clearnet_connected: 1,
+                    tor_connected: 0,
+                    total_configured: 2,
+                },
+                (false, true),
+            ),
+            (
+                RelayStatus {
+                    clearnet_connected: 1,
+                    tor_connected: 1,
+                    total_configured: 2,
+                },
+                (false, false),
+            ),
+        ] {
+            assert_eq!(degraded_relay_classes(&config, &status), expected);
+            warn_on_degraded_relay_classes(&config, &status);
+        }
     }
 
     #[test]

--- a/src/nostr/client.rs
+++ b/src/nostr/client.rs
@@ -148,6 +148,24 @@ impl RelayClient {
                     elapsed_ms = start.elapsed().as_millis() as u64,
                     "Connected to relays"
                 );
+
+                // A configured relay class with zero live connections silently
+                // degrades the deployment's guarantees: losing all Tor relays
+                // weakens the privacy property, losing all ClearNet relays
+                // weakens reachability. Warn prominently for each such class.
+                if degraded_relay_class(self.config.clearnet.len(), status.clearnet_connected) {
+                    warn!(
+                        configured = self.config.clearnet.len(),
+                        "No ClearNet relays connected at startup; configured ClearNet relays are all down"
+                    );
+                }
+                if degraded_relay_class(self.config.onion.len(), status.tor_connected) {
+                    warn!(
+                        configured = self.config.onion.len(),
+                        "No Tor relays connected at startup; privacy is degraded because configured Tor relays are all down"
+                    );
+                }
+
                 return Ok(());
             }
 
@@ -340,6 +358,12 @@ fn inbox_relay_tags(event: &Event) -> BTreeSet<String> {
         .collect()
 }
 
+/// Returns `true` when a relay class is configured but has zero live
+/// connections, signalling a degraded startup for that class.
+fn degraded_relay_class(configured: usize, connected: usize) -> bool {
+    configured > 0 && connected == 0
+}
+
 fn validate_relay_config(config: &RelayConfig) -> Result<()> {
     for url in &config.clearnet {
         if clearnet_relay_uses_tls(url) {
@@ -411,6 +435,16 @@ mod tests {
         .await
         .ok()
         .flatten()
+    }
+
+    #[test]
+    fn test_degraded_relay_class_flags_configured_class_with_no_connections() {
+        // A configured class with zero live connections is degraded.
+        assert!(degraded_relay_class(2, 0));
+        // A configured class with at least one connection is healthy.
+        assert!(!degraded_relay_class(2, 1));
+        // An unconfigured class is never considered degraded.
+        assert!(!degraded_relay_class(0, 0));
     }
 
     #[test]


### PR DESCRIPTION
Closes #109

## Summary
- Emit startup warnings when a configured relay class has zero live connections at the moment `RelayClient::connect()` reports ready.
- Covers both ClearNet reachability degradation and Tor privacy degradation without adding a new config knob.
- Add a small pure helper and focused regression test for the per-class degraded-connection decision.

## Verification
- `cargo fmt --all -- --check`
- `RUSTFLAGS=-Dwarnings cargo check --all-targets`
- `RUSTFLAGS=-Dwarnings cargo clippy --all-targets -- -D warnings`
- `RUSTFLAGS=-Dwarnings cargo test --all-targets` (347 unit tests + 4 integration tests)
- `RUSTFLAGS=-Dwarnings cargo check --all-targets --features tor`
- `RUSTFLAGS=-Dwarnings cargo test --all-targets --features tor` (348 unit tests + 4 integration tests)

## Sensitive paths
- `src/nostr/client.rs` — relay connectivity/privacy behavior. New logs contain only aggregate counts and class names; no relay URLs, tokens, private keys, or user-identifying values.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/transponder/pull/140">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->