### PR TITLE
fix: redact non-unicode env override values

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -508,9 +508,9 @@ where
             continue;
         };
 
-        let value = value.into_string().map_err(|os_string| {
+        let value = value.into_string().map_err(|_| {
             config::ConfigError::Message(format!(
-                "env variable {env_key:?} contains non-Unicode data: {os_string:?}"
+                "env variable {env_key} contains non-Unicode data"
             ))
         })?;
 
@@ -1118,6 +1118,30 @@ mod tests {
     fn test_from_env_rejects_unknown_prefixed_variable() {
         let error = from_test_env(&[("TRANSPONDER_SERVER_PRVATE_KEY", "value")]).unwrap_err();
         assert!(error.to_string().contains("unsupported config key"));
+    }
+
+    #[test]
+    fn test_from_env_non_unicode_private_key_value_is_not_leaked() {
+        use std::os::unix::ffi::OsStringExt;
+
+        let secret_value = "SECRET-PRIVATE-KEY-DO-NOT-LOG";
+        let mut secret_bytes = secret_value.as_bytes().to_vec();
+        // Add a lone continuation byte so `OsString::into_string` fails after a
+        // recognizable secret prefix.
+        secret_bytes.push(0x80);
+        let env_iter = vec![(
+            OsString::from("TRANSPONDER_SERVER_PRIVATE_KEY"),
+            OsString::from_vec(secret_bytes),
+        )];
+
+        let error = AppConfig::from_env_iter(env_iter).unwrap_err();
+        let message = error.to_string();
+
+        assert!(message.contains("TRANSPONDER_SERVER_PRIVATE_KEY"));
+        assert!(message.contains("non-Unicode data"));
+        assert!(!message.contains(secret_value));
+        assert!(!message.contains("SECRET-PRIVATE-KEY"));
+        assert!(!message.contains(r"\x80"));
     }
 
     #[test]


### PR DESCRIPTION
Closes #107

## Summary
- Redacts non-Unicode environment override errors so they report only the variable name, not the raw `OsString` value.
- Adds regression coverage for a non-Unicode `TRANSPONDER_SERVER_PRIVATE_KEY` value with a recognizable secret prefix.

## Verification
- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `RUSTFLAGS=-Dwarnings cargo test config::` (40 passed)
- `RUSTFLAGS=-Dwarnings cargo check --all-targets`
- `RUSTFLAGS=-Dwarnings cargo clippy --all-targets -- -D warnings`
- `RUSTFLAGS=-Dwarnings cargo test --all-targets` (347 unit tests + 4 integration tests passed)

## Sensitive paths
- `src/config.rs` — env override handling and regression test only.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/transponder/pull/141">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->