### PR TITLE
fix: expose inbox relay publish failures

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -144,6 +144,10 @@ pub struct Metrics {
     /// Relay subscription lookback window in seconds.
     pub relay_subscription_lookback_seconds: IntGauge,
 
+    /// Total number of kind-10050 inbox-relay-list publications that failed to
+    /// reach any relay (best-effort publish; non-fatal at startup).
+    pub inbox_relay_publish_failed_total: IntCounter,
+
     // === Server Metrics ===
     /// Timestamp when the server started (Unix seconds).
     pub server_start_time_seconds: Gauge,
@@ -521,6 +525,12 @@ impl Metrics {
         ))?;
         registry.register(Box::new(relay_subscription_lookback_seconds.clone()))?;
 
+        let inbox_relay_publish_failed_total = IntCounter::with_opts(Opts::new(
+            "transponder_inbox_relay_publish_failed_total",
+            "Total number of kind-10050 inbox-relay-list publications that failed to reach any relay",
+        ))?;
+        registry.register(Box::new(inbox_relay_publish_failed_total.clone()))?;
+
         // === Server Metrics ===
         let server_start_time_seconds = Gauge::with_opts(Opts::new(
             "transponder_server_start_time_seconds",
@@ -577,6 +587,7 @@ impl Metrics {
             relay_notifications_lagged_total,
             relay_notifications_dropped_total,
             relay_subscription_lookback_seconds,
+            inbox_relay_publish_failed_total,
             server_start_time_seconds,
             server_info,
         })
@@ -847,6 +858,14 @@ impl Metrics {
             .set(i64::try_from(seconds).unwrap_or(i64::MAX));
     }
 
+    /// Record a kind-10050 inbox-relay-list publication that reached no relays.
+    ///
+    /// Publishing the inbox relay list is best-effort and non-fatal at startup;
+    /// this counter lets operators alert on the routing breakage it implies.
+    pub fn record_inbox_relay_publish_failed(&self) {
+        self.inbox_relay_publish_failed_total.inc();
+    }
+
     /// Gather all metrics for export.
     pub fn gather(&self) -> Vec<prometheus::proto::MetricFamily> {
         self.registry.gather()
@@ -1102,6 +1121,7 @@ mod tests {
         metrics.record_relay_notifications_lagged();
         metrics.record_relay_notifications_dropped(4);
         metrics.set_relay_subscription_lookback(172_800);
+        metrics.record_inbox_relay_publish_failed();
 
         assert_eq!(
             gauge_value(
@@ -1158,6 +1178,14 @@ mod tests {
                 &[]
             ),
             172_800.0
+        );
+        assert_eq!(
+            counter_value(
+                &metrics,
+                "transponder_inbox_relay_publish_failed_total",
+                &[]
+            ),
+            1.0
         );
     }
 

--- a/src/nostr/client.rs
+++ b/src/nostr/client.rs
@@ -255,6 +255,13 @@ impl RelayClient {
     }
 
     /// Publish a kind 10050 event to advertise inbox relays.
+    ///
+    /// Publication is best-effort and non-fatal: a failure to reach any relay
+    /// (either an outright send error or a send whose `success` set is empty) is
+    /// logged and signaled via the `transponder_inbox_relay_publish_failed_total`
+    /// metric, but this method still returns `Ok(())`. Callers therefore must not
+    /// treat `Ok(())` as proof that the inbox relay list was advertised; rely on
+    /// the metric/logs for that signal.
     pub async fn publish_inbox_relays(&self) -> Result<()> {
         let relay_urls = self.configured_inbox_relays();
 
@@ -286,16 +293,30 @@ impl RelayClient {
         let builder = EventBuilder::new(Kind::Custom(10050), "").tags(relay_tags);
 
         match self.client.send_event_builder(builder).await {
-            Ok(output) => {
+            Ok(output) if !output.success.is_empty() => {
                 debug!(event_id = %output.id(), "Published kind 10050 inbox relay list");
                 info!("Published kind 10050 inbox relay list");
             }
+            Ok(output) => {
+                error!(
+                    relays_failed = output.failed.len(),
+                    "Failed to publish kind 10050 event to any relay"
+                );
+                self.record_inbox_relay_publish_failed();
+            }
             Err(e) => {
                 error!(error = %e, "Failed to publish kind 10050 event");
+                self.record_inbox_relay_publish_failed();
             }
         }
 
         Ok(())
+    }
+
+    fn record_inbox_relay_publish_failed(&self) {
+        if let Some(metrics) = &self.metrics {
+            metrics.record_inbox_relay_publish_failed();
+        }
     }
 
     fn configured_inbox_relays(&self) -> BTreeSet<String> {
@@ -776,6 +797,47 @@ mod tests {
 
         // Give it time to publish
         tokio::time::sleep(Duration::from_millis(100)).await;
+
+        client.disconnect().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_publish_inbox_relays_records_metric_when_publish_reaches_no_relays() {
+        use crate::test_metrics::counter_value;
+        use nostr_relay_builder::MockRelay;
+
+        let mock = MockRelay::run().await.unwrap();
+        let relay_url = mock.url().await;
+
+        let keys = Keys::generate();
+        let config = test_relay_config(vec![relay_url.to_string()]);
+        let metrics = Metrics::new().unwrap();
+
+        let client = RelayClient::with_metrics(keys, config, Some(metrics.clone()))
+            .await
+            .unwrap();
+        client.client.add_relay(&relay_url).await.unwrap();
+        client.client.connect().await;
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // Shut the relay down so the kind 10050 publish reaches zero relays and
+        // therefore fails to advertise the inbox relay list.
+        mock.shutdown();
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        // Publication is best-effort, so the call still returns Ok(()).
+        let result = client.publish_inbox_relays().await;
+        assert!(result.is_ok());
+
+        assert_eq!(
+            counter_value(
+                &metrics,
+                "transponder_inbox_relay_publish_failed_total",
+                &[]
+            ),
+            1.0,
+            "a kind 10050 publish that reaches no relays must increment the failure counter"
+        );
 
         client.disconnect().await.unwrap();
     }


### PR DESCRIPTION
Closes #105

## Summary
- Added a dedicated `transponder_inbox_relay_publish_failed_total` Prometheus counter for kind-10050 inbox relay advertisements that fail to reach any relay.
- Wired the metric into `RelayClient::publish_inbox_relays` for both send errors and `send_event_builder` results with an empty success set, while keeping the startup path best-effort/non-fatal.
- Documented the `publish_inbox_relays` contract so callers do not treat `Ok(())` as proof that the inbox relay list was advertised.

## Verification
- `RUSTFLAGS=-Dwarnings cargo test --bin transponder publish_inbox_relays` — 4 passed
- `RUSTFLAGS=-Dwarnings cargo test --bin transponder metrics::tests::test_relay_metrics` — 1 passed
- `cargo fmt --all -- --check` — passed
- `RUSTFLAGS=-Dwarnings cargo check --all-targets` — passed
- `RUSTFLAGS=-Dwarnings cargo clippy --all-targets -- -D warnings` — passed
- `RUSTFLAGS=-Dwarnings cargo test --all-targets` — 347 unit tests + 4 integration tests passed
- `RUSTFLAGS=-Dwarnings cargo check --all-targets --features tor` — passed
- `RUSTFLAGS=-Dwarnings cargo test --all-targets --features tor` — 348 unit tests + 4 integration tests passed
- `./scripts/cargo-audit.sh` — passed with 3 policy-allowed warnings

## Sensitive paths
- `src/nostr/client.rs` — publish-failure handling, docs, and regression test only. No crypto/key/auth behavior changed.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/transponder/pull/144">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->