### PR TITLE
fix: honor Retry-After on push 5xx responses

### DIFF
--- a/src/push/apns.rs
+++ b/src/push/apns.rs
@@ -459,11 +459,7 @@ impl ApnsClient {
             }
             429 => {
                 // Rate limited - retriable
-                let retry_after = response
-                    .headers()
-                    .get("retry-after")
-                    .and_then(|v| v.to_str().ok())
-                    .and_then(|v| retry::parse_retry_after(Some(v)));
+                let retry_after = retry::retry_after_from_headers(response.headers());
                 debug!(
                     payload_mode = %self.config.payload_mode,
                     "APNs rate limited request"
@@ -474,7 +470,9 @@ impl ApnsClient {
                 }
             }
             500..=599 => {
-                // Server error - retriable
+                // Server error - retriable. Honor an explicit Retry-After
+                // backpressure hint when the provider supplies one.
+                let retry_after = retry::retry_after_from_headers(response.headers());
                 debug!(
                     payload_mode = %self.config.payload_mode,
                     status = %status,
@@ -482,7 +480,7 @@ impl ApnsClient {
                 );
                 SendAttemptResult::Retriable {
                     status_code: status.as_u16(),
-                    retry_after: None,
+                    retry_after,
                 }
             }
             _ => {
@@ -1062,6 +1060,73 @@ mod tests {
             result,
             SendAttemptResult::Permanent(Error::Apns(ref message))
                 if message.contains("MissingTopic")
+        ));
+    }
+
+    /// Drive `handle_response` against a mock server returning `status_code`
+    /// with an optional `retry-after` header, returning the classified result.
+    async fn apns_status_result(status_code: u16, retry_after: Option<&str>) -> SendAttemptResult {
+        let mock_server = MockServer::start().await;
+        let mut template = ResponseTemplate::new(status_code);
+        if let Some(value) = retry_after {
+            template = template.insert_header("retry-after", value);
+        }
+        Mock::given(method("POST"))
+            .and(path_regex(r"/3/device/[a-f0-9]+"))
+            .respond_with(template)
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let client = ApnsClient::mock(test_config(), false);
+        let response = Client::new()
+            .post(format!("{}/3/device/{}", mock_server.uri(), "deadbeef1234"))
+            .send()
+            .await
+            .unwrap();
+
+        client
+            .handle_response(Instant::now(), response, "test-token")
+            .await
+    }
+
+    #[tokio::test]
+    async fn test_handle_response_503_honors_retry_after_header() {
+        // A 503 with an explicit Retry-After must surface the provider's
+        // backpressure hint, not fall back to the default backoff.
+        let result = apns_status_result(503, Some("120")).await;
+        assert!(matches!(
+            result,
+            SendAttemptResult::Retriable {
+                status_code: 503,
+                retry_after: Some(delay),
+            } if delay == Duration::from_secs(120)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_handle_response_500_without_retry_after_is_retriable_without_hint() {
+        // A 5xx without a Retry-After stays retriable but carries no hint,
+        // preserving the default exponential-backoff behavior.
+        let result = apns_status_result(500, None).await;
+        assert!(matches!(
+            result,
+            SendAttemptResult::Retriable {
+                status_code: 500,
+                retry_after: None,
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_handle_response_429_honors_retry_after_header() {
+        let result = apns_status_result(429, Some("30")).await;
+        assert!(matches!(
+            result,
+            SendAttemptResult::Retriable {
+                status_code: 429,
+                retry_after: Some(delay),
+            } if delay == Duration::from_secs(30)
         ));
     }
 

--- a/src/push/fcm.rs
+++ b/src/push/fcm.rs
@@ -509,22 +509,21 @@ impl FcmClient {
             }
             429 => {
                 // Rate limited - retriable
-                let retry_after = response
-                    .headers()
-                    .get("retry-after")
-                    .and_then(|v| v.to_str().ok())
-                    .and_then(|v| retry::parse_retry_after(Some(v)));
+                let retry_after = retry::retry_after_from_headers(response.headers());
                 SendAttemptResult::Retriable {
                     status_code: 429,
                     retry_after,
                 }
             }
             500..=599 => {
-                // Server error - retriable
+                // Server error - retriable. FCM documents that
+                // 503 SERVICE_UNAVAILABLE responses include a Retry-After the
+                // caller is expected to honor, so reuse the same extraction.
+                let retry_after = retry::retry_after_from_headers(response.headers());
                 debug!(status = %status, "FCM server error (retriable)");
                 SendAttemptResult::Retriable {
                     status_code: status.as_u16(),
-                    retry_after: None,
+                    retry_after,
                 }
             }
             _ => {
@@ -1083,6 +1082,71 @@ mod tests {
             }),
         )
         .await
+    }
+
+    /// Drive `handle_response` against a mock server returning `status_code`
+    /// with an optional `retry-after` header, returning the classified result.
+    async fn fcm_status_result(status_code: u16, retry_after: Option<&str>) -> SendAttemptResult {
+        let mock_server = MockServer::start().await;
+        let mut template =
+            ResponseTemplate::new(status_code).set_body_string("Service Unavailable");
+        if let Some(value) = retry_after {
+            template = template.insert_header("retry-after", value);
+        }
+        Mock::given(method("POST"))
+            .and(path_regex(r"/v1/projects/.+/messages:send"))
+            .respond_with(template)
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let config = FcmConfig {
+            enabled: true,
+            service_account_path: String::new(),
+            project_id: "test-project".to_string(),
+        };
+        let client = FcmClient::mock(config, false);
+
+        let response = Client::new()
+            .post(format!(
+                "{}/v1/projects/test-project/messages:send",
+                mock_server.uri()
+            ))
+            .send()
+            .await
+            .unwrap();
+
+        client
+            .handle_response(Instant::now(), response, "test-access-token")
+            .await
+    }
+
+    #[tokio::test]
+    async fn test_handle_response_503_honors_retry_after_header() {
+        // FCM documents that 503 SERVICE_UNAVAILABLE responses include a
+        // Retry-After the caller is expected to honor.
+        let result = fcm_status_result(503, Some("120")).await;
+        assert!(matches!(
+            result,
+            SendAttemptResult::Retriable {
+                status_code: 503,
+                retry_after: Some(delay),
+            } if delay == Duration::from_secs(120)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_handle_response_500_without_retry_after_is_retriable_without_hint() {
+        // A 5xx without a Retry-After stays retriable but carries no hint,
+        // preserving the default exponential-backoff behavior.
+        let result = fcm_status_result(500, None).await;
+        assert!(matches!(
+            result,
+            SendAttemptResult::Retriable {
+                status_code: 500,
+                retry_after: None,
+            }
+        ));
     }
 
     #[tokio::test]

--- a/src/push/retry.rs
+++ b/src/push/retry.rs
@@ -291,6 +291,21 @@ pub fn parse_retry_after(header_value: Option<&str>) -> Option<Duration> {
     None
 }
 
+/// Extract and parse a `Retry-After` header from a response's headers.
+///
+/// Returns the parsed backpressure hint when the provider supplied a
+/// `Retry-After` value understood by [`parse_retry_after`], and `None`
+/// otherwise. Shared by the `429` and `5xx` handling arms of the push clients
+/// so a `503 SERVICE_UNAVAILABLE` with an explicit `Retry-After` is honored,
+/// not just a `429`.
+#[must_use]
+pub(crate) fn retry_after_from_headers(headers: &reqwest::header::HeaderMap) -> Option<Duration> {
+    headers
+        .get("retry-after")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| parse_retry_after(Some(v)))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -324,6 +339,21 @@ mod tests {
     fn test_parse_retry_after_invalid() {
         assert_eq!(parse_retry_after(Some("invalid")), None);
         assert_eq!(parse_retry_after(Some("not-a-number")), None);
+    }
+
+    #[test]
+    fn test_retry_after_from_headers() {
+        let mut headers = reqwest::header::HeaderMap::new();
+        assert_eq!(retry_after_from_headers(&headers), None);
+
+        headers.insert("retry-after", "120".parse().unwrap());
+        assert_eq!(
+            retry_after_from_headers(&headers),
+            Some(Duration::from_secs(120))
+        );
+
+        headers.insert("retry-after", "not-a-number".parse().unwrap());
+        assert_eq!(retry_after_from_headers(&headers), None);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #103

## Summary
- Added a shared `retry::retry_after_from_headers` helper for push response handling.
- Reused it in both APNs and FCM `429` and `500..=599` handling so provider `Retry-After` backpressure hints are preserved on 5xx responses.
- Added regression coverage that drives real APNs/FCM `handle_response` classification for 5xx responses with and without `Retry-After`.

## Verification
- `cargo fmt --all -- --check`
- `RUSTFLAGS=-Dwarnings cargo check --all-targets`
- `RUSTFLAGS=-Dwarnings cargo clippy --all-targets -- -D warnings`
- `RUSTFLAGS=-Dwarnings cargo test --all-targets` (402 unit tests + 4 integration tests passed)
- `./scripts/cargo-audit.sh` (passed with existing allowed warnings: anyhow RUSTSEC-2026-0190, memmap2 RUSTSEC-2026-0186, rand RUSTSEC-2026-0097)
- `RUSTFLAGS=-Dwarnings cargo check --all-targets --features tor`
- `RUSTFLAGS=-Dwarnings cargo test --all-targets --features tor` (403 unit tests + 4 integration tests passed)
- `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --document-private-items`

## Sensitive paths
- `src/push/apns.rs`, `src/push/fcm.rs`, `src/push/retry.rs` — under repo-sensitive `src/push/**`; this is retry/backpressure handling only, with no token/key logging changes.

## Notes
- Existing `parse_retry_after` behavior still only parses delay-seconds; HTTP-date support is tracked separately by existing issue scope.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/transponder/pull/180">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->