### PR TITLE
fix: validate duration config bounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ private_key = ""
 # Generate with: transponder generate-keys --output /path/to/server.key
 # private_key_file = "/run/secrets/transponder_private_key"
 
-# Graceful shutdown timeout in seconds
+# Graceful shutdown timeout in seconds (must be >= 1; 0 skips the drain)
 shutdown_timeout_secs = 10
 
 # Event deduplication cache size (default: 100000)
@@ -92,8 +92,12 @@ allow_unencrypted_clearnet_relays = false
 onion = []
 
 # Reconnection settings (reserved for future use)
+# reconnect_interval_secs must be between 1 and 300 seconds
 reconnect_interval_secs = 5
 max_reconnect_attempts = 10
+
+# Startup wait for the first relay to connect (must be between 1 and 300 seconds)
+# connection_timeout_secs = 30
 
 [apns]
 # Enable APNs for iOS push notifications

--- a/config/default.toml
+++ b/config/default.toml
@@ -11,7 +11,8 @@ private_key = ""
 # Generate with: transponder generate-keys --output /run/secrets/transponder_private_key
 # private_key_file = "/run/secrets/transponder_private_key"
 
-# Graceful shutdown timeout in seconds
+# Graceful shutdown timeout in seconds. Must be >= 1; a value of 0 makes the
+# drain time out immediately and abandon in-flight push notifications.
 # Increase this for environments with slow networks or high in-flight notification counts
 shutdown_timeout_secs = 10
 
@@ -86,11 +87,13 @@ allow_unencrypted_clearnet_relays = false
 # Requires a binary built with: cargo build --features tor
 onion = []
 
-# Reconnection settings
+# Reconnection settings. reconnect_interval_secs must be between 1 and 300 seconds.
 reconnect_interval_secs = 5
 max_reconnect_attempts = 10
 
 # Timeout in seconds to wait for at least one relay to connect during startup.
+# Must be between 1 and 300 seconds: 0 times out immediately and never
+# connects, and an unbounded value would hang startup when relays are down.
 # Increase this for environments with slow networks or when using Tor relays.
 # Default: 30
 connection_timeout_secs = 30

--- a/src/config.rs
+++ b/src/config.rs
@@ -282,6 +282,15 @@ pub struct RelayConfig {
     pub connection_timeout_secs: u64,
 }
 
+/// Upper bound for the relay duration fields, in seconds.
+///
+/// `connection_timeout_secs` and `reconnect_interval_secs` are startup/retry
+/// waits, so an unbounded value (e.g. `u64::MAX`) makes startup hang effectively
+/// forever when relays are unreachable. Five minutes comfortably covers slow
+/// networks and Tor bootstrapping while keeping a misconfiguration from wedging
+/// the process, so anything larger is rejected at load time.
+const MAX_RELAY_DURATION_SECS: u64 = 300;
+
 fn default_connection_timeout() -> u64 {
     30
 }
