### PR TITLE
fix: share push transport retry budget

### DIFF
--- a/src/push/apns.rs
+++ b/src/push/apns.rs
@@ -500,7 +500,7 @@ impl ApnsClient {
     ///
     /// Returns a `SendAttemptResult` indicating success, retriable error, or permanent error.
     async fn send_once(&self, device_token: &str) -> SendAttemptResult {
-        self.send_once_with_transport_retry_config(device_token, &RetryConfig::default())
+        self.send_once_with_transport_retry_config(device_token, &RetryConfig::transport())
             .await
     }
 

--- a/src/push/fcm.rs
+++ b/src/push/fcm.rs
@@ -550,10 +550,7 @@ impl FcmClient {
             Err(e) => return SendAttemptResult::Permanent(e),
         };
 
-        let transport_retry = RetryConfig {
-            max_retries: 1,
-            ..RetryConfig::default()
-        };
+        let transport_retry = RetryConfig::transport();
         let response = match retry::with_transport_retry(
             &transport_retry,
             "FCM",

--- a/src/push/retry.rs
+++ b/src/push/retry.rs
@@ -52,6 +52,16 @@ impl BackoffPermit {
 /// Default maximum number of retry attempts.
 pub const DEFAULT_MAX_RETRIES: u32 = 3;
 
+/// Maximum number of transport (connect-error) retry attempts.
+///
+/// Transport retries only cover pre-delivery `reqwest` connect failures (see
+/// [`with_transport_retry`]), so a single extra attempt is enough to ride out a
+/// transient connection blip without meaningfully extending worst-case
+/// permit-hold time. Kept intentionally smaller than [`DEFAULT_MAX_RETRIES`]
+/// and shared by every push provider so their connect-retry budgets stay
+/// consistent (see issue #99).
+pub const TRANSPORT_MAX_RETRIES: u32 = 1;
+
 /// Default initial backoff duration.
 pub const DEFAULT_INITIAL_BACKOFF: Duration = Duration::from_millis(100);
 
@@ -71,6 +81,21 @@ impl Default for RetryConfig {
     fn default() -> Self {
         Self {
             max_retries: DEFAULT_MAX_RETRIES,
+            initial_backoff: DEFAULT_INITIAL_BACKOFF,
+        }
+    }
+}
+
+impl RetryConfig {
+    /// Shared retry budget for transport (connect-error) retries.
+    ///
+    /// Every push provider uses this for [`with_transport_retry`] so their
+    /// pre-delivery connect-retry budgets stay consistent and permit-hold time
+    /// is bounded uniformly (see issue #99).
+    #[must_use]
+    pub const fn transport() -> Self {
+        Self {
+            max_retries: TRANSPORT_MAX_RETRIES,
             initial_backoff: DEFAULT_INITIAL_BACKOFF,
         }
     }
@@ -302,6 +327,18 @@ mod tests {
     fn test_default_config() {
         let config = RetryConfig::default();
         assert_eq!(config.max_retries, DEFAULT_MAX_RETRIES);
+        assert_eq!(config.initial_backoff, DEFAULT_INITIAL_BACKOFF);
+    }
+
+    #[test]
+    fn test_transport_config_is_shared_and_bounded() {
+        // Every push provider must share the same transport connect-retry
+        // budget so APNs and FCM stay consistent (issue #99). It is a single,
+        // small extra attempt and intentionally tighter than the default.
+        let config = RetryConfig::transport();
+        assert_eq!(config.max_retries, TRANSPORT_MAX_RETRIES);
+        assert_eq!(config.max_retries, 1);
+        assert!(config.max_retries < DEFAULT_MAX_RETRIES);
         assert_eq!(config.initial_backoff, DEFAULT_INITIAL_BACKOFF);
     }
 


### PR DESCRIPTION
Fixes #99

## Summary
- Added a shared transport retry budget (`RetryConfig::transport()`) for pre-delivery connect-error retries.
- Switched both APNs and FCM `send_once` paths to use that shared config, matching both providers at one transport retry.
- Added a focused regression test that locks the shared transport retry budget below the default retry budget.

## Verification
- `cargo fmt --all -- --check` — pass
- `RUSTFLAGS=-Dwarnings cargo check --all-targets` — pass
- `RUSTFLAGS=-Dwarnings cargo clippy --all-targets -- -D warnings` — pass
- `RUSTFLAGS=-Dwarnings cargo test --all-targets` — pass (397 main tests + 4 integration tests)
- `RUSTFLAGS=-Dwarnings cargo check --all-targets --features tor` — pass
- `RUSTFLAGS=-Dwarnings cargo test --all-targets --features tor` — pass (398 main tests + 4 integration tests)
- `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --document-private-items` — pass
- `./scripts/cargo-audit.sh` — pass (3 existing allowed warnings)

## Sensitive paths
- `src/push/apns.rs`
- `src/push/fcm.rs`
- `src/push/retry.rs`

No crypto, Nostr, config, key-handling, or auth-flow code changed.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/transponder/pull/182">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retry handling for push delivery attempts so connection and transport issues use a more consistent, bounded retry policy.
  * Reduced excessive retry behavior during single-send requests, helping failures surface more predictably and avoiding unnecessary delays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->