### PR TITLE
fix: persist replay protection for gift wraps

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,7 @@ target
 trees
 credentials
 secrets
+state
 deploy/*.env
 .env
 .env.*

--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ private_key = ""
 # Graceful shutdown timeout in seconds
 shutdown_timeout_secs = 10
 
-# Event deduplication cache size (default: 100000)
+# Volatile event deduplication cache size when durable replay state is disabled
+# (default: 100000). With dedup_state_path set, all terminal event IDs inside
+# dedup_retention_secs are retained for the full NIP-59 subscription lookback.
 # max_dedup_cache_size = 100000
 
 # Optional durable replay state for processed gift-wrap event IDs.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Transponder enables push notifications for Marmot-compatible messaging apps whil
 
 ### Privacy Properties
 
-- **Stateless**: No persistent storage of tokens or user data
+- **No stored tokens or user data**: Durable replay state stores only public gift-wrap event IDs and processing timestamps
 - **Cannot learn**: Message content, sender/recipient identities, or group membership
 - **Minimal metadata**: Only knows that a notification event occurred
 
@@ -62,6 +62,16 @@ shutdown_timeout_secs = 10
 
 # Event deduplication cache size (default: 100000)
 # max_dedup_cache_size = 100000
+
+# Optional durable replay state for processed gift-wrap event IDs.
+# Production deployments should set this to a writable path so restarts do not
+# re-dispatch the NIP-59 2-day subscription backlog.
+# Stores only public event IDs and timestamps; no tokens, keys, payloads,
+# identities, or relay URLs.
+# dedup_state_path = "/var/lib/transponder/dedup-events.log"
+# dedup_retention_secs = 173100
+# max_notification_age_secs = 3600
+# max_notification_future_skew_secs = 300
 
 # Rate limiting to prevent spam and replay attacks
 # max_rate_limit_cache_size = 100000           # Tracked keys per limiter, not total timestamps
@@ -256,12 +266,20 @@ docker run -d \
   -p 127.0.0.1:8080:8080 \
   -v /path/to/config.toml:/etc/transponder/config.toml:ro \
   -v /path/to/credentials:/credentials:ro \
+  -v /path/to/state:/var/lib/transponder:rw \
   -e TRANSPONDER_SERVER_PRIVATE_KEY="your-hex-key" \
+  -e TRANSPONDER_SERVER_DEDUP_STATE_PATH="/var/lib/transponder/dedup-events.log" \
   -e TRANSPONDER_HEALTH_BIND_ADDRESS="0.0.0.0:8080" \
   transponder
 ```
 
 Docker port publishing needs the service to listen on the container interface. The command above still binds the host side to `127.0.0.1`, keeping the endpoints local to the host by default.
+
+The container runs as UID/GID `65532`. If you bind-mount a host state directory, create it so that user can write the replay log:
+
+```bash
+sudo install -d -m 0700 -o 65532 -g 65532 /path/to/state
+```
 
 ### Docker Compose
 
@@ -282,7 +300,8 @@ Services and ports:
 - The production image now uses Docker Hardened Images for both build and runtime stages.
 - Base images are pinned by digest for reproducible deploys.
 - Docker health checks use `transponder healthcheck`, so the container does not need `wget` or `curl`.
-- The build context intentionally excludes local configs and credentials via `.dockerignore`.
+- The build context intentionally excludes local configs, credentials, and state via `.dockerignore`.
+- Mount `/var/lib/transponder` persistently in production so processed gift-wrap event IDs survive restarts and reconnects.
 - Tor relay support is disabled in the default build and must be enabled explicitly with `--features tor`.
 
 ## Production Deployment
@@ -302,6 +321,7 @@ cp config/production.toml.example config/production.toml
 cp deploy/production.env.example deploy/production.env
 mkdir -p credentials secrets
 chmod 700 credentials secrets
+sudo install -d -m 0700 -o 65532 -g 65532 state
 
 ./target/release/transponder generate-keys --output secrets/server_private_key
 
@@ -310,7 +330,7 @@ docker build -t transponder:local .
 docker compose -f compose.prod.yml --env-file deploy/production.env up -d
 ```
 
-The production bundle uses `TRANSPONDER_SERVER_PRIVATE_KEY_FILE` so the server private key can be mounted as a file instead of injected directly as an environment variable.
+The production bundle uses `TRANSPONDER_SERVER_PRIVATE_KEY_FILE` so the server private key can be mounted as a file instead of injected directly as an environment variable. It also mounts `./state` at `/var/lib/transponder` for durable replay suppression state.
 
 If you plan to configure onion relays, build the image with `--build-arg CARGO_FEATURES='--features tor'` first and point `TRANSPONDER_IMAGE` at that Tor-enabled image tag.
 

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -17,8 +17,10 @@ services:
     volumes:
       - ${TRANSPONDER_CONFIG_FILE:-./config/production.toml}:/etc/transponder/config.toml:ro
       - ${TRANSPONDER_CREDENTIALS_DIR:-./credentials}:/credentials:ro
+      - ${TRANSPONDER_STATE_DIR:-./state}:/var/lib/transponder:rw
     environment:
       TRANSPONDER_SERVER_PRIVATE_KEY_FILE: /run/secrets/transponder_private_key
+      TRANSPONDER_SERVER_DEDUP_STATE_PATH: /var/lib/transponder/dedup-events.log
       # The host port is bound to 127.0.0.1 above; this keeps Docker port
       # publishing reachable without exposing it on public host interfaces.
       TRANSPONDER_HEALTH_BIND_ADDRESS: "0.0.0.0:8080"

--- a/config/default.toml
+++ b/config/default.toml
@@ -20,6 +20,23 @@ shutdown_timeout_secs = 10
 # Default: 100000
 # max_dedup_cache_size = 100000
 
+# Optional durable replay state for processed gift-wrap event IDs.
+# Production deployments should set this to a writable path so restarts or
+# relay reconnects do not re-dispatch the full NIP-59 2-day subscription
+# backlog. Stores only public event IDs and timestamps; no tokens, keys,
+# payloads, sender/recipient identities, or relay URLs.
+# dedup_state_path = "/var/lib/transponder/dedup-events.log"
+
+# Replay-state retention. Default covers the NIP-59 2-day timestamp tweak
+# window plus tolerated future skew (172800 + 300 seconds).
+# dedup_retention_secs = 173100
+
+# Freshness bound for the unwrapped kind:446 notification rumor timestamp.
+# Outer gift-wrap created_at is randomized by NIP-59 and is not a freshness
+# signal. Set to 0 to disable this stateless bound.
+# max_notification_age_secs = 3600
+# max_notification_future_skew_secs = 300
+
 # Maximum tracked keys for each rate limit cache (encrypted_token and device_token).
 # This caps key count, not timestamp storage: worst-case timestamps per limiter
 # are max_rate_limit_cache_size * (per_minute + per_hour), or ~524M Instant

--- a/config/default.toml
+++ b/config/default.toml
@@ -15,8 +15,10 @@ private_key = ""
 # Increase this for environments with slow networks or high in-flight notification counts
 shutdown_timeout_secs = 10
 
-# Maximum size for the event deduplication cache.
-# The cache uses LRU eviction to prevent unbounded memory growth.
+# Maximum size for the volatile event deduplication cache.
+# Applies only when dedup_state_path is unset. Durable replay state retains all
+# terminal event IDs inside dedup_retention_secs so restart/reconnect replay
+# suppression covers the full NIP-59 subscription lookback window.
 # Default: 100000
 # max_dedup_cache_size = 100000
 

--- a/config/production.toml.example
+++ b/config/production.toml.example
@@ -12,6 +12,8 @@ shutdown_timeout_secs = 20
 
 # These defaults are reasonable for small to medium deployments.
 # Reduce them if you are running on a very small VM.
+# Only applies if dedup_state_path is unset; durable replay state below retains
+# all terminal IDs inside dedup_retention_secs.
 # max_dedup_cache_size = 100000
 # Durable replay state for processed gift-wrap event IDs. The systemd example
 # and compose.prod.yml make /var/lib/transponder writable. This stores only

--- a/config/production.toml.example
+++ b/config/production.toml.example
@@ -13,6 +13,17 @@ shutdown_timeout_secs = 20
 # These defaults are reasonable for small to medium deployments.
 # Reduce them if you are running on a very small VM.
 # max_dedup_cache_size = 100000
+# Durable replay state for processed gift-wrap event IDs. The systemd example
+# and compose.prod.yml make /var/lib/transponder writable. This stores only
+# public event IDs and processing timestamps; no push tokens, keys, payloads,
+# identities, or relay URLs.
+dedup_state_path = "/var/lib/transponder/dedup-events.log"
+# Retain IDs across the full NIP-59 2-day subscription lookback plus skew.
+# dedup_retention_secs = 173100
+# Reject stale unwrapped notification rumors; outer gift-wrap timestamps are
+# intentionally randomized and are not freshness signals.
+# max_notification_age_secs = 3600
+# max_notification_future_skew_secs = 300
 # Rate-limit cache size caps tracked keys, not stored timestamps. Worst-case
 # timestamps per limiter are max_rate_limit_cache_size * (per_minute + per_hour),
 # or ~524M Instant values with the defaults (~8.4 GB at 16 B/timestamp before

--- a/deploy/production.env.example
+++ b/deploy/production.env.example
@@ -9,6 +9,7 @@ TRANSPONDER_IMAGE=transponder:local
 # Runtime files and paths
 TRANSPONDER_CONFIG_FILE=./config/production.toml
 TRANSPONDER_CREDENTIALS_DIR=./credentials
+TRANSPONDER_STATE_DIR=./state
 TRANSPONDER_SERVER_PRIVATE_KEY_SECRET_FILE=./secrets/server_private_key
 
 # Published port on localhost

--- a/deploy/transponder.service.example
+++ b/deploy/transponder.service.example
@@ -25,6 +25,7 @@ MemoryDenyWriteExecute=yes
 ReadOnlyPaths=/etc/transponder/config.toml /etc/transponder/secrets /etc/transponder/credentials
 ReadWritePaths=/var/lib/transponder
 Environment=TRANSPONDER_SERVER_PRIVATE_KEY_FILE=/etc/transponder/secrets/server_private_key
+Environment=TRANSPONDER_SERVER_DEDUP_STATE_PATH=/var/lib/transponder/dedup-events.log
 Environment=TRANSPONDER_LOGGING_LEVEL=info
 Environment=RUST_LOG=info,transponder=debug,nostr_relay_pool=info,nostr_sdk=info,nostr=info,reqwest=warn,hyper=warn,hyper_util=warn,h2=warn,tower=warn,rustls=warn,tungstenite=warn,tokio_tungstenite=warn
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,9 +18,12 @@ services:
       - ./config/local.toml:/etc/transponder/config.toml:ro
       # Mount credentials directory
       - ./credentials:/credentials:ro
+      # Persist processed gift-wrap event IDs across restarts/reconnects.
+      - ./state:/var/lib/transponder:rw
     environment:
       # Override config values via environment variables
       # TRANSPONDER_SERVER_PRIVATE_KEY: "your-hex-private-key"
+      TRANSPONDER_SERVER_DEDUP_STATE_PATH: /var/lib/transponder/dedup-events.log
       # TRANSPONDER_APNS_ENABLED: "true"
       # TRANSPONDER_FCM_ENABLED: "true"
       # The host port is bound to 127.0.0.1 above; this keeps Docker port

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -4,7 +4,7 @@ This guide covers practical single-VM deployments of Transponder using either Do
 
 ## Recommended Machine Size
 
-Transponder is stateless and does not run a database, so it is relatively light. The main costs are:
+Transponder does not run a database or persist tokens/user data, so it is relatively light. The main costs are:
 
 - Nostr relay connections
 - token decryption and verification
@@ -23,6 +23,7 @@ Why these numbers make sense today:
 - the dispatcher allows up to 100 concurrent outbound push requests
 - the push queue is bounded at 10,000 pending notifications
 - the event deduplication and rate-limit caches default to 100,000 entries each
+- production deployments persist a small replay-suppression log containing only public gift-wrap event IDs and processing timestamps
 - rate-limit cache entries retain admitted-hit timestamps for sliding-window precision; worst-case timestamp storage is `max_rate_limit_cache_size × (per_minute + per_hour)` per limiter (about 8.4 GB at 16 bytes per timestamp with the defaults, before `VecDeque` overhead), and Transponder runs separate encrypted-token and device-token limiters
 - new rate-limit keys are rejected at capacity, so size these caches with headroom for legitimate unique devices, adversarial noise, and process memory limits
 - Tor adds noticeable memory and connection-management overhead, which is why the default build leaves it disabled
@@ -78,6 +79,7 @@ cp config/production.toml.example config/production.toml
 cp deploy/production.env.example deploy/production.env
 mkdir -p credentials secrets
 chmod 700 credentials secrets
+sudo install -d -m 0700 -o 65532 -g 65532 state
 ```
 
 2. Create the server private key secret file:
@@ -124,7 +126,7 @@ docker login dhi.io
 docker build --build-arg CARGO_FEATURES='--features tor' -t transponder:tor .
 ```
 
-The Dockerfile pins the DHI base images by digest, and `compose.prod.yml` runs only the Transponder container.
+The Dockerfile pins the DHI base images by digest, and `compose.prod.yml` runs only the Transponder container. The runtime image runs as UID/GID `65532`, so any bind-mounted `TRANSPONDER_STATE_DIR` must be writable by that UID/GID.
 
 Start the service:
 
@@ -138,7 +140,7 @@ The Compose stack publishes Transponder on `127.0.0.1:${TRANSPONDER_PUBLISHED_PO
 
 ## Native systemd Deployment
 
-For operators who do not want Docker at all, a native `systemd` deployment is a good fit. Transponder is a single stateless binary with a config file and a small set of credential files.
+For operators who do not want Docker at all, a native `systemd` deployment is a good fit. Transponder is a single binary with a config file, a small set of credential files, and a writable state directory for replay suppression.
 
 Example host layout:
 
@@ -147,15 +149,19 @@ Example host layout:
 - `/etc/transponder/secrets/server_private_key`
 - `/etc/transponder/credentials/AuthKey_XXXXXXXXXX.p8`
 - `/etc/transponder/credentials/service-account.json`
+- `/var/lib/transponder/dedup-events.log`
 
 Build and install the binary:
 
 ```bash
 cargo build --release
 install -m 0755 target/release/transponder /usr/local/bin/transponder
-install -d -m 0750 /etc/transponder /etc/transponder/secrets /etc/transponder/credentials
-install -m 0640 config/production.toml /etc/transponder/config.toml
-install -m 0640 secrets/server_private_key /etc/transponder/secrets/server_private_key
+getent group transponder >/dev/null || groupadd --system transponder
+id -u transponder >/dev/null 2>&1 || useradd --system --gid transponder --home-dir /var/lib/transponder --shell /usr/sbin/nologin transponder
+install -d -m 0750 -o root -g transponder /etc/transponder /etc/transponder/secrets /etc/transponder/credentials
+install -d -m 0750 -o transponder -g transponder /var/lib/transponder
+install -m 0640 -o root -g transponder config/production.toml /etc/transponder/config.toml
+install -m 0640 -o root -g transponder secrets/server_private_key /etc/transponder/secrets/server_private_key
 ```
 
 If you need onion relay support, build with:

--- a/docs/zeroization-plan.md
+++ b/docs/zeroization-plan.md
@@ -8,7 +8,7 @@ This document outlines the implementation of secure memory zeroization for sensi
 
 ## Motivation
 
-Even though Transponder is stateless and doesn't persist tokens, sensitive data can remain in memory after use. This poses risks from:
+Even though Transponder doesn't persist tokens, keys, payloads, or user data, sensitive data can remain in memory after use. This poses risks from:
 
 - Memory dumps (crash dumps, debuggers)
 - Swap/hibernation writes to disk

--- a/src/config.rs
+++ b/src/config.rs
@@ -134,9 +134,13 @@ pub struct ServerConfig {
     #[serde(default = "default_shutdown_timeout")]
     pub shutdown_timeout_secs: u64,
 
-    /// Maximum size for the event deduplication cache.
+    /// Maximum size for the volatile event deduplication cache.
     ///
-    /// The cache uses LRU eviction to prevent unbounded memory growth.
+    /// Applies when durable replay state is disabled. When `dedup_state_path`
+    /// is configured, Transponder retains all terminal event IDs inside
+    /// `dedup_retention_secs` so restart/reconnect replay suppression covers the
+    /// full NIP-59 subscription lookback window instead of being capped by this
+    /// LRU size.
     /// Default: 100,000 entries.
     #[serde(default = "default_max_dedup_cache_size")]
     pub max_dedup_cache_size: usize,

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,12 +15,20 @@
 
 use config::{Config, ConfigBuilder, File, builder::DefaultState};
 use serde::{Deserialize, Deserializer};
-use std::{env, ffi::OsString, path::Path};
+use std::{
+    env,
+    ffi::OsString,
+    path::{Path, PathBuf},
+};
 use tracing::debug;
 use zeroize::Zeroizing;
 
 use crate::crypto::nip59::DEFAULT_MAX_TOKENS_PER_EVENT;
 use crate::error::Result;
+use crate::nostr::events::{
+    DEFAULT_DEDUP_RETENTION_SECS, DEFAULT_MAX_NOTIFICATION_AGE_SECS,
+    DEFAULT_MAX_NOTIFICATION_FUTURE_SKEW_SECS,
+};
 use crate::rate_limiter::{
     DEFAULT_GLOBAL_UNWRAP_LIMIT_PER_HOUR, DEFAULT_GLOBAL_UNWRAP_LIMIT_PER_MINUTE,
     DEFAULT_MAX_SIZE as DEFAULT_MAX_RATE_LIMIT_CACHE_SIZE, DEFAULT_RATE_LIMIT_PER_HOUR,
@@ -69,6 +77,18 @@ const DEFAULT_MAX_CONCURRENT_EVENT_PROCESSING: usize = 64;
 
 fn default_max_dedup_cache_size() -> usize {
     DEFAULT_MAX_DEDUP_CACHE_SIZE
+}
+
+fn default_dedup_retention_secs() -> u64 {
+    DEFAULT_DEDUP_RETENTION_SECS
+}
+
+fn default_max_notification_age_secs() -> u64 {
+    DEFAULT_MAX_NOTIFICATION_AGE_SECS
+}
+
+fn default_max_notification_future_skew_secs() -> u64 {
+    DEFAULT_MAX_NOTIFICATION_FUTURE_SKEW_SECS
 }
 
 fn default_max_concurrent_event_processing() -> usize {
@@ -120,6 +140,34 @@ pub struct ServerConfig {
     /// Default: 100,000 entries.
     #[serde(default = "default_max_dedup_cache_size")]
     pub max_dedup_cache_size: usize,
+
+    /// Optional path for durable event-ID replay state.
+    ///
+    /// Stores only public Nostr gift-wrap event IDs and processing timestamps,
+    /// never notification payloads, device tokens, private keys, sender
+    /// identities, recipient identities, or relay URLs. Empty disables durable
+    /// replay state.
+    #[serde(default)]
+    pub dedup_state_path: PathBuf,
+
+    /// Duration to retain event IDs in replay state.
+    ///
+    /// Default covers NIP-59's 2-day outer timestamp randomization window plus
+    /// tolerated future skew.
+    #[serde(default = "default_dedup_retention_secs")]
+    pub dedup_retention_secs: u64,
+
+    /// Maximum accepted age for the unwrapped kind:446 notification rumor.
+    ///
+    /// Outer gift-wrap timestamps are intentionally randomized by NIP-59, so
+    /// freshness is checked against the inner rumor timestamp. Set to 0 to
+    /// disable this stateless freshness bound.
+    #[serde(default = "default_max_notification_age_secs")]
+    pub max_notification_age_secs: u64,
+
+    /// Tolerated future clock skew for the unwrapped notification rumor.
+    #[serde(default = "default_max_notification_future_skew_secs")]
+    pub max_notification_future_skew_secs: u64,
 
     /// Maximum tracked keys for each rate limit cache (encrypted token and
     /// device token).
@@ -202,6 +250,13 @@ impl std::fmt::Debug for ServerConfig {
             .field("private_key_file", &self.private_key_file)
             .field("shutdown_timeout_secs", &self.shutdown_timeout_secs)
             .field("max_dedup_cache_size", &self.max_dedup_cache_size)
+            .field("dedup_state_path", &self.dedup_state_path)
+            .field("dedup_retention_secs", &self.dedup_retention_secs)
+            .field("max_notification_age_secs", &self.max_notification_age_secs)
+            .field(
+                "max_notification_future_skew_secs",
+                &self.max_notification_future_skew_secs,
+            )
             .field("max_rate_limit_cache_size", &self.max_rate_limit_cache_size)
             .field("max_tokens_per_event", &self.max_tokens_per_event)
             .field(
@@ -518,6 +573,19 @@ fn base_config_builder() -> Result<ConfigBuilder<DefaultState>> {
             "server.max_dedup_cache_size",
             DEFAULT_MAX_DEDUP_CACHE_SIZE as i64,
         )?
+        .set_default("server.dedup_state_path", "")?
+        .set_default(
+            "server.dedup_retention_secs",
+            DEFAULT_DEDUP_RETENTION_SECS as i64,
+        )?
+        .set_default(
+            "server.max_notification_age_secs",
+            DEFAULT_MAX_NOTIFICATION_AGE_SECS as i64,
+        )?
+        .set_default(
+            "server.max_notification_future_skew_secs",
+            DEFAULT_MAX_NOTIFICATION_FUTURE_SKEW_SECS as i64,
+        )?
         .set_default(
             "server.max_rate_limit_cache_size",
             DEFAULT_MAX_RATE_LIMIT_CACHE_SIZE as i64,
@@ -667,6 +735,10 @@ fn is_supported_config_key(config_key: &str) -> bool {
                 | "server.private_key_file"
                 | "server.shutdown_timeout_secs"
                 | "server.max_dedup_cache_size"
+                | "server.dedup_state_path"
+                | "server.dedup_retention_secs"
+                | "server.max_notification_age_secs"
+                | "server.max_notification_future_skew_secs"
                 | "server.max_rate_limit_cache_size"
                 | "server.max_tokens_per_event"
                 | "server.encrypted_token_rate_limit_per_minute"
@@ -818,6 +890,7 @@ impl ServerConfig {
                 "server.max_rate_limit_cache_size",
                 self.max_rate_limit_cache_size as u64,
             ),
+            ("server.dedup_retention_secs", self.dedup_retention_secs),
         ];
 
         for (field, value) in zero_checked_fields {
@@ -898,6 +971,10 @@ mod tests {
             private_key_file: String::new(),
             shutdown_timeout_secs: 10,
             max_dedup_cache_size: 100_000,
+            dedup_state_path: PathBuf::new(),
+            dedup_retention_secs: DEFAULT_DEDUP_RETENTION_SECS,
+            max_notification_age_secs: DEFAULT_MAX_NOTIFICATION_AGE_SECS,
+            max_notification_future_skew_secs: DEFAULT_MAX_NOTIFICATION_FUTURE_SKEW_SECS,
             max_rate_limit_cache_size: 100_000,
             max_tokens_per_event: DEFAULT_MAX_TOKENS_PER_EVENT,
             encrypted_token_rate_limit_per_minute: 240,
@@ -1023,6 +1100,10 @@ mod tests {
             [server]
             private_key = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
             shutdown_timeout_secs = 30
+            dedup_state_path = "/var/lib/transponder/dedup-events.log"
+            dedup_retention_secs = 173100
+            max_notification_age_secs = 7200
+            max_notification_future_skew_secs = 120
 
             [relays]
             clearnet = ["wss://relay1.example.com", "wss://relay2.example.com"]
@@ -1064,6 +1145,13 @@ mod tests {
             "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
         );
         assert_eq!(config.server.shutdown_timeout_secs, 30);
+        assert_eq!(
+            config.server.dedup_state_path,
+            PathBuf::from("/var/lib/transponder/dedup-events.log")
+        );
+        assert_eq!(config.server.dedup_retention_secs, 173_100);
+        assert_eq!(config.server.max_notification_age_secs, 7_200);
+        assert_eq!(config.server.max_notification_future_skew_secs, 120);
         assert_eq!(config.relays.clearnet.len(), 2);
         assert_eq!(config.relays.onion.len(), 1);
         assert!(!config.relays.allow_unencrypted_clearnet_relays);
@@ -1094,6 +1182,19 @@ mod tests {
 
         // Check defaults
         assert_eq!(config.server.shutdown_timeout_secs, 10);
+        assert!(config.server.dedup_state_path.as_os_str().is_empty());
+        assert_eq!(
+            config.server.dedup_retention_secs,
+            DEFAULT_DEDUP_RETENTION_SECS
+        );
+        assert_eq!(
+            config.server.max_notification_age_secs,
+            DEFAULT_MAX_NOTIFICATION_AGE_SECS
+        );
+        assert_eq!(
+            config.server.max_notification_future_skew_secs,
+            DEFAULT_MAX_NOTIFICATION_FUTURE_SKEW_SECS
+        );
         assert!(config.relays.clearnet.is_empty());
         assert!(config.relays.onion.is_empty());
         assert!(!config.relays.allow_unencrypted_clearnet_relays);
@@ -1108,6 +1209,19 @@ mod tests {
         assert!(config.metrics.enabled);
         assert_eq!(config.logging.level, "info");
         assert_eq!(config.logging.format, "json");
+    }
+
+    #[test]
+    fn test_replay_default_helpers_match_event_defaults() {
+        assert_eq!(default_dedup_retention_secs(), DEFAULT_DEDUP_RETENTION_SECS);
+        assert_eq!(
+            default_max_notification_age_secs(),
+            DEFAULT_MAX_NOTIFICATION_AGE_SECS
+        );
+        assert_eq!(
+            default_max_notification_future_skew_secs(),
+            DEFAULT_MAX_NOTIFICATION_FUTURE_SKEW_SECS
+        );
     }
 
     #[test]
@@ -1146,6 +1260,16 @@ mod tests {
             ("TRANSPONDER_SERVER_PRIVATE_KEY", "env-private-key"),
             ("TRANSPONDER_SERVER_SHUTDOWN_TIMEOUT_SECS", "30"),
             ("TRANSPONDER_SERVER_MAX_DEDUP_CACHE_SIZE", "50000"),
+            (
+                "TRANSPONDER_SERVER_DEDUP_STATE_PATH",
+                "/var/lib/transponder/dedup-events.log",
+            ),
+            ("TRANSPONDER_SERVER_DEDUP_RETENTION_SECS", "173100"),
+            ("TRANSPONDER_SERVER_MAX_NOTIFICATION_AGE_SECS", "7200"),
+            (
+                "TRANSPONDER_SERVER_MAX_NOTIFICATION_FUTURE_SKEW_SECS",
+                "120",
+            ),
             ("TRANSPONDER_SERVER_MAX_TOKENS_PER_EVENT", "25"),
             (
                 "TRANSPONDER_RELAYS_ALLOW_UNENCRYPTED_CLEARNET_RELAYS",
@@ -1159,6 +1283,13 @@ mod tests {
         assert_eq!(config.server.private_key.as_str(), "env-private-key");
         assert_eq!(config.server.shutdown_timeout_secs, 30);
         assert_eq!(config.server.max_dedup_cache_size, 50_000);
+        assert_eq!(
+            config.server.dedup_state_path,
+            PathBuf::from("/var/lib/transponder/dedup-events.log")
+        );
+        assert_eq!(config.server.dedup_retention_secs, 173_100);
+        assert_eq!(config.server.max_notification_age_secs, 7_200);
+        assert_eq!(config.server.max_notification_future_skew_secs, 120);
         assert_eq!(config.server.max_tokens_per_event, 25);
         assert!(config.relays.allow_unencrypted_clearnet_relays);
         assert_eq!(config.apns.key_id, "KEY123");

--- a/src/main.rs
+++ b/src/main.rs
@@ -135,6 +135,24 @@ fn build_rate_limit_config(server: &config::ServerConfig) -> nostr::events::Toke
     }
 }
 
+fn build_replay_protection_config(
+    server: &config::ServerConfig,
+) -> nostr::events::ReplayProtectionConfig {
+    let dedup_state_path = if server.dedup_state_path.as_os_str().is_empty() {
+        None
+    } else {
+        Some(server.dedup_state_path.clone())
+    };
+
+    nostr::events::ReplayProtectionConfig {
+        max_dedup_cache_size: server.max_dedup_cache_size,
+        dedup_state_path,
+        dedup_retention: Duration::from_secs(server.dedup_retention_secs),
+        max_notification_age: Duration::from_secs(server.max_notification_age_secs),
+        max_notification_future_skew: Duration::from_secs(server.max_notification_future_skew_secs),
+    }
+}
+
 fn parse_server_secret_key(server_private_key: &str) -> Result<SecretKey> {
     SecretKey::parse(server_private_key).context("Invalid server private key")
 }
@@ -351,16 +369,20 @@ async fn run(mut config: AppConfig) -> Result<()> {
         warn!(error = %e, "Failed to publish inbox relay list");
     }
 
-    // Create event processor with configured cache sizes and rate limiting
+    // Create event processor with configured replay protection and rate limiting
     let rate_limit_config = build_rate_limit_config(&config.server);
-    let event_processor = Arc::new(EventProcessor::with_full_config(
-        nip59_handler,
-        token_decryptor,
-        push_dispatcher.clone(),
-        config.server.max_dedup_cache_size,
-        rate_limit_config,
-        metrics.clone(),
-    ));
+    let replay_config = build_replay_protection_config(&config.server);
+    let event_processor = Arc::new(
+        EventProcessor::with_replay_config(
+            nip59_handler,
+            token_decryptor,
+            push_dispatcher.clone(),
+            rate_limit_config,
+            replay_config,
+            metrics.clone(),
+        )
+        .context("Failed to initialize event replay protection")?,
+    );
 
     // Initialize shutdown handler
     let shutdown = ShutdownHandler::new();
@@ -889,6 +911,11 @@ mod tests {
             private_key_file: "/tmp/ignored".to_string(),
             shutdown_timeout_secs: 10,
             max_dedup_cache_size: 100_000,
+            dedup_state_path: PathBuf::new(),
+            dedup_retention_secs: crate::nostr::events::DEFAULT_DEDUP_RETENTION_SECS,
+            max_notification_age_secs: crate::nostr::events::DEFAULT_MAX_NOTIFICATION_AGE_SECS,
+            max_notification_future_skew_secs:
+                crate::nostr::events::DEFAULT_MAX_NOTIFICATION_FUTURE_SKEW_SECS,
             max_rate_limit_cache_size: 100_000,
             max_tokens_per_event: crate::crypto::nip59::DEFAULT_MAX_TOKENS_PER_EVENT,
             encrypted_token_rate_limit_per_minute: 240,
@@ -917,6 +944,11 @@ mod tests {
             private_key_file: file.path().display().to_string(),
             shutdown_timeout_secs: 10,
             max_dedup_cache_size: 100_000,
+            dedup_state_path: PathBuf::new(),
+            dedup_retention_secs: crate::nostr::events::DEFAULT_DEDUP_RETENTION_SECS,
+            max_notification_age_secs: crate::nostr::events::DEFAULT_MAX_NOTIFICATION_AGE_SECS,
+            max_notification_future_skew_secs:
+                crate::nostr::events::DEFAULT_MAX_NOTIFICATION_FUTURE_SKEW_SECS,
             max_rate_limit_cache_size: 100_000,
             max_tokens_per_event: crate::crypto::nip59::DEFAULT_MAX_TOKENS_PER_EVENT,
             encrypted_token_rate_limit_per_minute: 240,
@@ -944,6 +976,11 @@ mod tests {
             private_key_file: format!("  {}  ", file.path().display()),
             shutdown_timeout_secs: 10,
             max_dedup_cache_size: 100_000,
+            dedup_state_path: PathBuf::new(),
+            dedup_retention_secs: crate::nostr::events::DEFAULT_DEDUP_RETENTION_SECS,
+            max_notification_age_secs: crate::nostr::events::DEFAULT_MAX_NOTIFICATION_AGE_SECS,
+            max_notification_future_skew_secs:
+                crate::nostr::events::DEFAULT_MAX_NOTIFICATION_FUTURE_SKEW_SECS,
             max_rate_limit_cache_size: 100_000,
             max_tokens_per_event: crate::crypto::nip59::DEFAULT_MAX_TOKENS_PER_EVENT,
             encrypted_token_rate_limit_per_minute: 240,
@@ -968,6 +1005,11 @@ mod tests {
             private_key_file: String::new(),
             shutdown_timeout_secs: 10,
             max_dedup_cache_size: 100_000,
+            dedup_state_path: PathBuf::new(),
+            dedup_retention_secs: crate::nostr::events::DEFAULT_DEDUP_RETENTION_SECS,
+            max_notification_age_secs: crate::nostr::events::DEFAULT_MAX_NOTIFICATION_AGE_SECS,
+            max_notification_future_skew_secs:
+                crate::nostr::events::DEFAULT_MAX_NOTIFICATION_FUTURE_SKEW_SECS,
             max_rate_limit_cache_size: 100_000,
             max_tokens_per_event: crate::crypto::nip59::DEFAULT_MAX_TOKENS_PER_EVENT,
             encrypted_token_rate_limit_per_minute: 240,
@@ -992,6 +1034,11 @@ mod tests {
             private_key_file: "/tmp/definitely-missing-transponder-key".to_string(),
             shutdown_timeout_secs: 10,
             max_dedup_cache_size: 100_000,
+            dedup_state_path: PathBuf::new(),
+            dedup_retention_secs: crate::nostr::events::DEFAULT_DEDUP_RETENTION_SECS,
+            max_notification_age_secs: crate::nostr::events::DEFAULT_MAX_NOTIFICATION_AGE_SECS,
+            max_notification_future_skew_secs:
+                crate::nostr::events::DEFAULT_MAX_NOTIFICATION_FUTURE_SKEW_SECS,
             max_rate_limit_cache_size: 100_000,
             max_tokens_per_event: crate::crypto::nip59::DEFAULT_MAX_TOKENS_PER_EVENT,
             encrypted_token_rate_limit_per_minute: 240,
@@ -1096,6 +1143,11 @@ mod tests {
             private_key_file: file.path().display().to_string(),
             shutdown_timeout_secs: 10,
             max_dedup_cache_size: 100_000,
+            dedup_state_path: PathBuf::new(),
+            dedup_retention_secs: crate::nostr::events::DEFAULT_DEDUP_RETENTION_SECS,
+            max_notification_age_secs: crate::nostr::events::DEFAULT_MAX_NOTIFICATION_AGE_SECS,
+            max_notification_future_skew_secs:
+                crate::nostr::events::DEFAULT_MAX_NOTIFICATION_FUTURE_SKEW_SECS,
             max_rate_limit_cache_size: 100_000,
             max_tokens_per_event: crate::crypto::nip59::DEFAULT_MAX_TOKENS_PER_EVENT,
             encrypted_token_rate_limit_per_minute: 240,
@@ -1120,6 +1172,11 @@ mod tests {
             private_key_file: String::new(),
             shutdown_timeout_secs: 10,
             max_dedup_cache_size: 100_000,
+            dedup_state_path: PathBuf::new(),
+            dedup_retention_secs: crate::nostr::events::DEFAULT_DEDUP_RETENTION_SECS,
+            max_notification_age_secs: crate::nostr::events::DEFAULT_MAX_NOTIFICATION_AGE_SECS,
+            max_notification_future_skew_secs:
+                crate::nostr::events::DEFAULT_MAX_NOTIFICATION_FUTURE_SKEW_SECS,
             max_rate_limit_cache_size: 1234,
             max_tokens_per_event: 25,
             encrypted_token_rate_limit_per_minute: 111,
@@ -1141,5 +1198,67 @@ mod tests {
         assert_eq!(rate_limit_config.device_token_per_hour, 4444);
         assert_eq!(rate_limit_config.global_unwrap_per_minute, 555);
         assert_eq!(rate_limit_config.global_unwrap_per_hour, 6666);
+    }
+
+    #[test]
+    fn build_replay_protection_config_matches_server_settings() {
+        let state_path = PathBuf::from("/var/lib/transponder/dedup-events.log");
+        let server = config::ServerConfig {
+            private_key: Zeroizing::new(String::new()),
+            private_key_file: String::new(),
+            shutdown_timeout_secs: 10,
+            max_dedup_cache_size: 77,
+            dedup_state_path: state_path.clone(),
+            dedup_retention_secs: 88,
+            max_notification_age_secs: 99,
+            max_notification_future_skew_secs: 11,
+            max_rate_limit_cache_size: 100_000,
+            max_tokens_per_event: crate::crypto::nip59::DEFAULT_MAX_TOKENS_PER_EVENT,
+            encrypted_token_rate_limit_per_minute: 240,
+            encrypted_token_rate_limit_per_hour: 5000,
+            device_token_rate_limit_per_minute: 240,
+            device_token_rate_limit_per_hour: 5000,
+            max_concurrent_event_processing: 64,
+            global_unwrap_rate_limit_per_minute: 600,
+            global_unwrap_rate_limit_per_hour: 30_000,
+        };
+
+        let replay_config = build_replay_protection_config(&server);
+
+        assert_eq!(replay_config.max_dedup_cache_size, 77);
+        assert_eq!(replay_config.dedup_state_path, Some(state_path));
+        assert_eq!(replay_config.dedup_retention, Duration::from_secs(88));
+        assert_eq!(replay_config.max_notification_age, Duration::from_secs(99));
+        assert_eq!(
+            replay_config.max_notification_future_skew,
+            Duration::from_secs(11)
+        );
+    }
+
+    #[test]
+    fn build_replay_protection_config_disables_empty_state_path() {
+        let server = config::ServerConfig {
+            private_key: Zeroizing::new(String::new()),
+            private_key_file: String::new(),
+            shutdown_timeout_secs: 10,
+            max_dedup_cache_size: 77,
+            dedup_state_path: PathBuf::new(),
+            dedup_retention_secs: 88,
+            max_notification_age_secs: 99,
+            max_notification_future_skew_secs: 11,
+            max_rate_limit_cache_size: 100_000,
+            max_tokens_per_event: crate::crypto::nip59::DEFAULT_MAX_TOKENS_PER_EVENT,
+            encrypted_token_rate_limit_per_minute: 240,
+            encrypted_token_rate_limit_per_hour: 5000,
+            device_token_rate_limit_per_minute: 240,
+            device_token_rate_limit_per_hour: 5000,
+            max_concurrent_event_processing: 64,
+            global_unwrap_rate_limit_per_minute: 600,
+            global_unwrap_rate_limit_per_hour: 30_000,
+        };
+
+        let replay_config = build_replay_protection_config(&server);
+
+        assert_eq!(replay_config.dedup_state_path, None);
     }
 }

--- a/src/nostr/events.rs
+++ b/src/nostr/events.rs
@@ -3,6 +3,7 @@
 //! Handles deduplication and processing of gift-wrapped notification requests,
 //! including rate limiting to prevent spam and replay attacks.
 
+use std::collections::HashMap;
 use std::fs::{self, OpenOptions as StdOpenOptions};
 use std::num::NonZeroUsize;
 #[cfg(unix)]
@@ -58,10 +59,13 @@ pub const DEFAULT_DEDUP_RETENTION_SECS: u64 =
 /// window expires.
 const DEDUP_WINDOW: Duration = Duration::from_secs(DEFAULT_DEDUP_RETENTION_SECS);
 
-/// Maximum number of entries to scan per cleanup cycle.
+/// Maximum number of volatile LRU entries to scan per cleanup cycle.
+///
+/// Durable replay state scans the retained set so retention, not LRU capacity,
+/// remains the source of truth for restart/reconnect duplicate suppression.
 const CLEANUP_BATCH_SIZE: usize = 1000;
 
-/// Default maximum size for the deduplication cache.
+/// Default maximum size for the volatile deduplication cache.
 pub const DEFAULT_MAX_DEDUP_CACHE_SIZE: usize = 100_000;
 
 #[derive(Clone, Copy)]
@@ -82,6 +86,105 @@ impl SeenEvent {
         Self {
             seen_at,
             terminal: true,
+        }
+    }
+}
+
+enum SeenEventStore {
+    Bounded(LruCache<EventId, SeenEvent>),
+    Retained(HashMap<EventId, SeenEvent>),
+}
+
+impl SeenEventStore {
+    fn bounded(cache_size: NonZeroUsize) -> Self {
+        Self::Bounded(LruCache::new(cache_size))
+    }
+
+    fn retained() -> Self {
+        Self::Retained(HashMap::new())
+    }
+
+    fn len(&self) -> usize {
+        match self {
+            Self::Bounded(seen) => seen.len(),
+            Self::Retained(seen) => seen.len(),
+        }
+    }
+
+    fn contains(&self, event_id: &EventId) -> bool {
+        match self {
+            Self::Bounded(seen) => seen.contains(event_id),
+            Self::Retained(seen) => seen.contains_key(event_id),
+        }
+    }
+
+    fn put(&mut self, event_id: EventId, seen_event: SeenEvent) {
+        match self {
+            Self::Bounded(seen) => {
+                seen.put(event_id, seen_event);
+            }
+            Self::Retained(seen) => {
+                seen.insert(event_id, seen_event);
+            }
+        }
+    }
+
+    fn pop(&mut self, event_id: &EventId) {
+        match self {
+            Self::Bounded(seen) => {
+                seen.pop(event_id);
+            }
+            Self::Retained(seen) => {
+                seen.remove(event_id);
+            }
+        }
+    }
+
+    fn expired_keys(&self, now: Instant, retention: Duration) -> Vec<EventId> {
+        match self {
+            Self::Bounded(seen) => seen
+                .iter()
+                .rev()
+                .take(CLEANUP_BATCH_SIZE)
+                .filter(|(_, seen_event)| now.duration_since(seen_event.seen_at) >= retention)
+                .map(|(id, _)| *id)
+                .collect(),
+            Self::Retained(seen) => seen
+                .iter()
+                .filter(|(_, seen_event)| now.duration_since(seen_event.seen_at) >= retention)
+                .map(|(id, _)| *id)
+                .collect(),
+        }
+    }
+
+    fn terminal_entries(&self, now_wall: u64, now_instant: Instant) -> Vec<(EventId, u64)> {
+        match self {
+            Self::Bounded(seen) => seen
+                .iter()
+                .filter_map(|(event_id, seen_event)| {
+                    if seen_event.terminal {
+                        Some((
+                            *event_id,
+                            instant_to_unix_secs(seen_event.seen_at, now_wall, now_instant),
+                        ))
+                    } else {
+                        None
+                    }
+                })
+                .collect(),
+            Self::Retained(seen) => seen
+                .iter()
+                .filter_map(|(event_id, seen_event)| {
+                    if seen_event.terminal {
+                        Some((
+                            *event_id,
+                            instant_to_unix_secs(seen_event.seen_at, now_wall, now_instant),
+                        ))
+                    } else {
+                        None
+                    }
+                })
+                .collect(),
         }
     }
 }
@@ -118,16 +221,12 @@ impl PersistentDedupState {
         Ok(())
     }
 
-    fn load_seen_events(
-        path: &Path,
-        cache_size: NonZeroUsize,
-        retention: Duration,
-    ) -> Result<LruCache<EventId, SeenEvent>> {
+    fn load_seen_events(path: &Path, retention: Duration) -> Result<SeenEventStore> {
         Self::prepare_path(path)?;
 
         let now_wall = Timestamp::now().as_secs();
         let now_instant = Instant::now();
-        let mut seen = LruCache::new(cache_size);
+        let mut seen = SeenEventStore::retained();
         let contents = fs::read_to_string(path)?;
 
         for line in contents.lines() {
@@ -235,8 +334,8 @@ pub struct EventProcessor {
     nip59_handler: Nip59Handler,
     token_decryptor: TokenDecryptor,
     push_dispatcher: Arc<PushDispatcher>,
-    /// Event ID deduplication cache.
-    seen_events: Arc<RwLock<LruCache<EventId, SeenEvent>>>,
+    /// Event ID replay-protection state.
+    seen_events: Arc<RwLock<SeenEventStore>>,
     /// Optional durable event-ID replay state.
     dedup_persistence: Option<Arc<PersistentDedupState>>,
     /// How long event IDs remain in replay state.
@@ -300,7 +399,12 @@ impl Default for TokenRateLimitConfig {
 /// Replay-protection configuration for event IDs and notification freshness.
 #[derive(Debug, Clone)]
 pub struct ReplayProtectionConfig {
-    /// Maximum in-memory event IDs retained for duplicate suppression.
+    /// Maximum in-memory event IDs retained for duplicate suppression when
+    /// durable replay state is disabled.
+    ///
+    /// When `dedup_state_path` is set, all terminal event IDs inside
+    /// `dedup_retention` are kept so durable replay state covers the full relay
+    /// lookback window instead of being capped by this LRU size.
     pub max_dedup_cache_size: usize,
     /// Optional durable replay-state path.
     ///
@@ -410,17 +514,17 @@ impl EventProcessor {
         );
 
         let (seen_events, dedup_persistence) = if let Some(path) = replay_config.dedup_state_path {
-            let seen = PersistentDedupState::load_seen_events(
-                &path,
-                cache_size,
-                replay_config.dedup_retention,
-            )?;
+            let seen =
+                PersistentDedupState::load_seen_events(&path, replay_config.dedup_retention)?;
             (
                 Arc::new(RwLock::new(seen)),
                 Some(Arc::new(PersistentDedupState::new(path)?)),
             )
         } else {
-            (Arc::new(RwLock::new(LruCache::new(cache_size))), None)
+            (
+                Arc::new(RwLock::new(SeenEventStore::bounded(cache_size))),
+                None,
+            )
         };
 
         Ok(Self {
@@ -898,8 +1002,10 @@ impl EventProcessor {
 
     /// Clean up all caches by removing expired entries.
     ///
-    /// Uses incremental cleanup to avoid holding write locks for extended
-    /// periods. Call periodically for full cleanup of all expired entries.
+    /// Uses incremental cleanup for volatile LRU state to avoid holding write
+    /// locks for extended periods. Durable replay state scans all retained IDs
+    /// so the persisted set stays bounded by retention rather than cache size.
+    /// Call periodically for full cleanup of all expired entries.
     pub async fn cleanup(&self) {
         // Clean event deduplication cache
         let persistence = self.dedup_persistence.clone();
@@ -914,33 +1020,14 @@ impl EventProcessor {
             let now = Instant::now();
             let now_wall = Timestamp::now().as_secs();
 
-            let expired_keys: Vec<_> = seen
-                .iter()
-                .rev()
-                .take(CLEANUP_BATCH_SIZE)
-                .filter(|(_, seen_event)| {
-                    now.duration_since(seen_event.seen_at) >= self.dedup_retention
-                })
-                .map(|(id, _)| *id)
-                .collect();
+            let expired_keys = seen.expired_keys(now, self.dedup_retention);
 
             for key in &expired_keys {
                 seen.pop(key);
             }
 
             let retained_entries = if persistence.is_some() {
-                seen.iter()
-                    .filter_map(|(event_id, seen_event)| {
-                        if seen_event.terminal {
-                            Some((
-                                *event_id,
-                                instant_to_unix_secs(seen_event.seen_at, now_wall, now),
-                            ))
-                        } else {
-                            None
-                        }
-                    })
-                    .collect()
+                seen.terminal_entries(now_wall, now)
             } else {
                 Vec::new()
             };
@@ -1447,6 +1534,42 @@ mod tests {
         assert!(restarted.is_duplicate(&event.id).await);
     }
 
+    #[tokio::test]
+    async fn test_durable_dedup_state_is_not_capped_by_lru_size() {
+        let server_keys = Keys::generate();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let state_path = dir.path().join("dedup-state.tsv");
+        let replay_config = ReplayProtectionConfig {
+            max_dedup_cache_size: 2,
+            dedup_state_path: Some(state_path.clone()),
+            ..ReplayProtectionConfig::default()
+        };
+        let processor = create_processor_with_replay_config(&server_keys, replay_config.clone());
+        let event_ids: Vec<_> = (0..5)
+            .map(|i| {
+                let mut bytes = [0u8; 32];
+                bytes[0] = i;
+                EventId::from_byte_array(bytes)
+            })
+            .collect();
+
+        for event_id in &event_ids {
+            processor.mark_seen(*event_id).await;
+        }
+
+        assert_eq!(processor.cache_len(), event_ids.len());
+        assert!(processor.is_duplicate(&event_ids[0]).await);
+
+        let restarted = create_processor_with_replay_config(&server_keys, replay_config);
+        assert_eq!(restarted.cache_len(), event_ids.len());
+        for event_id in event_ids {
+            assert!(
+                restarted.is_duplicate(&event_id).await,
+                "durable replay state must retain every ID inside retention, even past max_dedup_cache_size"
+            );
+        }
+    }
+
     #[test]
     fn test_dedup_state_loader_ignores_malformed_and_expired_rows() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -1468,12 +1591,8 @@ mod tests {
         std::fs::create_dir_all(state_path.parent().expect("state parent")).expect("mkdir");
         std::fs::write(&state_path, state).expect("write state");
 
-        let seen = PersistentDedupState::load_seen_events(
-            &state_path,
-            NonZeroUsize::new(10).expect("non-zero cache"),
-            Duration::from_secs(60),
-        )
-        .expect("load state");
+        let seen = PersistentDedupState::load_seen_events(&state_path, Duration::from_secs(60))
+            .expect("load state");
 
         assert!(seen.contains(&retained_id));
         assert!(!seen.contains(&expired_id));

--- a/src/nostr/events.rs
+++ b/src/nostr/events.rs
@@ -3,14 +3,19 @@
 //! Handles deduplication and processing of gift-wrapped notification requests,
 //! including rate limiting to prevent spam and replay attacks.
 
+use std::fs::{self, OpenOptions as StdOpenOptions};
 use std::num::NonZeroUsize;
+#[cfg(unix)]
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant as StdInstant};
 
 use lru::LruCache;
 use nostr_sdk::prelude::*;
 use sha2::{Digest, Sha256};
-use tokio::sync::RwLock;
+use tokio::io::AsyncWriteExt;
+use tokio::sync::{Mutex, RwLock};
 use tokio::time::Instant;
 use tracing::{debug, info, trace, warn};
 
@@ -25,14 +30,170 @@ use crate::rate_limiter::{
     DEFAULT_RATE_LIMIT_PER_HOUR, DEFAULT_RATE_LIMIT_PER_MINUTE, RateLimitConfig, RateLimiter,
 };
 
-/// Duration to keep event IDs for deduplication (5 minutes).
-const DEDUP_WINDOW: Duration = Duration::from_secs(300);
+/// Maximum NIP-59 timestamp randomization window for gift wraps.
+///
+/// Relays must still be queried with this full lookback because compliant gift
+/// wraps randomize their outer `created_at`; durable replay state and inner
+/// rumor freshness bound what we will actually dispatch from that backlog.
+const NIP59_TIMESTAMP_TWEAK_WINDOW_SECS: u64 = nip59::RANGE_RANDOM_TIMESTAMP_TWEAK.end;
+
+/// Default maximum age for the unwrapped kind:446 notification request rumor.
+///
+/// Outer gift-wrap timestamps are deliberately randomized by NIP-59 and are not
+/// freshness signals. The inner notification rumor timestamp is the only
+/// stateless bound available before dispatching a replayed backlog event.
+pub const DEFAULT_MAX_NOTIFICATION_AGE_SECS: u64 = 3_600;
+
+/// Default tolerated clock skew for future-dated notification rumors.
+pub const DEFAULT_MAX_NOTIFICATION_FUTURE_SKEW_SECS: u64 = 300;
+
+/// Default duration to keep processed gift-wrap event IDs in replay state.
+pub const DEFAULT_DEDUP_RETENTION_SECS: u64 =
+    NIP59_TIMESTAMP_TWEAK_WINDOW_SECS + DEFAULT_MAX_NOTIFICATION_FUTURE_SKEW_SECS;
+
+/// Duration to keep event IDs for deduplication.
+///
+/// The cache must cover the relay subscription lookback; otherwise a restart or
+/// reconnect can re-deliver backlog entries after the old 5-minute in-memory
+/// window expires.
+const DEDUP_WINDOW: Duration = Duration::from_secs(DEFAULT_DEDUP_RETENTION_SECS);
 
 /// Maximum number of entries to scan per cleanup cycle.
 const CLEANUP_BATCH_SIZE: usize = 1000;
 
 /// Default maximum size for the deduplication cache.
 pub const DEFAULT_MAX_DEDUP_CACHE_SIZE: usize = 100_000;
+
+#[derive(Clone, Copy)]
+struct SeenEvent {
+    seen_at: Instant,
+    terminal: bool,
+}
+
+impl SeenEvent {
+    fn reservation(seen_at: Instant) -> Self {
+        Self {
+            seen_at,
+            terminal: false,
+        }
+    }
+
+    fn terminal(seen_at: Instant) -> Self {
+        Self {
+            seen_at,
+            terminal: true,
+        }
+    }
+}
+
+struct PersistentDedupState {
+    path: PathBuf,
+    write_lock: Mutex<()>,
+}
+
+impl PersistentDedupState {
+    fn new(path: PathBuf) -> Result<Self> {
+        Self::prepare_path(&path)?;
+        Ok(Self {
+            path,
+            write_lock: Mutex::new(()),
+        })
+    }
+
+    fn prepare_path(path: &Path) -> Result<()> {
+        if let Some(parent) = path.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            fs::create_dir_all(parent)?;
+        }
+
+        let mut options = StdOpenOptions::new();
+        options.create(true).append(true).read(true);
+        #[cfg(unix)]
+        options.mode(0o600);
+        let _file = options.open(path)?;
+
+        #[cfg(unix)]
+        fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
+        Ok(())
+    }
+
+    fn load_seen_events(
+        path: &Path,
+        cache_size: NonZeroUsize,
+        retention: Duration,
+    ) -> Result<LruCache<EventId, SeenEvent>> {
+        Self::prepare_path(path)?;
+
+        let now_wall = Timestamp::now().as_secs();
+        let now_instant = Instant::now();
+        let mut seen = LruCache::new(cache_size);
+        let contents = fs::read_to_string(path)?;
+
+        for line in contents.lines() {
+            let mut fields = line.split_whitespace();
+            let (Some(event_id_hex), Some(seen_at_secs), None) =
+                (fields.next(), fields.next(), fields.next())
+            else {
+                continue;
+            };
+            let Ok(event_id) = EventId::from_hex(event_id_hex) else {
+                continue;
+            };
+            let Ok(seen_at_secs) = seen_at_secs.parse::<u64>() else {
+                continue;
+            };
+            let age = now_wall.saturating_sub(seen_at_secs);
+            if age > retention.as_secs() {
+                continue;
+            }
+            let seen_at = now_instant
+                .checked_sub(Duration::from_secs(age))
+                .unwrap_or(now_instant);
+            seen.put(event_id, SeenEvent::terminal(seen_at));
+        }
+
+        Ok(seen)
+    }
+
+    async fn append_seen_locked(
+        &self,
+        event_id: EventId,
+        seen_at_secs: u64,
+    ) -> std::io::Result<()> {
+        let mut file = tokio::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)
+            .await?;
+        #[cfg(unix)]
+        tokio::fs::set_permissions(&self.path, fs::Permissions::from_mode(0o600)).await?;
+        file.write_all(format!("{} {}\n", event_id.to_hex(), seen_at_secs).as_bytes())
+            .await?;
+        file.flush().await
+    }
+
+    async fn rewrite_locked(&self, entries: &[(EventId, u64)]) -> std::io::Result<()> {
+        let tmp_path = self.path.with_extension("tmp");
+        let mut contents = String::new();
+        for (event_id, seen_at_secs) in entries {
+            use std::fmt::Write as _;
+            let _ = writeln!(&mut contents, "{} {}", event_id.to_hex(), seen_at_secs);
+        }
+        tokio::fs::write(&tmp_path, contents).await?;
+        #[cfg(unix)]
+        tokio::fs::set_permissions(&tmp_path, fs::Permissions::from_mode(0o600)).await?;
+        tokio::fs::rename(&tmp_path, &self.path).await
+    }
+}
+
+fn instant_to_unix_secs(seen_at: Instant, now_wall: u64, now_instant: Instant) -> u64 {
+    let age = now_instant
+        .checked_duration_since(seen_at)
+        .unwrap_or_default()
+        .as_secs();
+    now_wall.saturating_sub(age)
+}
 
 #[must_use]
 struct InFlightEventGuard<'a> {
@@ -75,7 +236,15 @@ pub struct EventProcessor {
     token_decryptor: TokenDecryptor,
     push_dispatcher: Arc<PushDispatcher>,
     /// Event ID deduplication cache.
-    seen_events: Arc<RwLock<LruCache<EventId, Instant>>>,
+    seen_events: Arc<RwLock<LruCache<EventId, SeenEvent>>>,
+    /// Optional durable event-ID replay state.
+    dedup_persistence: Option<Arc<PersistentDedupState>>,
+    /// How long event IDs remain in replay state.
+    dedup_retention: Duration,
+    /// Maximum accepted age for the unwrapped notification rumor.
+    max_notification_age: Duration,
+    /// Tolerated sender/server clock skew for future-dated notification rumors.
+    max_notification_future_skew: Duration,
     /// Global pre-unwrap admission limiter.
     ///
     /// Checked BEFORE the gift-wrap unwrap (ECDH + seal decryption) using a
@@ -128,6 +297,41 @@ impl Default for TokenRateLimitConfig {
     }
 }
 
+/// Replay-protection configuration for event IDs and notification freshness.
+#[derive(Debug, Clone)]
+pub struct ReplayProtectionConfig {
+    /// Maximum in-memory event IDs retained for duplicate suppression.
+    pub max_dedup_cache_size: usize,
+    /// Optional durable replay-state path.
+    ///
+    /// The file stores only public Nostr gift-wrap event IDs and the time they
+    /// reached a terminal state. It does not store tokens, payloads, sender
+    /// identities, device identifiers, or relay URLs.
+    pub dedup_state_path: Option<PathBuf>,
+    /// How long event IDs remain eligible for duplicate suppression.
+    pub dedup_retention: Duration,
+    /// Maximum accepted age for the unwrapped kind:446 notification rumor.
+    ///
+    /// Set to zero to disable the freshness bound.
+    pub max_notification_age: Duration,
+    /// Tolerated future clock skew for the unwrapped notification rumor.
+    pub max_notification_future_skew: Duration,
+}
+
+impl Default for ReplayProtectionConfig {
+    fn default() -> Self {
+        Self {
+            max_dedup_cache_size: DEFAULT_MAX_DEDUP_CACHE_SIZE,
+            dedup_state_path: None,
+            dedup_retention: DEDUP_WINDOW,
+            max_notification_age: Duration::from_secs(DEFAULT_MAX_NOTIFICATION_AGE_SECS),
+            max_notification_future_skew: Duration::from_secs(
+                DEFAULT_MAX_NOTIFICATION_FUTURE_SKEW_SECS,
+            ),
+        }
+    }
+}
+
 impl EventProcessor {
     /// Create a new event processor with default settings.
     ///
@@ -168,6 +372,7 @@ impl EventProcessor {
     }
 
     /// Create a new event processor with full configuration.
+    #[cfg(test)]
     pub fn with_full_config(
         nip59_handler: Nip59Handler,
         token_decryptor: TokenDecryptor,
@@ -176,16 +381,57 @@ impl EventProcessor {
         rate_limit_config: TokenRateLimitConfig,
         metrics: Option<Metrics>,
     ) -> Self {
-        let cache_size = NonZeroUsize::new(max_dedup_cache_size).unwrap_or(
+        Self::with_replay_config(
+            nip59_handler,
+            token_decryptor,
+            push_dispatcher,
+            rate_limit_config,
+            ReplayProtectionConfig {
+                max_dedup_cache_size,
+                ..ReplayProtectionConfig::default()
+            },
+            metrics,
+        )
+        .expect("in-memory replay protection config cannot fail")
+    }
+
+    /// Create a new event processor with full replay-protection configuration.
+    pub fn with_replay_config(
+        nip59_handler: Nip59Handler,
+        token_decryptor: TokenDecryptor,
+        push_dispatcher: Arc<PushDispatcher>,
+        rate_limit_config: TokenRateLimitConfig,
+        replay_config: ReplayProtectionConfig,
+        metrics: Option<Metrics>,
+    ) -> Result<Self> {
+        let cache_size = NonZeroUsize::new(replay_config.max_dedup_cache_size).unwrap_or(
             NonZeroUsize::new(DEFAULT_MAX_DEDUP_CACHE_SIZE)
                 .expect("DEFAULT_MAX_DEDUP_CACHE_SIZE is non-zero"),
         );
 
-        Self {
+        let (seen_events, dedup_persistence) = if let Some(path) = replay_config.dedup_state_path {
+            let seen = PersistentDedupState::load_seen_events(
+                &path,
+                cache_size,
+                replay_config.dedup_retention,
+            )?;
+            (
+                Arc::new(RwLock::new(seen)),
+                Some(Arc::new(PersistentDedupState::new(path)?)),
+            )
+        } else {
+            (Arc::new(RwLock::new(LruCache::new(cache_size))), None)
+        };
+
+        Ok(Self {
             nip59_handler,
             token_decryptor,
             push_dispatcher,
-            seen_events: Arc::new(RwLock::new(LruCache::new(cache_size))),
+            seen_events,
+            dedup_persistence,
+            dedup_retention: replay_config.dedup_retention,
+            max_notification_age: replay_config.max_notification_age,
+            max_notification_future_skew: replay_config.max_notification_future_skew,
             // A single fixed `()` key, so capacity of 1 entry is sufficient.
             global_unwrap_limiter: RateLimiter::new(RateLimitConfig {
                 max_per_minute: rate_limit_config.global_unwrap_per_minute,
@@ -204,7 +450,7 @@ impl EventProcessor {
             }),
             max_tokens_per_event: rate_limit_config.max_tokens_per_event,
             metrics,
-        }
+        })
     }
 
     /// Process an incoming event.
@@ -345,6 +591,28 @@ impl EventProcessor {
         }
     }
 
+    fn validate_notification_freshness(&self, created_at: Timestamp) -> Result<()> {
+        if self.max_notification_age.is_zero() {
+            return Ok(());
+        }
+
+        let now = Timestamp::now().as_secs();
+        let created_at = created_at.as_secs();
+        if created_at > now.saturating_add(self.max_notification_future_skew.as_secs()) {
+            return Err(Error::InvalidToken(
+                "Notification request timestamp is too far in the future".to_string(),
+            ));
+        }
+
+        if now.saturating_sub(created_at) > self.max_notification_age.as_secs() {
+            return Err(Error::InvalidToken(
+                "Notification request timestamp is stale".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+
     /// Inner processing logic for an event.
     async fn process_inner(&self, event: &Event) -> Result<usize> {
         // Unwrap the gift wrap to get the notification request
@@ -369,6 +637,8 @@ impl EventProcessor {
                 return Err(e);
             }
         };
+
+        self.validate_notification_freshness(notification.created_at)?;
 
         debug!("Unwrapped notification request");
 
@@ -567,7 +837,7 @@ impl EventProcessor {
         if seen.contains(&event_id) {
             return false;
         }
-        seen.put(event_id, Instant::now());
+        seen.put(event_id, SeenEvent::reservation(Instant::now()));
 
         // Update cache size metric
         if let Some(ref m) = self.metrics {
@@ -601,12 +871,28 @@ impl EventProcessor {
     /// measured from completion. Kept distinct from `try_reserve` for clarity
     /// at the call sites.
     async fn mark_seen(&self, event_id: EventId) {
-        let mut seen = self.seen_events.write().await;
-        seen.put(event_id, Instant::now());
+        let now = Instant::now();
+        {
+            let mut seen = self.seen_events.write().await;
+            seen.put(event_id, SeenEvent::terminal(now));
 
-        // Update cache size metric
-        if let Some(ref m) = self.metrics {
-            m.set_dedup_cache_size(seen.len());
+            // Update cache size metric
+            if let Some(ref m) = self.metrics {
+                m.set_dedup_cache_size(seen.len());
+            }
+        }
+
+        if let Some(ref state) = self.dedup_persistence {
+            let _guard = state.write_lock.lock().await;
+            if let Err(e) = state
+                .append_seen_locked(event_id, Timestamp::now().as_secs())
+                .await
+            {
+                warn!(
+                    error = %e,
+                    "Failed to persist event deduplication state"
+                );
+            }
         }
     }
 
@@ -616,15 +902,25 @@ impl EventProcessor {
     /// periods. Call periodically for full cleanup of all expired entries.
     pub async fn cleanup(&self) {
         // Clean event deduplication cache
-        let (evicted, remaining) = {
+        let persistence = self.dedup_persistence.clone();
+        let _persistence_guard = if let Some(ref state) = persistence {
+            Some(state.write_lock.lock().await)
+        } else {
+            None
+        };
+
+        let (evicted, remaining, retained_entries) = {
             let mut seen = self.seen_events.write().await;
             let now = Instant::now();
+            let now_wall = Timestamp::now().as_secs();
 
             let expired_keys: Vec<_> = seen
                 .iter()
                 .rev()
                 .take(CLEANUP_BATCH_SIZE)
-                .filter(|(_, seen_at)| now.duration_since(**seen_at) >= DEDUP_WINDOW)
+                .filter(|(_, seen_event)| {
+                    now.duration_since(seen_event.seen_at) >= self.dedup_retention
+                })
                 .map(|(id, _)| *id)
                 .collect();
 
@@ -632,8 +928,38 @@ impl EventProcessor {
                 seen.pop(key);
             }
 
-            (expired_keys.len(), seen.len())
+            let retained_entries = if persistence.is_some() {
+                seen.iter()
+                    .filter_map(|(event_id, seen_event)| {
+                        if seen_event.terminal {
+                            Some((
+                                *event_id,
+                                instant_to_unix_secs(seen_event.seen_at, now_wall, now),
+                            ))
+                        } else {
+                            None
+                        }
+                    })
+                    .collect()
+            } else {
+                Vec::new()
+            };
+
+            (expired_keys.len(), seen.len(), retained_entries)
         };
+
+        if evicted > 0 {
+            let rewrite_result = match persistence.as_ref() {
+                Some(state) => state.rewrite_locked(&retained_entries).await,
+                None => Ok(()),
+            };
+            if let Err(e) = rewrite_result {
+                warn!(
+                    error = %e,
+                    "Failed to compact event deduplication state"
+                );
+            }
+        }
 
         if let Some(ref m) = self.metrics {
             m.set_dedup_cache_size(remaining);
@@ -732,6 +1058,27 @@ mod tests {
         let token_decryptor = TokenDecryptor::new(&mut secp_secret_key);
         let push_dispatcher = Arc::new(PushDispatcher::new(None, None));
         EventProcessor::with_cache_size(nip59_handler, token_decryptor, push_dispatcher, cache_size)
+    }
+
+    fn create_processor_with_replay_config(
+        server_keys: &Keys,
+        replay_config: ReplayProtectionConfig,
+    ) -> EventProcessor {
+        let nip59_handler = Nip59Handler::new(server_keys.clone());
+        let mut secp_secret_key =
+            secp256k1::SecretKey::from_slice(&server_keys.secret_key().to_secret_bytes())
+                .expect("valid secret key");
+        let token_decryptor = TokenDecryptor::new(&mut secp_secret_key);
+        let push_dispatcher = Arc::new(PushDispatcher::new(None, None));
+        EventProcessor::with_replay_config(
+            nip59_handler,
+            token_decryptor,
+            push_dispatcher,
+            TokenRateLimitConfig::default(),
+            replay_config,
+            None,
+        )
+        .expect("replay-protected processor")
     }
 
     fn create_processor_with_metrics(server_keys: &Keys) -> (EventProcessor, Metrics) {
@@ -979,6 +1326,234 @@ mod tests {
                 &[("outcome", EventOutcome::Duplicate.as_str())],
             ),
             1
+        );
+    }
+
+    #[tokio::test]
+    async fn test_process_rejects_stale_notification_rumor() {
+        use crate::test_vectors::{GiftWrapBuilder, NotificationContentBuilder};
+
+        let server_keys = Keys::generate();
+        let sender_keys = Keys::generate();
+        let content = NotificationContentBuilder::new(&server_keys)
+            .with_apns_token("deadbeef12345678deadbeef12345678deadbeef12345678deadbeef12345678")
+            .build();
+        let stale_created_at = Timestamp::from_secs(
+            Timestamp::now()
+                .as_secs()
+                .saturating_sub(DEFAULT_MAX_NOTIFICATION_AGE_SECS + 1),
+        );
+        let event = GiftWrapBuilder::new(server_keys.clone(), sender_keys)
+            .build_with_created_at(&content, stale_created_at)
+            .await;
+
+        let (processor, metrics) = create_processor_with_metrics(&server_keys);
+        let result = processor.process(&event).await;
+
+        assert!(result.is_ok());
+        assert!(!result.unwrap(), "stale notification must not dispatch");
+        assert_eq!(
+            counter_value(&metrics, "transponder_events_processed_total", &[]),
+            0.0
+        );
+        assert_eq!(
+            counter_value(&metrics, "transponder_events_failed_total", &[]),
+            1.0
+        );
+        assert_eq!(processor.cache_len(), 1, "stale replays are terminal");
+    }
+
+    #[tokio::test]
+    async fn test_process_rejects_future_notification_rumor() {
+        use crate::test_vectors::{GiftWrapBuilder, NotificationContentBuilder};
+
+        let server_keys = Keys::generate();
+        let sender_keys = Keys::generate();
+        let content = NotificationContentBuilder::new(&server_keys)
+            .with_apns_token("deadbeef12345678deadbeef12345678deadbeef12345678deadbeef12345678")
+            .build();
+        let future_created_at = Timestamp::from_secs(
+            Timestamp::now()
+                .as_secs()
+                .saturating_add(DEFAULT_MAX_NOTIFICATION_FUTURE_SKEW_SECS + 1),
+        );
+        let event = GiftWrapBuilder::new(server_keys.clone(), sender_keys)
+            .build_with_created_at(&content, future_created_at)
+            .await;
+
+        let (processor, metrics) = create_processor_with_metrics(&server_keys);
+        let result = processor.process(&event).await;
+
+        assert!(result.is_ok());
+        assert!(
+            !result.unwrap(),
+            "future-dated notification must not dispatch"
+        );
+        assert_eq!(
+            counter_value(&metrics, "transponder_events_processed_total", &[]),
+            0.0
+        );
+        assert_eq!(
+            counter_value(&metrics, "transponder_events_failed_total", &[]),
+            1.0
+        );
+        assert_eq!(
+            processor.cache_len(),
+            1,
+            "future-dated replays are terminal"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_dedup_state_persists_processed_event_across_processors() {
+        let server_keys = Keys::generate();
+        let sender_keys = Keys::generate();
+        let event = scenarios::single_apns_notification(
+            &server_keys,
+            &sender_keys,
+            "deadbeef12345678deadbeef12345678deadbeef12345678deadbeef12345678",
+        )
+        .await;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let state_path = dir.path().join("dedup-state.tsv");
+
+        let processor = create_processor_with_replay_config(
+            &server_keys,
+            ReplayProtectionConfig {
+                dedup_state_path: Some(state_path.clone()),
+                ..ReplayProtectionConfig::default()
+            },
+        );
+        assert!(processor.process(&event).await.unwrap());
+
+        let state = std::fs::read_to_string(&state_path).expect("dedup state written");
+        assert!(
+            state.contains(&event.id.to_hex()),
+            "state file must record processed event IDs"
+        );
+
+        let restarted = create_processor_with_replay_config(
+            &server_keys,
+            ReplayProtectionConfig {
+                dedup_state_path: Some(state_path),
+                ..ReplayProtectionConfig::default()
+            },
+        );
+
+        assert!(
+            !restarted.process(&event).await.unwrap(),
+            "a restarted processor must not re-dispatch an event already in durable dedup state"
+        );
+        assert!(restarted.is_duplicate(&event.id).await);
+    }
+
+    #[test]
+    fn test_dedup_state_loader_ignores_malformed_and_expired_rows() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let state_path = dir.path().join("nested").join("dedup-state.tsv");
+        let now = Timestamp::now().as_secs();
+        let retained_id = EventId::from_byte_array([1u8; 32]);
+        let expired_id = EventId::from_byte_array([2u8; 32]);
+        let state = format!(
+            "malformed\nnot-an-event-id {}\n{} not-a-timestamp\n{} {}\n{} {} extra\n{} {}\n",
+            now,
+            retained_id.to_hex(),
+            expired_id.to_hex(),
+            now.saturating_sub(61),
+            EventId::from_byte_array([3u8; 32]).to_hex(),
+            now,
+            retained_id.to_hex(),
+            now
+        );
+        std::fs::create_dir_all(state_path.parent().expect("state parent")).expect("mkdir");
+        std::fs::write(&state_path, state).expect("write state");
+
+        let seen = PersistentDedupState::load_seen_events(
+            &state_path,
+            NonZeroUsize::new(10).expect("non-zero cache"),
+            Duration::from_secs(60),
+        )
+        .expect("load state");
+
+        assert!(seen.contains(&retained_id));
+        assert!(!seen.contains(&expired_id));
+        assert_eq!(seen.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_dedup_state_cleanup_compacts_terminal_entries_only() {
+        let server_keys = Keys::generate();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let state_path = dir.path().join("dedup-state.tsv");
+        let processor = create_processor_with_replay_config(
+            &server_keys,
+            ReplayProtectionConfig {
+                dedup_state_path: Some(state_path.clone()),
+                dedup_retention: Duration::from_secs(1),
+                ..ReplayProtectionConfig::default()
+            },
+        );
+        let expired_id = EventId::from_byte_array([4u8; 32]);
+        let retained_id = EventId::from_byte_array([5u8; 32]);
+        let reserved_id = EventId::from_byte_array([6u8; 32]);
+
+        {
+            let mut seen = processor.seen_events.write().await;
+            seen.put(
+                expired_id,
+                SeenEvent::terminal(Instant::now() - Duration::from_secs(2)),
+            );
+            seen.put(retained_id, SeenEvent::terminal(Instant::now()));
+            seen.put(reserved_id, SeenEvent::reservation(Instant::now()));
+        }
+
+        processor.cleanup().await;
+
+        let state = std::fs::read_to_string(&state_path).expect("compacted state");
+        assert!(state.contains(&retained_id.to_hex()));
+        assert!(!state.contains(&expired_id.to_hex()));
+        assert!(!state.contains(&reserved_id.to_hex()));
+        assert!(processor.is_duplicate(&retained_id).await);
+        assert!(!processor.is_duplicate(&expired_id).await);
+        assert!(processor.is_duplicate(&reserved_id).await);
+    }
+
+    #[tokio::test]
+    async fn test_notification_freshness_can_be_disabled() {
+        use crate::test_vectors::{GiftWrapBuilder, NotificationContentBuilder};
+
+        let server_keys = Keys::generate();
+        let sender_keys = Keys::generate();
+        let content = NotificationContentBuilder::new(&server_keys)
+            .with_apns_token("deadbeef12345678deadbeef12345678deadbeef12345678deadbeef12345678")
+            .build();
+        let stale_created_at = Timestamp::from_secs(
+            Timestamp::now()
+                .as_secs()
+                .saturating_sub(DEFAULT_MAX_NOTIFICATION_AGE_SECS + 1),
+        );
+        let event = GiftWrapBuilder::new(server_keys.clone(), sender_keys)
+            .build_with_created_at(&content, stale_created_at)
+            .await;
+        let processor = create_processor_with_replay_config(
+            &server_keys,
+            ReplayProtectionConfig {
+                max_notification_age: Duration::ZERO,
+                ..ReplayProtectionConfig::default()
+            },
+        );
+
+        assert!(processor.process(&event).await.unwrap());
+    }
+
+    #[test]
+    fn test_instant_to_unix_secs_saturates_future_seen_at() {
+        let now_instant = Instant::now();
+        let now_wall = 123_456;
+
+        assert_eq!(
+            instant_to_unix_secs(now_instant + Duration::from_secs(1), now_wall, now_instant),
+            now_wall
         );
     }
 
@@ -1591,7 +2166,7 @@ mod tests {
                 let mut bytes = [0u8; 32];
                 bytes[0..4].copy_from_slice(&(i as u32).to_le_bytes());
                 let event_id = EventId::from_byte_array(bytes);
-                seen.put(event_id, old_time);
+                seen.put(event_id, SeenEvent::terminal(old_time));
             }
         }
 
@@ -1642,10 +2217,10 @@ mod tests {
         {
             let mut seen = processor.seen_events.write().await;
             for event_id in &stale_ids {
-                seen.put(*event_id, old_time);
+                seen.put(*event_id, SeenEvent::terminal(old_time));
             }
             for event_id in &recent_ids {
-                seen.put(*event_id, recent_time);
+                seen.put(*event_id, SeenEvent::terminal(recent_time));
             }
         }
 
@@ -1684,7 +2259,7 @@ mod tests {
                 let mut bytes = [0u8; 32];
                 bytes[0..4].copy_from_slice(&(i as u32).to_le_bytes());
                 let event_id = EventId::from_byte_array(bytes);
-                seen.put(event_id, old_time);
+                seen.put(event_id, SeenEvent::terminal(old_time));
             }
 
             // Add some recent entries
@@ -1692,7 +2267,7 @@ mod tests {
                 let mut bytes = [0u8; 32];
                 bytes[0..4].copy_from_slice(&(i as u32).to_le_bytes());
                 let event_id = EventId::from_byte_array(bytes);
-                seen.put(event_id, recent_time);
+                seen.put(event_id, SeenEvent::terminal(recent_time));
             }
         }
 

--- a/src/test_vectors.rs
+++ b/src/test_vectors.rs
@@ -304,10 +304,28 @@ impl GiftWrapBuilder {
     /// Matches the Darkmatter / Marmot compatibility shape.
     #[must_use = "event must be used or creation effort is wasted"]
     pub async fn build_without_encoding_tag(&self, content: &str) -> Event {
-        self.build_with_tags(content, false).await
+        self.build_with_tags_and_created_at(content, false, None)
+            .await
+    }
+
+    /// Build a gift-wrapped notification request with a custom rumor timestamp.
+    #[must_use = "event must be used or creation effort is wasted"]
+    pub async fn build_with_created_at(&self, content: &str, created_at: Timestamp) -> Event {
+        self.build_with_tags_and_created_at(content, true, Some(created_at))
+            .await
     }
 
     async fn build_with_tags(&self, content: &str, include_encoding_tag: bool) -> Event {
+        self.build_with_tags_and_created_at(content, include_encoding_tag, None)
+            .await
+    }
+
+    async fn build_with_tags_and_created_at(
+        &self,
+        content: &str,
+        include_encoding_tag: bool,
+        created_at: Option<Timestamp>,
+    ) -> Event {
         let mut tags =
             vec![Tag::parse([TAG_VERSION, VERSION_MIP05_V1]).expect("valid version tag")];
         if include_encoding_tag {
@@ -315,8 +333,11 @@ impl GiftWrapBuilder {
         }
 
         // Create the kind 446 rumor (unsigned event)
-        let rumor_builder =
+        let mut rumor_builder =
             EventBuilder::new(Kind::Custom(KIND_NOTIFICATION_REQUEST), content).tags(tags);
+        if let Some(created_at) = created_at {
+            rumor_builder = rumor_builder.custom_created_at(created_at);
+        }
 
         // Build the unsigned event (rumor)
         let rumor = rumor_builder.build(self.sender_keys.public_key());


### PR DESCRIPTION
## Summary
- Add durable replay suppression for processed gift-wrap event IDs, persisted as public event IDs plus processing timestamps only.
- Keep the NIP-59 2-day relay lookback, but bound dispatch by persisted replay state and inner kind:446 rumor freshness.
- Wire production Docker/systemd examples to mount `/var/lib/transponder` and set `TRANSPONDER_SERVER_DEDUP_STATE_PATH`.

## Test Plan
- `just ci`
- `RUSTFLAGS='-Dwarnings' cargo check --all-targets`
- `RUSTFLAGS='-Dwarnings' cargo clippy --all-targets -- -D warnings`
- `RUSTFLAGS='-Dwarnings' cargo test --all-targets`
- `RUSTFLAGS='-Dwarnings' cargo check --all-targets --features tor`
- `RUSTFLAGS='-Dwarnings' cargo test --all-targets --features tor`
- `RUSTDOCFLAGS='-Dwarnings' cargo doc --no-deps --document-private-items`

Fixes #110


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/transponder/pull/183">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->