@@ -756,9 +765,11 @@ impl AppConfig {
     /// size. A `0` count would either block every request for that limiter
     /// dimension (a silent push outage) or be silently swapped for the default,
     /// so an explicit error at load time surfaces the misconfiguration instead
-    /// of letting it reach runtime.
+    /// of letting it reach runtime. Duration fields are also range-checked so a
+    /// degenerate value cannot defeat graceful shutdown or hang startup.
     fn validate(&self) -> Result<()> {
         self.server.validate()?;
+        self.relays.validate()?;
         self.glitchtip.validate()?;
         Ok(())
     }
@@ -783,12 +794,22 @@ impl AppConfig {
 }
 
 impl ServerConfig {
-    /// Rejects rate-limit count fields and the rate-limit cache size set to `0`.
+    /// Rejects rate-limit count fields and the rate-limit cache size set to `0`,
+    /// and `shutdown_timeout_secs` set to `0`.
     ///
     /// A `0` per-minute/per-hour limit blocks every request for that limiter
     /// dimension, and a `0` cache size is silently replaced by the default
-    /// rather than honoured. Each error names the offending config field.
+    /// rather than honoured. A `0` `shutdown_timeout_secs` makes the graceful
+    /// drain time out immediately, abandoning in-flight push notifications, so
+    /// it is rejected rather than silently skipping the drain. Each error names
+    /// the offending config field.
     fn validate(&self) -> std::result::Result<(), config::ConfigError> {
+        if self.shutdown_timeout_secs == 0 {
+            return Err(config::ConfigError::Message(
+                "server.shutdown_timeout_secs must be greater than 0; a value of 0 makes graceful shutdown time out immediately and abandon in-flight push notifications".to_string(),
+            ));
+        }
+
         let zero_checked_fields = [
             (
                 "server.encrypted_token_rate_limit_per_minute",
@@ -824,6 +845,45 @@ impl ServerConfig {
             if value == 0 {
                 return Err(config::ConfigError::Message(format!(
                     "{field} must be greater than 0"
+                )));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl RelayConfig {
+    /// Range-checks the relay duration fields.
+    ///
+    /// `connection_timeout_secs` is the startup wait for the first relay to
+    /// connect: `0` would time out instantly and never connect, while an
+    /// unbounded value hangs startup effectively forever when relays are
+    /// unreachable. `reconnect_interval_secs` is likewise range-checked so a
+    /// degenerate value cannot busy-loop or stall reconnection once used. Both
+    /// are capped at [`MAX_RELAY_DURATION_SECS`], and each error names the
+    /// offending field.
+    fn validate(&self) -> std::result::Result<(), config::ConfigError> {
+        let duration_fields = [
+            (
+                "relays.connection_timeout_secs",
+                self.connection_timeout_secs,
+            ),
+            (
+                "relays.reconnect_interval_secs",
+                self.reconnect_interval_secs,
+            ),
+        ];
+
+        for (field, value) in duration_fields {
+            if value == 0 {
+                return Err(config::ConfigError::Message(format!(
+                    "{field} must be greater than 0"
+                )));
+            }
+            if value > MAX_RELAY_DURATION_SECS {
+                return Err(config::ConfigError::Message(format!(
+                    "{field} must be at most {MAX_RELAY_DURATION_SECS} seconds"
                 )));
             }
         }
@@ -1795,5 +1855,153 @@ mod tests {
         assert_eq!(config.server.global_unwrap_rate_limit_per_minute, 1);
         assert_eq!(config.server.global_unwrap_rate_limit_per_hour, 1);
         assert_eq!(config.server.max_rate_limit_cache_size, 1);
+    }
+
+    #[test]
+    fn test_zero_shutdown_timeout_rejected_from_file() {
+        let config_content = r#"
+            [server]
+            private_key = "test"
+            shutdown_timeout_secs = 0
+        "#;
+
+        let file = create_temp_config(config_content);
+        let error = load_with_test_env(file.path(), &[]).unwrap_err();
+        let message = error.to_string();
+
+        assert!(
+            message.contains("server.shutdown_timeout_secs"),
+            "expected error to name `server.shutdown_timeout_secs`, got: {message}"
+        );
+        assert!(
+            message.contains("must be greater than 0"),
+            "expected `must be greater than 0`, got: {message}"
+        );
+    }
+
+    #[test]
+    fn test_zero_shutdown_timeout_rejected_from_env() {
+        let error =
+            from_test_env(&[("TRANSPONDER_SERVER_SHUTDOWN_TIMEOUT_SECS", "0")]).unwrap_err();
+        let message = error.to_string();
+
+        assert!(
+            message.contains("server.shutdown_timeout_secs"),
+            "expected error to name `server.shutdown_timeout_secs`, got: {message}"
+        );
+        assert!(
+            message.contains("must be greater than 0"),
+            "expected `must be greater than 0`, got: {message}"
+        );
+    }
+
+    #[test]
+    fn test_minimal_shutdown_timeout_accepted() {
+        let config = from_test_env(&[("TRANSPONDER_SERVER_SHUTDOWN_TIMEOUT_SECS", "1")]).unwrap();
+
+        assert_eq!(config.server.shutdown_timeout_secs, 1);
+    }
+
+    #[test]
+    fn test_zero_connection_timeout_rejected() {
+        let error =
+            from_test_env(&[("TRANSPONDER_RELAYS_CONNECTION_TIMEOUT_SECS", "0")]).unwrap_err();
+        let message = error.to_string();
+
+        assert!(
+            message.contains("relays.connection_timeout_secs"),
+            "expected error to name `relays.connection_timeout_secs`, got: {message}"
+        );
+        assert!(
+            message.contains("must be greater than 0"),
+            "expected `must be greater than 0`, got: {message}"
+        );
+    }
+
+    #[test]
+    fn test_zero_reconnect_interval_rejected() {
+        let error =
+            from_test_env(&[("TRANSPONDER_RELAYS_RECONNECT_INTERVAL_SECS", "0")]).unwrap_err();
+        let message = error.to_string();
+
+        assert!(
+            message.contains("relays.reconnect_interval_secs"),
+            "expected error to name `relays.reconnect_interval_secs`, got: {message}"
+        );
+        assert!(
+            message.contains("must be greater than 0"),
+            "expected `must be greater than 0`, got: {message}"
+        );
+    }
+
+    #[test]
+    fn test_oversized_connection_timeout_rejected() {
+        let over = (MAX_RELAY_DURATION_SECS + 1).to_string();
+        let error = from_test_env(&[("TRANSPONDER_RELAYS_CONNECTION_TIMEOUT_SECS", over.as_str())])
+            .unwrap_err();
+        let message = error.to_string();
+
+        assert!(
+            message.contains("relays.connection_timeout_secs"),
+            "expected error to name `relays.connection_timeout_secs`, got: {message}"
+        );
+        assert!(
+            message.contains(&format!("at most {MAX_RELAY_DURATION_SECS}")),
+            "expected `at most {MAX_RELAY_DURATION_SECS}`, got: {message}"
+        );
+    }
+
+    #[test]
+    fn test_unbounded_connection_timeout_rejected() {
+        // The degenerate `u64::MAX` from the issue must be rejected rather than
+        // hanging startup effectively forever when relays are unreachable.
+        let error = from_test_env(&[(
+            "TRANSPONDER_RELAYS_CONNECTION_TIMEOUT_SECS",
+            "18446744073709551615",
+        )])
+        .unwrap_err();
+
+        assert!(
+            error.to_string().contains("relays.connection_timeout_secs"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn test_oversized_reconnect_interval_rejected() {
+        let over = (MAX_RELAY_DURATION_SECS + 1).to_string();
+        let error = from_test_env(&[("TRANSPONDER_RELAYS_RECONNECT_INTERVAL_SECS", over.as_str())])
+            .unwrap_err();
+        let message = error.to_string();
+
+        assert!(
+            message.contains("relays.reconnect_interval_secs"),
+            "expected error to name `relays.reconnect_interval_secs`, got: {message}"
+        );
+        assert!(
+            message.contains(&format!("at most {MAX_RELAY_DURATION_SECS}")),
+            "expected `at most {MAX_RELAY_DURATION_SECS}`, got: {message}"
+        );
+    }
+
+    #[test]
+    fn test_relay_duration_upper_bound_accepted() {
+        // The exact cap must pass so operators on slow networks or Tor can use
+        // the full budget without tripping validation.
+        let cap = MAX_RELAY_DURATION_SECS.to_string();
+        let config = from_test_env(&[
+            ("TRANSPONDER_RELAYS_CONNECTION_TIMEOUT_SECS", cap.as_str()),
+            ("TRANSPONDER_RELAYS_RECONNECT_INTERVAL_SECS", cap.as_str()),
+        ])
+        .unwrap();
+
+        assert_eq!(
+            config.relays.connection_timeout_secs,
+            MAX_RELAY_DURATION_SECS
+        );
+        assert_eq!(
+            config.relays.reconnect_interval_secs,
+            MAX_RELAY_DURATION_SECS
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -149,6 +149,38 @@ fn event_processing_permits(max_concurrent_event_processing: usize) -> usize {
     max_concurrent_event_processing.max(1)
 }
 
+/// Outcome of racing relay startup against a shutdown signal.
+#[derive(Debug)]
+enum StartupOutcome<T> {
+    /// Startup finished; carries the connect result.
+    Connected(T),
+    /// A shutdown signal arrived before startup finished.
+    ShutdownRequested,
+}
+
+/// Awaits a startup future while remaining responsive to a shutdown signal.
+///
+/// The signal future must already have its SIGTERM/SIGINT handlers installed
+/// *before* the startup work is awaited, so a signal that arrives while waiting
+/// for relay connections exits promptly instead of being ignored until the
+/// connect timeout elapses. Shutdown is preferred (`biased`) so a signal that is
+/// already pending wins over a startup future that resolves in the same poll.
+async fn run_startup_or_shutdown<T, StartupFut, SignalFut>(
+    startup: StartupFut,
+    signal_fut: SignalFut,
+) -> StartupOutcome<T>
+where
+    StartupFut: std::future::Future<Output = T>,
+    SignalFut: std::future::Future<Output = ()>,
+{
+    tokio::select! {
+        biased;
+
+        () = signal_fut => StartupOutcome::ShutdownRequested,
+        result = startup => StartupOutcome::Connected(result),
+    }
+}
+
 async fn acquire_event_processing_permit_or_shutdown(
     semaphore: Arc<Semaphore>,
     shutdown: &mut watch::Receiver<bool>,
@@ -323,11 +355,27 @@ async fn run(mut config: AppConfig) -> Result<()> {
             .context("Failed to create relay client")?,
     );
 
-    // Connect to relays
-    relay_client
-        .connect()
-        .await
-        .context("Failed to connect to relays")?;
+    // Initialize shutdown handler before connecting so a SIGTERM/SIGINT during
+    // startup exits promptly. Without this, signal handlers were installed only
+    // after `connect()` returned, so a signal received while waiting for relays
+    // (potentially up to the whole connection timeout) was ignored.
+    let shutdown = ShutdownHandler::new();
+
+    // Connect to relays, but bail out immediately if a shutdown signal arrives
+    // while we are still waiting for the first relay to connect.
+    match run_startup_or_shutdown(relay_client.connect(), shutdown.wait_for_signal()).await {
+        StartupOutcome::Connected(result) => {
+            result.context("Failed to connect to relays")?;
+        }
+        StartupOutcome::ShutdownRequested => {
+            info!("Shutdown signal received during startup; stopping before relay connection");
+            if let Err(e) = relay_client.disconnect().await {
+                warn!(error = %e, "Error disconnecting from relays during startup shutdown");
+            }
+            info!("Transponder stopped");
+            return Ok(());
+        }
+    }
 
     // Obtain the broadcast receiver BEFORE issuing the subscription REQ.
     //
@@ -361,9 +409,6 @@ async fn run(mut config: AppConfig) -> Result<()> {
         rate_limit_config,
         metrics.clone(),
     ));
-
-    // Initialize shutdown handler
-    let shutdown = ShutdownHandler::new();
 
     // Start health server
     let health_server = HealthServer::new(
@@ -742,6 +787,59 @@ mod tests {
 
         assert!(result.is_none());
         assert_eq!(semaphore.available_permits(), 0);
+    }
+
+    #[tokio::test]
+    async fn run_startup_or_shutdown_returns_connected_when_startup_finishes_first() {
+        // A signal future that never resolves models no signal arriving; the
+        // startup future's result must be surfaced verbatim.
+        let outcome = run_startup_or_shutdown(
+            async { Ok::<(), anyhow::Error>(()) },
+            std::future::pending(),
+        )
+        .await;
+
+        assert!(matches!(outcome, StartupOutcome::Connected(Ok(()))));
+    }
+
+    #[tokio::test]
+    async fn run_startup_or_shutdown_surfaces_startup_error() {
+        let outcome = run_startup_or_shutdown(
+            async { Err::<(), anyhow::Error>(anyhow::anyhow!("connect failed")) },
+            std::future::pending(),
+        )
+        .await;
+
+        match outcome {
+            StartupOutcome::Connected(Err(error)) => {
+                assert_eq!(error.to_string(), "connect failed");
+            }
+            other => panic!("expected a surfaced startup error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn run_startup_or_shutdown_returns_shutdown_when_signal_arrives_first() {
+        // Startup never finishes, so only the already-ready signal can win.
+        let outcome =
+            run_startup_or_shutdown(std::future::pending::<Result<()>>(), std::future::ready(()))
+                .await;
+
+        assert!(matches!(outcome, StartupOutcome::ShutdownRequested));
+    }
+
+    #[tokio::test]
+    async fn run_startup_or_shutdown_prefers_shutdown_when_both_ready() {
+        // When both futures are ready in the same poll, the `biased` select must
+        // prefer shutdown so a pending signal is never masked by a connect that
+        // resolves simultaneously.
+        let outcome = run_startup_or_shutdown(
+            std::future::ready(Ok::<(), anyhow::Error>(())),
+            std::future::ready(()),
+        )
+        .await;
+
+        assert!(matches!(outcome, StartupOutcome::ShutdownRequested));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #91

## Summary
- Adds load-time bounds for duration config fields: `server.shutdown_timeout_secs >= 1`, and `relays.connection_timeout_secs` / `relays.reconnect_interval_secs` in `1..=300` seconds.
- Moves shutdown signal setup ahead of relay startup and races `relay_client.connect()` against SIGTERM/SIGINT, so startup can stop promptly while waiting for relays.
- Documents the new bounds in `config/default.toml` and `README.md`.

## Verification
- `git diff --check`
- `cargo fmt --all -- --check`
- `RUSTFLAGS=-Dwarnings cargo check --all-targets`
- `RUSTFLAGS=-Dwarnings cargo clippy --all-targets -- -D warnings`
- `RUSTFLAGS=-Dwarnings cargo test --all-targets` (417 unit + 4 integration passed)
- `RUSTFLAGS=-Dwarnings cargo check --all-targets --features tor`
- `RUSTFLAGS=-Dwarnings cargo test --all-targets --features tor` (418 unit + 4 integration passed)
- `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --document-private-items`
- `./scripts/cargo-audit.sh` (exit 0; 3 allowed warnings from current advisory DB)

## Sensitive paths
- `src/config.rs` — task metadata marks this sensitive; changed config validation only.

## Notes
- `src/nostr/**` was not changed; relay timeout safety is enforced before runtime via config validation.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/transponder/pull/189">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved startup behavior so the app can shut down cleanly even while relay connections are still being established.
  * Added clearer configuration limits for relay reconnect and connection timeouts.

* **Bug Fixes**
  * Prevented invalid shutdown and relay timeout values from being accepted.
  * Ensured shutdown is handled more reliably during startup and avoids continuing into normal processing.

* **Documentation**
  * Clarified configuration comments with timeout units, allowed ranges, and what happens when values are set to `0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->