### PR TITLE
fix: clarify token payload bounds invariant

### DIFF
--- a/src/crypto/token.rs
+++ b/src/crypto/token.rs
@@ -173,13 +173,10 @@ impl TokenPayload {
             )));
         }
 
+        // The `data.len() == TOKEN_PLAINTEXT_SIZE` and `token_length <= MAX_DEVICE_TOKEN_SIZE`
+        // checks above already guarantee `payload_end <= data.len()`, so the slice is in bounds.
         let payload_end = 3 + token_length;
-        if payload_end > data.len() {
-            return Err(Error::InvalidToken(format!(
-                "Token length {token_length} exceeds plaintext size {}",
-                data.len()
-            )));
-        }
+        debug_assert!(payload_end <= data.len());
 
         let device_token = data[3..payload_end].to_vec();
 


### PR DESCRIPTION
Fixes #97

## Summary
- Replaced the unreachable `payload_end > data.len()` error branch in `TokenPayload::from_decrypted` with an explicit invariant comment and `debug_assert!`.
- Preserves parsing behavior while making the actual bound guarantee clear: fixed plaintext length plus `token_length <= MAX_DEVICE_TOKEN_SIZE` already keeps the device-token slice in bounds.

## Verification
- `cargo fmt --all -- --check` — passed
- `RUSTFLAGS=-Dwarnings cargo check --all-targets` — passed
- `RUSTFLAGS=-Dwarnings cargo clippy --all-targets -- -D warnings` — passed
- `RUSTFLAGS=-Dwarnings cargo test --all-targets` — passed
- `RUSTFLAGS=-Dwarnings cargo check --all-targets --features tor` — passed
- `RUSTFLAGS=-Dwarnings cargo test --all-targets --features tor` — passed
- `RUSTFLAGS=-Dwarnings RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --document-private-items` — passed
- `./scripts/cargo-audit.sh` — passed; reported 3 allowed warnings

## Sensitive paths
- `src/crypto/token.rs` — crypto token parsing; change is comment/debug-assert only and does not alter runtime behavior in release builds.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/transponder/pull/184">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->