### PR TITLE
fix: backdate push auth jwt timestamps

### DIFF
--- a/src/push/apns.rs
+++ b/src/push/apns.rs
@@ -294,10 +294,15 @@ impl ApnsClient {
             .map_err(|e| Error::Apns(format!("System time error: {e}")))?
             .as_secs();
 
+        // Backdate `iat` by the clock-skew leeway so a fast host clock does not
+        // yield an `iat` in APNs's future (403 InvalidProviderToken); `exp`
+        // stays within Apple's 1-hour max measured from the backdated `iat`.
+        let (iat, exp) = crate::push::auth_jwt_iat_exp(now, TOKEN_EXPIRATION_SECS);
+
         let claims = ApnsClaims {
             iss: self.config.team_id.clone(),
-            iat: now,
-            exp: now + TOKEN_EXPIRATION_SECS,
+            iat,
+            exp,
         };
 
         let mut header = Header::new(Algorithm::ES256);
@@ -1218,7 +1223,7 @@ mod tests {
             .unwrap();
 
         let result = client
-            .handle_response(Instant::now(), response, "test-token")
+            .handle_response(Duration::ZERO, response, "test-token")
             .await;
 
         let SendAttemptResult::Permanent(Error::Apns(message)) = result else {
@@ -1254,7 +1259,7 @@ mod tests {
             .unwrap();
 
         let result = client
-            .handle_response(Instant::now(), response, "test-token")
+            .handle_response(Duration::ZERO, response, "test-token")
             .await;
 
         let SendAttemptResult::Permanent(Error::Apns(message)) = result else {
@@ -1860,6 +1865,11 @@ OF/2NxApJCzGCEDdfSp6VQO30hyhRANCAAQRWz+jn65BtOMvdyHKcvjBeBSDZH2r
             .await
             .unwrap();
 
+        let before = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+
         // Generate a token
         let token = client.generate_token().unwrap();
 
@@ -1920,6 +1930,24 @@ OF/2NxApJCzGCEDdfSp6VQO30hyhRANCAAQRWz+jn65BtOMvdyHKcvjBeBSDZH2r
         let iat = claims["iat"].as_u64().unwrap();
         let exp = claims["exp"].as_u64().unwrap();
         assert_eq!(exp - iat, 3600, "exp should be iat + 3600 seconds");
+
+        // iat must be backdated by the clock-skew leeway so a fast host clock
+        // does not stamp an iat in APNs's future. Bound it by the wall-clock
+        // times captured before and after signing so the assertion is stable
+        // even if the test crosses a second boundary.
+        let after = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let leeway = crate::push::AUTH_JWT_CLOCK_SKEW_LEEWAY_SECS;
+        assert!(
+            iat >= before.saturating_sub(leeway),
+            "iat ({iat}) should be no earlier than the backdated start ({before} - {leeway})"
+        );
+        assert!(
+            iat <= after.saturating_sub(leeway),
+            "iat ({iat}) should be backdated at least {leeway}s before now ({after})"
+        );
     }
 
     #[tokio::test]

--- a/src/push/fcm.rs
+++ b/src/push/fcm.rs
@@ -286,13 +286,16 @@ impl FcmClient {
             .map_err(|e| Error::Fcm(format!("System time error: {e}")))?
             .as_secs();
 
-        let exp = now + 3600; // 1 hour
+        // Backdate `iat` by the clock-skew leeway so a fast host clock does not
+        // produce an assertion Google sees as issued in the future; `exp` stays
+        // within Google's 1-hour max measured from the backdated `iat`.
+        let (iat, exp) = crate::push::auth_jwt_iat_exp(now, 3600);
 
         let claims = OAuthClaims {
             iss: sa.client_email.clone(),
             scope: FCM_SCOPE.to_string(),
             aud: sa.token_uri.clone(),
-            iat: now,
+            iat,
             exp,
         };
 
@@ -1303,7 +1306,7 @@ mod tests {
             .unwrap();
 
         client
-            .handle_response(Instant::now(), response, "test-access-token")
+            .handle_response(Duration::ZERO, response, "test-access-token")
             .await
     }
 

--- a/src/push/mod.rs
+++ b/src/push/mod.rs
@@ -21,6 +21,17 @@ use serde::de::DeserializeOwned;
 /// keeps a single failing request from buffering an unbounded body into memory.
 const MAX_ERROR_BODY_BYTES: usize = 8 * 1024;
 
+/// Clock-skew allowance (seconds) subtracted from `iat` when minting provider
+/// auth JWTs.
+///
+/// A host clock running slightly ahead of the provider's clock makes an `iat`
+/// stamped at the exact local second look like it is in the future, which APNs
+/// rejects as `403 InvalidProviderToken` (and caches the bad token) and Google
+/// OAuth rejects as an assertion issued in the future. Backdating `iat` by this
+/// small standard leeway absorbs that skew without meaningfully shortening the
+/// usable token lifetime.
+const AUTH_JWT_CLOCK_SKEW_LEEWAY_SECS: u64 = 30;
+
 /// Read at most [`MAX_ERROR_BODY_BYTES`] of a provider error response and
 /// deserialize the bounded prefix as JSON.
 ///
@@ -58,6 +69,20 @@ async fn parse_bounded_error_body<T: DeserializeOwned>(
     }
 
     serde_json::from_slice(&body).ok()
+}
+
+/// Compute the `iat`/`exp` claims for a provider auth JWT from the current Unix
+/// time `now_secs`.
+///
+/// `iat` is backdated by [`AUTH_JWT_CLOCK_SKEW_LEEWAY_SECS`] to tolerate a fast
+/// host clock, and `exp` is derived from the backdated `iat` plus
+/// `max_lifetime_secs` so the token stays within the provider's maximum lifetime
+/// (APNs and Google both cap it at 3600 seconds). `iat` saturates at 0 to stay
+/// robust for clocks reporting a time within the leeway of the Unix epoch.
+#[must_use]
+fn auth_jwt_iat_exp(now_secs: u64, max_lifetime_secs: u64) -> (u64, u64) {
+    let iat = now_secs.saturating_sub(AUTH_JWT_CLOCK_SKEW_LEEWAY_SECS);
+    (iat, iat + max_lifetime_secs)
 }
 
 #[cfg(test)]
@@ -136,5 +161,31 @@ mod tests {
 
         let parsed = parse_body(body).await;
         assert_eq!(parsed, Some(TestError { reason }));
+    }
+
+    #[test]
+    fn auth_jwt_iat_is_backdated_by_the_clock_skew_leeway() {
+        let now = 1_700_000_000;
+        let (iat, _exp) = auth_jwt_iat_exp(now, 3600);
+        assert_eq!(iat, now - AUTH_JWT_CLOCK_SKEW_LEEWAY_SECS);
+    }
+
+    #[test]
+    fn auth_jwt_exp_is_max_lifetime_after_the_backdated_iat() {
+        let now = 1_700_000_000;
+        let (iat, exp) = auth_jwt_iat_exp(now, 3600);
+        // exp must stay within the provider max lifetime measured from iat,
+        // not from now, so the whole window fits under the 3600s cap.
+        assert_eq!(exp - iat, 3600);
+        assert_eq!(exp, now - AUTH_JWT_CLOCK_SKEW_LEEWAY_SECS + 3600);
+    }
+
+    #[test]
+    fn auth_jwt_iat_saturates_at_epoch() {
+        // A clock reporting a time within the leeway of the Unix epoch must not
+        // underflow; iat saturates at 0.
+        let (iat, exp) = auth_jwt_iat_exp(5, 3600);
+        assert_eq!(iat, 0);
+        assert_eq!(exp, 3600);
     }
 }


### PR DESCRIPTION
Fixes #89

## Summary
- Backdates APNs provider JWT and FCM OAuth assertion `iat` by a 30-second clock-skew leeway.
- Derives `exp` from the backdated `iat`, preserving the provider max lifetime window (`exp - iat == 3600`) instead of extending tokens to `now + 3600`.
- Adds focused regression coverage for the shared timestamp helper and the APNs generated JWT claims.

## Verification
- `cargo fmt --all -- --check`
- `RUSTFLAGS=-Dwarnings cargo check --all-targets`
- `RUSTFLAGS=-Dwarnings cargo clippy --all-targets -- -D warnings`
- `RUSTFLAGS=-Dwarnings cargo test --all-targets` (407 unit tests + 4 integration tests passed)
- `RUSTFLAGS=-Dwarnings cargo check --all-targets --features tor`
- `RUSTFLAGS=-Dwarnings cargo test --all-targets --features tor` (408 unit tests + 4 integration tests passed)
- `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --document-private-items`
- `./scripts/cargo-audit.sh` (passed with 3 allowed warnings: RUSTSEC-2026-0190, RUSTSEC-2026-0186, RUSTSEC-2026-0097)

## Sensitive paths
- `src/push/apns.rs` — APNs auth JWT hot path
- `src/push/fcm.rs` — FCM OAuth assertion hot path
- `src/push/mod.rs` — shared push auth timestamp helper


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/transponder/pull/191">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->