### PR TITLE
fix: bound push provider error bodies

### DIFF
--- a/src/push/apns.rs
+++ b/src/push/apns.rs
@@ -406,9 +406,11 @@ impl ApnsClient {
                 SendAttemptResult::Success(true)
             }
             400 => {
-                let error: ApnsErrorResponse = response.json().await.unwrap_or(ApnsErrorResponse {
-                    reason: "Unknown".to_string(),
-                });
+                let error = crate::push::parse_bounded_error_body::<ApnsErrorResponse>(response)
+                    .await
+                    .unwrap_or(ApnsErrorResponse {
+                        reason: "Unknown".to_string(),
+                    });
                 match classify_apns_400(&error.reason) {
                     Apns400Classification::TokenDead => {
                         debug!(
@@ -436,9 +438,11 @@ impl ApnsClient {
             }
             403 => {
                 self.invalidate_cached_token(auth_token).await;
-                let error: ApnsErrorResponse = response.json().await.unwrap_or(ApnsErrorResponse {
-                    reason: "Unknown".to_string(),
-                });
+                let error = crate::push::parse_bounded_error_body::<ApnsErrorResponse>(response)
+                    .await
+                    .unwrap_or(ApnsErrorResponse {
+                        reason: "Unknown".to_string(),
+                    });
                 debug!(
                     payload_mode = %self.config.payload_mode,
                     reason = %error.reason,
@@ -1063,6 +1067,81 @@ mod tests {
             SendAttemptResult::Permanent(Error::Apns(ref message))
                 if message.contains("MissingTopic")
         ));
+    }
+
+    #[tokio::test]
+    async fn test_handle_response_400_oversized_body_falls_back_without_whole_body_parse() {
+        // A hostile/buggy endpoint returns a 400 with a multi-megabyte body.
+        // The bounded read must refuse to buffer/parse the whole body and fall
+        // back to the "Unknown" reason (a permanent error), never treating the
+        // token as dead based on attacker-controlled content.
+        let padding = "A".repeat(4 * 1024 * 1024);
+        let huge_body = format!(r#"{{"reason":"{padding}"}}"#);
+
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path_regex(r"/3/device/[a-f0-9]+"))
+            .respond_with(ResponseTemplate::new(400).set_body_string(huge_body))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let client = ApnsClient::mock(test_config(), false);
+        let response = Client::new()
+            .post(format!("{}/3/device/{}", mock_server.uri(), "deadbeef1234"))
+            .send()
+            .await
+            .unwrap();
+
+        let result = client
+            .handle_response(Instant::now(), response, "test-token")
+            .await;
+
+        let SendAttemptResult::Permanent(Error::Apns(message)) = result else {
+            panic!("expected a permanent APNs error, got {result:?}");
+        };
+        assert!(message.contains("Unknown"));
+        // The oversized provider body must not leak into the error message,
+        // which stays bounded regardless of the (huge) upstream body.
+        assert!(!message.contains(&padding));
+        assert!(message.len() < 128);
+    }
+
+    #[tokio::test]
+    async fn test_handle_response_403_oversized_body_falls_back_to_unknown_reason() {
+        // The 403 auth-error path must likewise cap the body it reads and fall
+        // back to the "Unknown" reason instead of embedding the huge body.
+        let padding = "A".repeat(4 * 1024 * 1024);
+        let huge_body = format!(r#"{{"reason":"{padding}"}}"#);
+
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path_regex(r"/3/device/[a-f0-9]+"))
+            .respond_with(ResponseTemplate::new(403).set_body_string(huge_body))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let client = ApnsClient::mock(test_config(), false);
+        let response = Client::new()
+            .post(format!("{}/3/device/{}", mock_server.uri(), "deadbeef1234"))
+            .send()
+            .await
+            .unwrap();
+
+        let result = client
+            .handle_response(Instant::now(), response, "test-token")
+            .await;
+
+        let SendAttemptResult::Permanent(Error::Apns(message)) = result else {
+            panic!("expected a permanent APNs error, got {result:?}");
+        };
+        assert!(message.contains("Authentication error"));
+        assert!(message.contains("Unknown"));
+        // The oversized provider body must not leak into the error message,
+        // which stays bounded regardless of the (huge) upstream body.
+        assert!(!message.contains(&padding));
+        assert!(message.len() < 128);
     }
 
     #[tokio::test]

--- a/src/push/fcm.rs
+++ b/src/push/fcm.rs
@@ -435,8 +435,9 @@ impl FcmClient {
     /// permanent error.
     ///
     /// `default_status` is used when the body cannot be parsed (e.g. an empty
-    /// or non-JSON body), preserving the provider's HTTP-status-implied default
-    /// classification. Only a provider-specific FCM detail with
+    /// or non-JSON body, or a body exceeding the bounded read limit), preserving
+    /// the provider's HTTP-status-implied default classification. Only a
+    /// provider-specific FCM detail with
     /// `errorCode: "UNREGISTERED"` is treated as a dead device token; every
     /// other response — including `INVALID_ARGUMENT` and `NOT_FOUND` (which can
     /// mean a misconfigured project ID) — is surfaced as a permanent error so a
@@ -447,14 +448,16 @@ impl FcmClient {
         default_code: u32,
         default_status: &str,
     ) -> SendAttemptResult {
-        let error: FcmErrorResponse = response.json().await.unwrap_or(FcmErrorResponse {
-            error: FcmError {
-                code: default_code,
-                message: "Unknown".to_string(),
-                status: default_status.to_string(),
-                details: Vec::new(),
-            },
-        });
+        let error = crate::push::parse_bounded_error_body::<FcmErrorResponse>(response)
+            .await
+            .unwrap_or(FcmErrorResponse {
+                error: FcmError {
+                    code: default_code,
+                    message: "Unknown".to_string(),
+                    status: default_status.to_string(),
+                    details: Vec::new(),
+                },
+            });
 
         match classify_fcm_error(&error.error) {
             FcmClassification::TokenDead => {
@@ -1140,6 +1143,65 @@ mod tests {
             SendAttemptResult::Permanent(Error::Fcm(ref message))
                 if message.contains("NOT_FOUND")
         ));
+    }
+
+    /// Drive `handle_response` against a mock server returning `status_code`
+    /// with a raw (potentially oversized) string body.
+    async fn fcm_error_result_with_string_body(
+        status_code: u16,
+        body: String,
+    ) -> SendAttemptResult {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path_regex(r"/v1/projects/.+/messages:send"))
+            .respond_with(ResponseTemplate::new(status_code).set_body_string(body))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let config = FcmConfig {
+            enabled: true,
+            service_account_path: String::new(),
+            project_id: "test-project".to_string(),
+        };
+        let client = FcmClient::mock(config, false);
+
+        let response = Client::new()
+            .post(format!(
+                "{}/v1/projects/test-project/messages:send",
+                mock_server.uri()
+            ))
+            .send()
+            .await
+            .unwrap();
+
+        client
+            .handle_response(Instant::now(), response, "test-access-token")
+            .await
+    }
+
+    #[tokio::test]
+    async fn test_handle_response_oversized_body_falls_back_without_whole_body_parse() {
+        // A hostile/buggy endpoint returns a 400 whose body is far larger than
+        // any legitimate FCM error payload but contains an UNREGISTERED detail.
+        // The bounded read must refuse to buffer/parse the whole body and fall
+        // back to the default INVALID_ARGUMENT classification (a permanent
+        // error), never evicting the token based on attacker-controlled content.
+        let padding = "A".repeat(4 * 1024 * 1024);
+        let huge_body = format!(
+            r#"{{"error":{{"code":400,"message":"{padding}","status":"NOT_FOUND","details":[{{"@type":"type.googleapis.com/google.firebase.fcm.v1.FcmError","errorCode":"UNREGISTERED"}}]}}}}"#
+        );
+
+        let result = fcm_error_result_with_string_body(400, huge_body).await;
+
+        let SendAttemptResult::Permanent(Error::Fcm(message)) = result else {
+            panic!("expected a permanent FCM error, got {result:?}");
+        };
+        assert!(message.contains("INVALID_ARGUMENT"));
+        // The oversized provider body must not leak into the error message,
+        // which stays bounded regardless of the (huge) upstream body.
+        assert!(!message.contains(&padding));
+        assert!(message.len() < 128);
     }
 
     #[tokio::test]

--- a/src/push/mod.rs
+++ b/src/push/mod.rs
@@ -8,3 +8,133 @@ pub mod retry;
 pub use apns::ApnsClient;
 pub use dispatcher::PushDispatcher;
 pub use fcm::FcmClient;
+
+use serde::de::DeserializeOwned;
+
+/// Maximum number of bytes read from a provider error response before JSON
+/// parsing.
+///
+/// Legitimate APNs/FCM error payloads are tiny (a `reason`/`status` plus a
+/// short message). The response body is provider/network-controlled and the
+/// HTTP client imposes no size cap, so a hostile or buggy endpoint could stream
+/// an arbitrarily large body on an error status. Reading only a bounded prefix
+/// keeps a single failing request from buffering an unbounded body into memory.
+const MAX_ERROR_BODY_BYTES: usize = 8 * 1024;
+
+/// Read at most [`MAX_ERROR_BODY_BYTES`] of a provider error response and
+/// deserialize the bounded prefix as JSON.
+///
+/// If the server declares a body larger than the cap, the helper returns before
+/// reading it. Otherwise the body is streamed chunk by chunk and reading stops
+/// as soon as the cap is reached, so the full body is never buffered. Returns
+/// `None` when the body is unreadable, exceeds the cap, or does not parse (e.g.
+/// an empty or non-JSON body, or a JSON document truncated by the cap), letting
+/// callers fall back to their default status-derived classification.
+async fn parse_bounded_error_body<T: DeserializeOwned>(
+    mut response: reqwest::Response,
+) -> Option<T> {
+    if response
+        .content_length()
+        .is_some_and(|len| len > MAX_ERROR_BODY_BYTES as u64)
+    {
+        return None;
+    }
+
+    let mut body = Vec::new();
+
+    loop {
+        match response.chunk().await {
+            Ok(Some(chunk)) => {
+                if body.len() + chunk.len() > MAX_ERROR_BODY_BYTES {
+                    // The body is larger than any legitimate provider error
+                    // payload; stop reading and fall back to the default.
+                    return None;
+                }
+                body.extend_from_slice(&chunk);
+            }
+            Ok(None) => break,
+            Err(_) => return None,
+        }
+    }
+
+    serde_json::from_slice(&body).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+    use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[derive(Debug, Deserialize, PartialEq, Eq)]
+    struct TestError {
+        reason: String,
+    }
+
+    async fn parse_body(body: String) -> Option<TestError> {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(400).set_body_string(body))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let response = reqwest::Client::new()
+            .get(mock_server.uri())
+            .send()
+            .await
+            .unwrap();
+
+        parse_bounded_error_body::<TestError>(response).await
+    }
+
+    #[tokio::test]
+    async fn test_parses_small_error_body() {
+        let parsed = parse_body(r#"{"reason":"BadDeviceToken"}"#.to_string()).await;
+        assert_eq!(
+            parsed,
+            Some(TestError {
+                reason: "BadDeviceToken".to_string()
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn test_returns_none_for_non_json_body() {
+        let parsed = parse_body("not json at all".to_string()).await;
+        assert_eq!(parsed, None);
+    }
+
+    #[tokio::test]
+    async fn test_returns_none_for_empty_body() {
+        let parsed = parse_body(String::new()).await;
+        assert_eq!(parsed, None);
+    }
+
+    #[tokio::test]
+    async fn test_oversized_body_falls_back_without_parsing_whole_body() {
+        // A hostile/buggy endpoint returns a valid-JSON error whose `reason`
+        // value alone is far larger than any legitimate payload. The helper
+        // must refuse to buffer/parse the whole body and fall back to `None`
+        // rather than materializing the multi-megabyte string.
+        let padding = "A".repeat(4 * 1024 * 1024);
+        let huge_body = format!(r#"{{"reason":"{padding}"}}"#);
+        assert!(huge_body.len() > MAX_ERROR_BODY_BYTES);
+
+        let parsed = parse_body(huge_body).await;
+        assert_eq!(parsed, None);
+    }
+
+    #[tokio::test]
+    async fn test_body_at_limit_is_still_parsed() {
+        // A body up to the cap is read and parsed normally.
+        let reason_len = MAX_ERROR_BODY_BYTES - r#"{"reason":""}"#.len();
+        let reason = "A".repeat(reason_len);
+        let body = format!(r#"{{"reason":"{reason}"}}"#);
+        assert_eq!(body.len(), MAX_ERROR_BODY_BYTES);
+
+        let parsed = parse_body(body).await;
+        assert_eq!(parsed, Some(TestError { reason }));
+    }
+}


### PR DESCRIPTION
Fixes #95

## Summary
- Added a shared `parse_bounded_error_body` helper that refuses declared oversized provider error bodies and otherwise streams APNs/FCM error responses with an 8 KiB cap before JSON parsing.
- Replaced send-path APNs `400`/`403` and FCM `400`/`404` error parsing so oversized/unparseable bodies fall back to existing bounded defaults instead of buffering arbitrary provider output.
- Added regression coverage for small, empty, non-JSON, at-limit, and oversized error bodies. Confirmed the FCM OAuth error path already does not read provider error bodies.

## Verification
- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `RUSTFLAGS=-Dwarnings cargo check --all-targets`
- `RUSTFLAGS=-Dwarnings cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets` (405 unit tests + 4 integration tests passed)
- `RUSTFLAGS=-Dwarnings cargo check --all-targets --features tor`
- `cargo test --all-targets --features tor` (405 unit tests + 4 integration tests passed)
- `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --document-private-items`
- `./scripts/cargo-audit.sh` (passed; 3 allowed warnings reported by existing policy)

## Sensitive paths
- `src/push/apns.rs` — APNs send-path provider response handling.
- `src/push/fcm.rs` — FCM send-path provider response handling.
- `src/push/mod.rs` — shared push error-body parsing helper.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/transponder/pull/186">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error responses from push providers are now handled more safely, with oversized or malformed bodies falling back to a generic error instead of being fully read.
  * Error messages are kept short and no longer include attacker-controlled extra content from large provider responses.
  * Push error classification remains consistent for APNs and FCM, even when provider responses are invalid or too large.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->