### PR TITLE
fix: lower per-event notification success log

### DIFF
--- a/src/nostr/events.rs
+++ b/src/nostr/events.rs
@@ -18,7 +18,7 @@ use sha2::{Digest, Sha256};
 use tokio::io::AsyncWriteExt;
 use tokio::sync::{Mutex, RwLock};
 use tokio::time::Instant;
-use tracing::{debug, info, trace, warn};
+use tracing::{debug, trace, warn};
 
 use crate::crypto::nip59::DEFAULT_MAX_TOKENS_PER_EVENT;
 use crate::crypto::token::ENCRYPTED_TOKEN_SIZE;
@@ -632,16 +632,18 @@ impl EventProcessor {
 
         // Process the event
         match self.process_inner(event).await {
-            Ok(count) => {
+            Ok(_) => {
                 // Refresh the seen timestamp now that processing succeeded, so
                 // the dedup window is measured from completion. The reservation
                 // taken above already keeps the event marked seen.
                 self.mark_seen(event.id).await;
 
-                info!(
-                    notifications_admitted = count,
-                    "Processed notification event"
-                );
+                // Logged at trace, not info: emitting a per-event success line
+                // at the default level persists delivery-timing metadata in
+                // logs (and downstream log shipping). The recipient fan-out
+                // count is intentionally omitted — it is already captured in
+                // Prometheus via `observe_notifications_admitted_per_event`.
+                trace!("Processed notification event");
 
                 if let Some(ref m) = self.metrics {
                     m.record_event_processed();


### PR DESCRIPTION
Fixes #161

## Summary
- Downgraded the per-delivery `Processed notification event` success log from `info!` to `trace!`.
- Removed the `notifications_admitted` fan-out field from that log line.
- Left the existing Prometheus `observe_notifications_admitted_per_event` metric path intact for aggregate observability.

## Verification
- `cargo fmt --all -- --check`
- `RUSTFLAGS=-Dwarnings cargo check --all-targets`
- `RUSTFLAGS=-Dwarnings cargo clippy --all-targets -- -D warnings`
- `RUSTFLAGS=-Dwarnings cargo test --all-targets` (457 unit tests + 4 integration tests passed)

Note: `/tmp` was full on vault, so local verification used workspace-local `TMPDIR`/`CARGO_TARGET_DIR` and then removed those build directories.

## Sensitive paths
- `src/nostr/events.rs` — repo-sensitive `src/nostr/**`; privacy-affecting event logging metadata.

## Tests
No new log-capture test added. Existing tests cover the fan-out metric path; adding a test for the tracing level would require a new logging capture harness for a one-line default-log privacy change.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/transponder/pull/202">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->