### PR TITLE
feat(telemetry): add opt-in GlitchTip error and panic reporting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,7 @@ src/
 ## Security Considerations
 
 - **Never log device tokens or private keys** - these are sensitive
+- **`ERROR` logs and panics are forwarded to GlitchTip.** Transponder-target `error!` events, plus any panic, are sent to the error reporter (see `src/telemetry.rs`; panics go through Sentry's global hook and are *not* target-scoped, so they can originate anywhere). Never interpolate a device token, encrypted blob, private key, recipient identity, or a raw `reqwest::Error` (whose APNs URL contains the device token) into an `error!`, `panic!`, `expect`, or `unwrap` message - fail or log with a redacted id or status instead. The same rule already governs `warn!`/`debug!`, but for anything reportable it is a hard privacy boundary, not just hygiene.
 - **No persistent storage** - the spec requires stateless operation for privacy
 - **Silently ignore invalid/expired tokens** (per MIP-05 spec)
 - Use `tracing` at debug level for push results, never include user-identifying info
@@ -154,6 +155,8 @@ src/
 | `tracing` | Structured logging |
 | `config` | Configuration loading with env overrides |
 | `prometheus` | Prometheus metrics collection |
+| `sentry` | GlitchTip/Sentry error and panic reporting |
+| `rustls` | Installs the `ring` crypto provider for sentry's `rustls-no-provider` transport (keeps the build off `aws-lc-rs`) |
 
 ## Configuration
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Optional error and panic reporting to a GlitchTip (Sentry-compatible) instance, enabled by setting `glitchtip.dsn` (or `TRANSPONDER_GLITCHTIP_DSN`). Only Transponder's own `ERROR` events and panics are sent, over a self-contained TLS transport (bundled roots, no system CA store dependency); dependency-crate errors and lower log levels are dropped, and Transponder never logs or panics with secret material.
+
 ### Fixed
 
 - Limit each notification event to at most 100 encrypted tokens before base64 decoding, preventing oversized events from forcing unbounded token blob allocation and rate-limit work ([#38](https://github.com/marmot-protocol/transponder/pull/38)).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -452,6 +461,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -557,6 +581,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
 ]
 
 [[package]]
@@ -748,6 +781,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "compression-codecs"
 version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -843,6 +886,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9885fa71e26b8ab7855e2ec7cae6e9b380edff76cd052e07c683a0319d51b3a2"
 dependencies = [
  "futures",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1043,6 +1096,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "serde",
+ "uuid",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1094,7 +1157,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b48e8e38a4aa565da767322b5ca55fb0f8347983c5bc7f7647db069405420479"
 dependencies = [
  "heck",
- "indexmap 1.9.3",
+ "indexmap 2.13.0",
  "itertools",
  "proc-macro-crate",
  "proc-macro2",
@@ -1199,6 +1262,16 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
 ]
 
 [[package]]
@@ -1660,6 +1733,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
 name = "glob-match"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1803,6 +1882,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link",
 ]
 
 [[package]]
@@ -2185,6 +2275,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2426,6 +2565,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0efe882e02d206d8d279c20eb40e03baf7cb5136a1476dc084a324fbc3ec42d"
 
 [[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2659,6 +2810,174 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.11.0",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags 2.11.0",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2",
+ "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-core-text",
+ "objc2-foundation",
+ "objc2-quartz-core",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2686,6 +3005,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2708,6 +3033,22 @@ checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
 dependencies = [
  "dlv-list",
  "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "os_info"
+version = "3.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf20a545b305cf1da722b236b5155c9bb35f1d5ceb28c048bd96ca842f41b5b"
+dependencies = [
+ "android_system_properties",
+ "log",
+ "nix",
+ "objc2",
+ "objc2-foundation",
+ "objc2-ui-kit",
+ "serde",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3136,7 +3477,7 @@ dependencies = [
  "derive-deftly",
  "libc",
  "paste",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3168,7 +3509,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring 0.17.14",
  "rustc-hash",
  "rustls",
@@ -3234,9 +3575,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -3398,6 +3739,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "retry-error"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3503,6 +3883,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3555,6 +3941,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3563,6 +3961,33 @@ dependencies = [
  "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -3625,6 +4050,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc984f4f9ceb736a7bb755c3e3bd17dc56370af2600c9780dcc48c66453da34d"
 dependencies = [
  "regex",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3704,10 +4138,130 @@ dependencies = [
 ]
 
 [[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
+name = "sentry"
+version = "0.48.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1975064d9f3d9d87a7c8f0371f7fac10d876906ca3e39faad72e61c263ff9b87"
+dependencies = [
+ "cfg_aliases",
+ "httpdate",
+ "reqwest 0.13.4",
+ "rustls",
+ "sentry-backtrace",
+ "sentry-contexts",
+ "sentry-core",
+ "sentry-panic",
+ "sentry-tracing",
+ "tokio",
+ "ureq",
+]
+
+[[package]]
+name = "sentry-backtrace"
+version = "0.48.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "134f552b6b147f77aeee46ece875d67a8bfc1d56fe3860d78446ed4c25bb5f9f"
+dependencies = [
+ "backtrace",
+ "regex",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-contexts"
+version = "0.48.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98482b938fb1f31ecd23506fb7f08b2ba20d60b9cc72581b1205a9acd31d32fa"
+dependencies = [
+ "hostname",
+ "libc",
+ "os_info",
+ "rustc_version",
+ "sentry-core",
+ "uname",
+]
+
+[[package]]
+name = "sentry-core"
+version = "0.48.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cff96247f4dc36867511d108709e703eb354143e7893319d763d2dd1edb4f48"
+dependencies = [
+ "rand 0.9.4",
+ "sentry-types",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
+name = "sentry-panic"
+version = "0.48.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61de3f4a1fc77d4c57e8bacd8ef064c26aaa88ea5b2541a761d37c7c3703b9a9"
+dependencies = [
+ "sentry-backtrace",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-tracing"
+version = "0.48.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc59b27dae3bb495e37e6d62d252214840a2e7e1875531ee9fa2953df8985537"
+dependencies = [
+ "bitflags 2.11.0",
+ "sentry-backtrace",
+ "sentry-core",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "sentry-types"
+version = "0.48.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d7e78132ccfb4a1c777b959fb2944d1f6d5145bffe6be2a98ee6b25d244f72c"
+dependencies = [
+ "debugid",
+ "hex",
+ "rand 0.9.4",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "time",
+ "url",
+ "uuid",
+]
 
 [[package]]
 name = "serde"
@@ -3939,6 +4493,22 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "simple_asn1"
@@ -5571,8 +6141,11 @@ dependencies = [
  "nostr-relay-builder",
  "nostr-sdk",
  "prometheus",
- "reqwest",
+ "reqwest 0.12.28",
+ "reqwest 0.13.4",
+ "rustls",
  "secp256k1",
+ "sentry",
  "serde",
  "serde_json",
  "sha2",
@@ -5583,6 +6156,7 @@ dependencies = [
  "toml 0.8.23",
  "tracing",
  "tracing-subscriber",
+ "webpki-roots 1.0.6",
  "wiremock",
  "zeroize",
 ]
@@ -5604,7 +6178,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rustls",
  "rustls-pki-types",
  "sha1",
@@ -5635,6 +6209,15 @@ name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "uname"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "uncased"
@@ -5695,6 +6278,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5714,6 +6325,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5724,6 +6341,17 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+dependencies = [
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"
@@ -5925,6 +6553,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,40 @@ toml = "0.8"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.22", features = ["json", "env-filter"] }
 
+# Error reporting (GlitchTip, via the Sentry protocol).
+# default-features = false drops native-tls: the release binary is a fully
+# static musl build on a distroless runtime, so the transport must use rustls.
+# We select `reqwest` (the HTTP transport) + `rustls-no-provider`, but NOT
+# sentry's `transport` feature — an alias for `reqwest + native-tls` that would
+# drag in OpenSSL. `reqwest` alone provides the default transport.
+#
+# `rustls-no-provider` (not `rustls`) keeps the whole build on ONE crypto
+# provider. sentry's `rustls` feature pulls `aws-lc-rs` (a C/assembly library
+# that needs cmake to build on musl), whereas the rest of the tree — nostr-sdk,
+# jsonwebtoken, and our reqwest 0.12 client — already use `ring`. The GlitchTip
+# transport client is built explicitly in `telemetry` with the `ring` provider
+# and bundled webpki roots (see the reqwest13/rustls/webpki-roots deps below).
+sentry = { version = "0.48", default-features = false, features = [
+    "backtrace",
+    "contexts",
+    "panic",
+    "reqwest",
+    "rustls-no-provider",
+    "tracing",
+] }
+
+# Build sentry's HTTP transport client with bundled webpki roots so GlitchTip TLS
+# does not depend on the runtime image shipping a system CA store (the app's own
+# reqwest 0.12 client above makes the same choice). `reqwest13` is aliased
+# because the app client is 0.12; it must match sentry's reqwest 0.13 so the
+# injected client type is identical. `rustls` builds the TLS config, and
+# default-features = false keeps it on `ring` (its defaults would add aws-lc-rs).
+reqwest13 = { package = "reqwest", version = "0.13", default-features = false, features = [
+    "rustls-no-provider",
+] }
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
+webpki-roots = "1"
+
 # HTTP server (for health checks)
 axum = "0.8"
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,14 @@ level = "info"
 
 # Log format: "json" (structured, for production) or "pretty" (human-readable)
 format = "json"
+
+[glitchtip]
+# Error and panic reporting to a GlitchTip (Sentry-compatible) instance.
+# Disabled while dsn is empty. Prefer TRANSPONDER_GLITCHTIP_DSN over committing
+# the DSN. Only transponder's own ERROR events and panics are sent.
+dsn = ""
+environment = "production"
+# traces_sample_rate = 0.0   # 0.0..=1.0; 0.0 = errors only (recommended)
 ```
 
 Rate-limit memory scales with admitted hits, not just tracked keys. Each active
@@ -452,6 +460,12 @@ Typical patterns:
 - scrape `http://127.0.0.1:8080/metrics` from a local Prometheus, VictoriaMetrics, or similar agent
 - forward metrics through an existing reverse proxy or VPN if you need remote scraping
 - keep `/metrics` internal-only unless you have a deliberate access-control story
+
+### Error reporting (GlitchTip)
+
+Transponder can report errors and panics to a [GlitchTip](https://glitchtip.com/) instance (or any Sentry-compatible endpoint). It is disabled unless you set a DSN via the `[glitchtip]` config section or `TRANSPONDER_GLITCHTIP_DSN`.
+
+To preserve the server's privacy guarantees, only `ERROR`-level events emitted by Transponder's own code, plus panics, are sent — dependency-crate errors (which can embed URLs and device tokens) and all lower log levels are dropped before transmission. Transponder never puts tokens, keys, or message content into log or panic messages (an invariant enforced in review; see AGENTS.md), so none reach GlitchTip. TLS trusts bundled roots, so reporting does not depend on the runtime's system CA store. A malformed DSN fails startup rather than silently disabling reporting.
 
 ## How It Works
 

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -24,6 +24,9 @@ services:
       TRANSPONDER_HEALTH_BIND_ADDRESS: "0.0.0.0:8080"
       TRANSPONDER_LOGGING_LEVEL: ${TRANSPONDER_LOGGING_LEVEL:-info}
       TRANSPONDER_LOGGING_FORMAT: json
+      # Error reporting to GlitchTip. Unset by default, which leaves it disabled.
+      TRANSPONDER_GLITCHTIP_DSN: ${TRANSPONDER_GLITCHTIP_DSN:-}
+      TRANSPONDER_GLITCHTIP_ENVIRONMENT: ${TRANSPONDER_GLITCHTIP_ENVIRONMENT:-production}
       RUST_LOG: ${RUST_LOG:-info,transponder=debug,nostr_relay_pool=info,nostr_sdk=info,nostr=info,reqwest=warn,hyper=warn,hyper_util=warn,h2=warn,tower=warn,rustls=warn,tungstenite=warn,tokio_tungstenite=warn}
     secrets:
       - transponder_private_key

--- a/config/default.toml
+++ b/config/default.toml
@@ -144,3 +144,18 @@ level = "info"
 
 # Log format: "json" (for production) or "pretty" (for development)
 format = "json"
+
+[glitchtip]
+# Error and panic reporting to a GlitchTip (Sentry-compatible) instance.
+# Reporting is OFF until a DSN is set. Prefer supplying the DSN via the
+# TRANSPONDER_GLITCHTIP_DSN environment variable rather than committing it here.
+# Only transponder's own ERROR events and panics are sent; no tokens, keys, or
+# message content leave the process.
+dsn = ""
+
+# Deployment environment tag attached to every event.
+environment = "production"
+
+# Performance-trace sample rate (0.0..=1.0). 0.0 = errors only, which is
+# recommended: transponder has no request transactions to trace.
+# traces_sample_rate = 0.0

--- a/config/production.toml.example
+++ b/config/production.toml.example
@@ -70,3 +70,11 @@ enabled = true
 [logging]
 level = "info"
 format = "json"
+
+[glitchtip]
+# Error and panic reporting to a GlitchTip instance. Disabled while the DSN is
+# empty. In production, supply the DSN via TRANSPONDER_GLITCHTIP_DSN (see
+# compose.prod.yml) rather than committing it to this file.
+dsn = ""
+environment = "production"
+# traces_sample_rate = 0.0

--- a/src/config.rs
+++ b/src/config.rs
@@ -44,6 +44,9 @@ pub struct AppConfig {
 
     /// Logging configuration.
     pub logging: LoggingConfig,
+
+    /// GlitchTip error-reporting configuration.
+    pub glitchtip: GlitchtipConfig,
 }
 
 /// Default maximum size for the deduplication cache.
@@ -427,6 +430,51 @@ fn default_log_format() -> String {
     "json".to_string()
 }
 
+/// GlitchTip (Sentry-compatible) error-reporting configuration.
+///
+/// Reporting is enabled by the presence of a non-empty `dsn`; there is no
+/// separate on/off flag, so there is no way to configure an enabled-but-unusable
+/// state.
+#[derive(Clone, Deserialize)]
+pub struct GlitchtipConfig {
+    /// GlitchTip DSN. Empty disables error reporting.
+    #[serde(default)]
+    pub dsn: String,
+
+    /// Deployment environment tag attached to every event (e.g. "production").
+    #[serde(default = "default_glitchtip_environment")]
+    pub environment: String,
+
+    /// Performance-trace sample rate in the range `0.0..=1.0`.
+    ///
+    /// Default `0.0` (errors only). Transponder is an event loop with no request
+    /// transactions to trace, so raise this only after adding span instrumentation.
+    #[serde(default)]
+    pub traces_sample_rate: f32,
+}
+
+impl std::fmt::Debug for GlitchtipConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // The DSN embeds a write-auth key; redact it so a config debug dump never
+        // leaks it, mirroring `ServerConfig`. Empty is shown as-is so a disabled
+        // reporter is not mistaken for a hidden secret.
+        let dsn = if self.dsn.is_empty() {
+            ""
+        } else {
+            "[REDACTED]"
+        };
+        f.debug_struct("GlitchtipConfig")
+            .field("dsn", &dsn)
+            .field("environment", &self.environment)
+            .field("traces_sample_rate", &self.traces_sample_rate)
+            .finish()
+    }
+}
+
+fn default_glitchtip_environment() -> String {
+    "production".to_string()
+}
+
 fn base_config_builder() -> Result<ConfigBuilder<DefaultState>> {
     Ok(Config::builder()
         // Start with default values
@@ -493,7 +541,10 @@ fn base_config_builder() -> Result<ConfigBuilder<DefaultState>> {
         .set_default("health.bind_address", DEFAULT_HEALTH_BIND_ADDRESS)?
         .set_default("metrics.enabled", true)?
         .set_default("logging.level", "info")?
-        .set_default("logging.format", "json")?)
+        .set_default("logging.format", "json")?
+        .set_default("glitchtip.dsn", "")?
+        .set_default("glitchtip.environment", "production")?
+        .set_default("glitchtip.traces_sample_rate", 0.0)?)
 }
 
 fn apply_env_overrides<I>(
@@ -602,6 +653,9 @@ fn is_supported_config_key(config_key: &str) -> bool {
                 | "metrics.enabled"
                 | "logging.level"
                 | "logging.format"
+                | "glitchtip.dsn"
+                | "glitchtip.environment"
+                | "glitchtip.traces_sample_rate"
         )
 }
 
@@ -663,6 +717,7 @@ impl AppConfig {
     /// of letting it reach runtime.
     fn validate(&self) -> Result<()> {
         self.server.validate()?;
+        self.glitchtip.validate()?;
         Ok(())
     }
 
@@ -731,6 +786,22 @@ impl ServerConfig {
             }
         }
 
+        Ok(())
+    }
+}
+
+impl GlitchtipConfig {
+    /// Rejects a `traces_sample_rate` outside `0.0..=1.0`.
+    ///
+    /// The Sentry protocol interprets the rate as a probability; a value outside
+    /// the unit interval is a misconfiguration, so it is rejected at load time
+    /// rather than silently clamped.
+    fn validate(&self) -> std::result::Result<(), config::ConfigError> {
+        if !(0.0..=1.0).contains(&self.traces_sample_rate) {
+            return Err(config::ConfigError::Message(
+                "glitchtip.traces_sample_rate must be between 0.0 and 1.0".to_string(),
+            ));
+        }
         Ok(())
     }
 }
@@ -1194,6 +1265,99 @@ mod tests {
     fn test_logging_config_defaults() {
         assert_eq!(default_log_level(), "info");
         assert_eq!(default_log_format(), "json");
+    }
+
+    #[test]
+    fn test_glitchtip_config_debug_redacts_dsn() {
+        let config = GlitchtipConfig {
+            dsn: "https://public@glitch.example/1".to_string(),
+            environment: "production".to_string(),
+            traces_sample_rate: 0.0,
+        };
+
+        let debug_output = format!("{config:?}");
+
+        assert!(!debug_output.contains("public@glitch.example"));
+        assert!(debug_output.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn test_glitchtip_config_debug_shows_empty_dsn_as_disabled() {
+        let config = GlitchtipConfig {
+            dsn: String::new(),
+            environment: "production".to_string(),
+            traces_sample_rate: 0.0,
+        };
+
+        // An empty DSN is shown as empty (disabled), not "[REDACTED]", which would
+        // misleadingly imply a secret is present.
+        assert!(!format!("{config:?}").contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn test_glitchtip_defaults_disable_reporting() {
+        let config = from_test_env(&[]).unwrap();
+
+        assert_eq!(config.glitchtip.dsn, "");
+        assert_eq!(config.glitchtip.environment, "production");
+        assert_eq!(config.glitchtip.traces_sample_rate, 0.0);
+    }
+
+    #[test]
+    fn test_glitchtip_env_overrides() {
+        // Also exercises the string -> f32 coercion path: `traces_sample_rate`
+        // is the only floating-point config field, so this locks it in.
+        let config = from_test_env(&[
+            ("TRANSPONDER_GLITCHTIP_DSN", "https://key@glitch.example/1"),
+            ("TRANSPONDER_GLITCHTIP_ENVIRONMENT", "staging"),
+            ("TRANSPONDER_GLITCHTIP_TRACES_SAMPLE_RATE", "0.25"),
+        ])
+        .unwrap();
+
+        assert_eq!(config.glitchtip.dsn, "https://key@glitch.example/1");
+        assert_eq!(config.glitchtip.environment, "staging");
+        assert_eq!(config.glitchtip.traces_sample_rate, 0.25);
+    }
+
+    #[test]
+    fn test_glitchtip_traces_sample_rate_above_one_rejected() {
+        let error = from_test_env(&[("TRANSPONDER_GLITCHTIP_TRACES_SAMPLE_RATE", "1.5")])
+            .expect_err("a sample rate above 1.0 should be rejected");
+
+        assert!(
+            error
+                .to_string()
+                .contains("glitchtip.traces_sample_rate must be between 0.0 and 1.0"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn test_glitchtip_traces_sample_rate_negative_rejected() {
+        let error = from_test_env(&[("TRANSPONDER_GLITCHTIP_TRACES_SAMPLE_RATE", "-0.1")])
+            .expect_err("a negative sample rate should be rejected");
+
+        assert!(
+            error
+                .to_string()
+                .contains("glitchtip.traces_sample_rate must be between 0.0 and 1.0"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn test_glitchtip_traces_sample_rate_nan_rejected() {
+        // `RangeInclusive::contains` compares with `PartialOrd`, so NaN is not
+        // contained and is rejected rather than silently accepted.
+        let error = from_test_env(&[("TRANSPONDER_GLITCHTIP_TRACES_SAMPLE_RATE", "nan")])
+            .expect_err("a NaN sample rate should be rejected");
+
+        assert!(
+            error
+                .to_string()
+                .contains("glitchtip.traces_sample_rate must be between 0.0 and 1.0"),
+            "{error}"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ use nostr_sdk::prelude::*;
 use tokio::sync::broadcast::error::RecvError;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore, watch};
 use tracing::{debug, error, info, warn};
-use tracing_subscriber::{EnvFilter, fmt, prelude::*};
+use tracing_subscriber::{EnvFilter, Layer, fmt, prelude::*};
 use zeroize::Zeroizing;
 
 mod config;
@@ -31,6 +31,7 @@ mod push;
 mod rate_limiter;
 mod server;
 mod shutdown;
+mod telemetry;
 
 #[cfg(test)]
 mod test_metrics;
@@ -181,12 +182,41 @@ async fn main() -> Result<()> {
     }
 
     // Load configuration
-    let mut config = AppConfig::load(&args.config)
+    let config = AppConfig::load(&args.config)
         .with_context(|| format!("Failed to load config from {}", args.config))?;
+
+    // Initialize error reporting before logging so a GlitchTip client exists for
+    // the first captured event. The guard is held for the whole process and
+    // dropped last, flushing buffered events — including any fatal error captured
+    // below. It must stay in `main` rather than move into `run`, or it would drop
+    // before that error is recorded.
+    let _glitchtip_guard = telemetry::init(&config.glitchtip)?;
 
     // Initialize logging
     init_logging(&config.logging)?;
 
+    info!(
+        version = env!("CARGO_PKG_VERSION"),
+        config_path = %args.config,
+        "Starting Transponder"
+    );
+
+    let result = run(config).await;
+    if let Err(error) = &result {
+        error!(error = %error, "Fatal error, shutting down");
+    }
+    result
+}
+
+/// Bring the server up and run until shutdown.
+///
+/// Split from `main` so a failure during startup or the run loop is logged at
+/// `ERROR` — and therefore reported to GlitchTip — instead of only surfacing on
+/// process exit. The GlitchTip guard stays in `main` so it outlives this call
+/// and flushes the captured event. Failures *before* this point (config load,
+/// `telemetry::init`, `init_logging`) occur before the subscriber and client
+/// exist, so they surface only on stderr, not in GlitchTip.
+async fn run(mut config: AppConfig) -> Result<()> {
     // Initialize metrics
     let metrics = if config.metrics.enabled {
         match Metrics::new() {
@@ -204,12 +234,6 @@ async fn main() -> Result<()> {
         info!("Metrics disabled");
         None
     };
-
-    info!(
-        version = env!("CARGO_PKG_VERSION"),
-        config_path = %args.config,
-        "Starting Transponder"
-    );
 
     let server_private_key = resolve_server_private_key(&mut config.server)?;
 
@@ -601,29 +625,23 @@ fn init_logging(config: &config::LoggingConfig) -> Result<()> {
     let filter =
         EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(&config.level));
 
-    match config.format.as_str() {
-        "json" => {
-            tracing_subscriber::registry()
-                .with(filter)
-                .with(fmt::layer().json())
-                .init();
-        }
-        "pretty" => {
-            tracing_subscriber::registry()
-                .with(filter)
-                .with(fmt::layer().pretty())
-                .init();
-        }
-        "off" => {
-            // No logging
-        }
-        _ => {
-            tracing_subscriber::registry()
-                .with(filter)
-                .with(fmt::layer())
-                .init();
-        }
-    }
+    // Build the console layer for the configured format (`None` disables console
+    // logging). The `EnvFilter` is attached per-layer to the fmt layer only, so it
+    // never gates the GlitchTip layer: error reporting stays independent of console
+    // verbosity — a tightened `RUST_LOG`, or `format = "off"`, does not silence it.
+    // The GlitchTip layer carries its own ERROR-level filter (see `telemetry`).
+    let console_layer: Option<Box<dyn Layer<tracing_subscriber::Registry> + Send + Sync>> =
+        match config.format.as_str() {
+            "json" => Some(fmt::layer().json().with_filter(filter).boxed()),
+            "pretty" => Some(fmt::layer().pretty().with_filter(filter).boxed()),
+            "off" => None,
+            _ => Some(fmt::layer().with_filter(filter).boxed()),
+        };
+
+    tracing_subscriber::registry()
+        .with(console_layer)
+        .with(telemetry::glitchtip_layer())
+        .init();
 
     Ok(())
 }

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,0 +1,260 @@
+//! Error and panic reporting to a GlitchTip (Sentry-compatible) instance.
+//!
+//! Reporting is opt-in: it activates only when a DSN is configured. Transponder's
+//! own `ERROR` events are forwarded — first-party only, see [`glitchtip_layer`] —
+//! together with panics, which Sentry's global hook captures from anywhere in the
+//! process (not just first-party code). Message content is kept clean by the
+//! "never log secrets" invariant in AGENTS.md, not by mechanical scrubbing.
+
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use sentry::integrations::tracing::EventFilter;
+use sentry::{Transport, TransportFactory, TransportOptions};
+use tracing::{Level, Subscriber};
+use tracing_subscriber::Layer;
+use tracing_subscriber::filter::LevelFilter;
+use tracing_subscriber::registry::LookupSpan;
+
+use crate::config::GlitchtipConfig;
+
+/// Initialize GlitchTip reporting from configuration.
+///
+/// Returns `Ok(None)` when no DSN is configured, leaving reporting disabled.
+/// When a DSN is set, returns a guard that must be held for the lifetime of the
+/// process; dropping it flushes any buffered events. A malformed DSN is a hard
+/// startup error rather than a silent no-op, so a misconfiguration surfaces
+/// immediately instead of quietly dropping telemetry.
+pub fn init(config: &GlitchtipConfig) -> Result<Option<sentry::ClientInitGuard>> {
+    let dsn = config.dsn.trim();
+    if dsn.is_empty() {
+        return Ok(None);
+    }
+
+    let dsn: sentry::types::Dsn = dsn.parse().context("Invalid GlitchTip DSN")?;
+
+    let guard = sentry::init(sentry::ClientOptions {
+        dsn: Some(dsn),
+        release: sentry::release_name!(),
+        environment: Some(config.environment.clone().into()),
+        traces_sample_rate: config.traces_sample_rate,
+        // Never attach request/user PII. This is the default; set explicitly so
+        // the intent survives future edits.
+        send_default_pii: false,
+        before_send: Some(Arc::new(scrub_event)),
+        // Send over a transport whose TLS trusts the bundled webpki roots, so
+        // error reporting does not depend on the runtime image shipping a system
+        // CA store — the same posture as the app's own reqwest client.
+        transport: Some(Arc::new(GlitchtipTransportFactory)),
+        // `default_integrations` stays enabled (via `..Default::default()`); it
+        // registers the panic hook that captures panics. Session tracking is
+        // deliberately not compiled in — the `release-health` feature is left
+        // off in Cargo.toml.
+        ..Default::default()
+    });
+
+    Ok(Some(guard))
+}
+
+/// Sentry transport factory whose HTTP client trusts the bundled webpki roots.
+///
+/// reqwest 0.13 (sentry's transport client) verifies TLS against the OS trust
+/// store by default; on the distroless runtime that store may be absent, which
+/// would make GlitchTip delivery fail silently. Injecting a client built with
+/// the bundled Mozilla roots keeps reporting self-contained.
+struct GlitchtipTransportFactory;
+
+impl TransportFactory for GlitchtipTransportFactory {
+    fn create_transport_with_options(&self, options: TransportOptions) -> Arc<dyn Transport> {
+        Arc::new(
+            sentry::transports::ReqwestHttpTransportOptions::from(options)
+                .with_client(glitchtip_http_client())
+                .build(),
+        )
+    }
+}
+
+/// Build the GlitchTip HTTP client: rustls with the `ring` provider, trusting
+/// only the bundled webpki root certificates (no dependency on a system CA
+/// store). The explicit provider keeps this off `aws-lc-rs` and independent of
+/// any process-wide default.
+fn glitchtip_http_client() -> reqwest13::Client {
+    let mut roots = rustls::RootCertStore::empty();
+    roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+
+    let tls_config = rustls::ClientConfig::builder_with_provider(Arc::new(
+        rustls::crypto::ring::default_provider(),
+    ))
+    .with_safe_default_protocol_versions()
+    .expect("ring provider supports the default TLS protocol versions")
+    .with_root_certificates(roots)
+    .with_no_client_auth();
+
+    reqwest13::Client::builder()
+        .tls_backend_preconfigured(tls_config)
+        .build()
+        .expect("building the GlitchTip HTTP client should not fail")
+}
+
+/// Tracing layer that forwards events to GlitchTip.
+///
+/// Captures **only** `ERROR` events emitted by transponder's own code; every
+/// other level and every dependency-crate event is dropped before it can reach
+/// GlitchTip. The target scope is the privacy boundary: dependency errors
+/// (`reqwest`, `hyper`, `nostr_sdk`, `tungstenite`, …) routinely embed URLs, and
+/// the APNs request URL carries a device token. Restricting capture to the
+/// `transponder` target — whose `ERROR` sites are audited to carry no secret
+/// material — keeps that data out of the sink.
+///
+/// The layer is a no-op when no client is initialized, so it is always safe to
+/// attach whether or not GlitchTip is configured.
+pub(crate) fn glitchtip_layer<S>() -> impl Layer<S>
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    sentry::integrations::tracing::layer()
+        .event_filter(|metadata| capture_decision(*metadata.level(), metadata.target()))
+        // Independent of the console `EnvFilter`/`RUST_LOG`: only `ERROR` events
+        // are ever handed to this layer, and they always are.
+        .with_filter(LevelFilter::ERROR)
+}
+
+/// The GlitchTip capture policy: forward only first-party `ERROR` events as
+/// events; drop everything else. This is the privacy boundary — dependency-crate
+/// events and non-error levels never reach the sink. (`glitchtip_layer` also
+/// pre-filters to `ERROR` via `with_filter`; this stays self-contained so the
+/// policy is correct regardless of that.)
+fn capture_decision(level: Level, target: &str) -> EventFilter {
+    if level == Level::ERROR && is_first_party_target(target) {
+        EventFilter::Event
+    } else {
+        EventFilter::Ignore
+    }
+}
+
+/// Whether a tracing target belongs to transponder's own crate.
+///
+/// This is the privacy boundary for error reporting: only first-party events are
+/// forwarded, so dependency-crate messages (which can embed relay URLs or the
+/// APNs device-token URL) never reach GlitchTip. Matches the crate root and any
+/// of its modules, but not an unrelated crate whose name merely begins with
+/// `transponder`.
+fn is_first_party_target(target: &str) -> bool {
+    target == "transponder" || target.starts_with("transponder::")
+}
+
+/// Scrub every outgoing event immediately before it is sent.
+///
+/// This runs for both tracing-captured errors and panic events, so it is the one
+/// choke point that sees everything leaving the process. It drops the hostname
+/// (which can reveal deployment topology). It does NOT redact message or panic
+/// bodies: the guarantee that no secret material leaves rests on the invariant
+/// that transponder never puts secrets in `error!`/`panic!`/`expect`/`unwrap`
+/// messages (see AGENTS.md) — the same discipline that governs all logging.
+fn scrub_event(
+    mut event: sentry::protocol::Event<'static>,
+) -> Option<sentry::protocol::Event<'static>> {
+    event.server_name = None;
+    Some(event)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config_with_dsn(dsn: &str) -> GlitchtipConfig {
+        GlitchtipConfig {
+            dsn: dsn.to_string(),
+            environment: "test".to_string(),
+            traces_sample_rate: 0.0,
+        }
+    }
+
+    #[test]
+    fn init_is_disabled_without_a_dsn() {
+        let guard = init(&config_with_dsn("")).expect("an empty DSN should disable, not error");
+        assert!(guard.is_none());
+    }
+
+    #[test]
+    fn init_treats_a_whitespace_dsn_as_disabled() {
+        let guard = init(&config_with_dsn("   \n\t ")).expect("a blank DSN should disable");
+        assert!(guard.is_none());
+    }
+
+    #[test]
+    fn init_rejects_a_malformed_dsn() {
+        // `expect_err` is unavailable here: `ClientInitGuard` is not `Debug`, so
+        // inspect the error through `.err()` instead.
+        let error = init(&config_with_dsn("not-a-valid-dsn"))
+            .err()
+            .expect("a malformed DSN must fail loudly");
+        assert!(error.to_string().contains("Invalid GlitchTip DSN"));
+    }
+
+    // `EventFilter` is a bitflags type without `PartialEq`, so compare `.bits()`.
+    #[test]
+    fn capture_decision_forwards_first_party_errors() {
+        let event = EventFilter::Event.bits();
+        assert_eq!(capture_decision(Level::ERROR, "transponder").bits(), event);
+        assert_eq!(
+            capture_decision(Level::ERROR, "transponder::push::retry").bits(),
+            event
+        );
+    }
+
+    #[test]
+    fn capture_decision_drops_non_errors_and_third_party() {
+        let ignore = EventFilter::Ignore.bits();
+        // Lower levels are dropped even from first-party code (they may carry
+        // tokens/URLs per AGENTS.md).
+        assert_eq!(capture_decision(Level::WARN, "transponder").bits(), ignore);
+        assert_eq!(
+            capture_decision(Level::INFO, "transponder::nostr::client").bits(),
+            ignore
+        );
+        // Dependency-crate errors never reach the sink, even at ERROR level.
+        assert_eq!(capture_decision(Level::ERROR, "reqwest").bits(), ignore);
+        assert_eq!(
+            capture_decision(Level::ERROR, "hyper::client::conn").bits(),
+            ignore
+        );
+    }
+
+    #[test]
+    fn first_party_targets_are_captured() {
+        assert!(is_first_party_target("transponder"));
+        assert!(is_first_party_target("transponder::push::retry"));
+        assert!(is_first_party_target("transponder::nostr::client"));
+    }
+
+    #[test]
+    fn third_party_and_lookalike_targets_are_excluded() {
+        assert!(!is_first_party_target("nostr_sdk"));
+        assert!(!is_first_party_target("reqwest"));
+        assert!(!is_first_party_target("hyper::client::conn"));
+        // A crate whose name merely starts with "transponder" is not first-party.
+        assert!(!is_first_party_target("transponderx"));
+        assert!(!is_first_party_target("transponder_utils"));
+    }
+
+    #[test]
+    fn glitchtip_http_client_builds_with_bundled_roots() {
+        // Exercises the load-bearing transport path: a rustls config using the
+        // `ring` provider + bundled webpki roots, injected into a reqwest client.
+        // Hermetic — constructs the client, makes no network call.
+        let _client = glitchtip_http_client();
+    }
+
+    #[test]
+    fn scrub_event_drops_the_server_name() {
+        let event = sentry::protocol::Event {
+            server_name: Some("internal-host-01".into()),
+            ..Default::default()
+        };
+
+        let scrubbed = scrub_event(event).expect("the scrubber keeps the event");
+
+        assert!(scrubbed.server_name.is_none());
+    }
+}


### PR DESCRIPTION
<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/transponder/pull/159">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional GlitchTip (Sentry-compatible) error and panic reporting with production-ready configuration, enabled only when a DSN is set.
  * Uses bundled TLS roots for reporting connections.

* **Bug Fixes**
  * Prevents oversized notification token batches by capping tokens processed per event.
  * Expands encrypted token and variable-length device token handling.

* **Security**
  * Further reduces secret exposure by tightening redaction and zeroizing sensitive key material during startup and runtime.

* **Documentation**
  * Updated configuration and setup docs, including DSN enablement, reporting scope, and redaction guarantees.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->