### PR TITLE
fix: align FCM hot-path log levels

### DIFF
--- a/src/push/fcm.rs
+++ b/src/push/fcm.rs
@@ -10,7 +10,7 @@ use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
-use tracing::{debug, error, info, trace, warn};
+use tracing::{debug, error, trace, warn};
 use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
 use crate::config::FcmConfig;
@@ -494,7 +494,7 @@ impl FcmClient {
 
         match classify_fcm_error(&error.error) {
             FcmClassification::TokenDead => {
-                info!(status = %error.error.status, "FCM token unregistered");
+                debug!(status = %error.error.status, "FCM token unregistered");
                 SendAttemptResult::Success(false)
             }
             FcmClassification::Permanent => {
@@ -526,7 +526,7 @@ impl FcmClient {
 
         match status.as_u16() {
             200 => {
-                info!("FCM notification accepted");
+                debug!(status = status.as_u16(), "FCM notification accepted");
                 SendAttemptResult::Success(true)
             }
             400 => {
@@ -536,7 +536,7 @@ impl FcmClient {
             401 => {
                 // Auth error - permanent for this request, refresh on the next one.
                 self.invalidate_cached_token(access_token).await;
-                error!("FCM authentication error");
+                debug!("FCM authentication error");
                 SendAttemptResult::Permanent(Error::Fcm("Authentication error".to_string()))
             }
             403 => {


### PR DESCRIPTION
## Summary
- Downgrades FCM accepted-delivery logging from INFO to DEBUG.
- Downgrades FCM unregistered-token logging from INFO to DEBUG.
- Downgrades FCM 401 auth-rejection logging from ERROR to DEBUG, matching the APNs hot-path behavior.

## Test Plan
- `cargo fmt --check`
- `cargo test push::fcm -- --nocapture`
- `just ci`

Fixes #98


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/transponder/pull/200">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted notification logging levels to reduce noisy output during normal operation.
  * Routine token and delivery messages now appear at a lower log level.
  * Authentication-related failures are also logged less prominently.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->