### PR TITLE
fix: desynchronize push retry backoff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6142,6 +6142,7 @@ dependencies = [
  "nostr-relay-builder",
  "nostr-sdk",
  "prometheus",
+ "rand 0.9.4",
  "reqwest 0.12.28",
  "reqwest 0.13.4",
  "rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ base64 = "0.22"
 hex = "0.4.3"
 bytes = "1.11"
 lru = "0.16"
+rand = "0.9"
 
 [dev-dependencies]
 tokio-test = "0.4.5"

--- a/src/push/dispatcher.rs
+++ b/src/push/dispatcher.rs
@@ -1475,10 +1475,11 @@ mod tests {
         let guard = dispatcher.inflight.enter();
 
         // A retry config with a backoff long enough to observe the sleep window
-        // deterministically from the test.
+        // deterministically from the test even after retry jitter shortens the
+        // fallback sleep by up to half.
         let config = RetryConfig {
             max_retries: 3,
-            initial_backoff: Duration::from_millis(300),
+            initial_backoff: Duration::from_millis(600),
         };
         let attempts = Arc::new(AtomicU32::new(0));
         let attempts_op = attempts.clone();

--- a/src/push/retry.rs
+++ b/src/push/retry.rs
@@ -74,6 +74,12 @@ pub const DEFAULT_INITIAL_BACKOFF: Duration = Duration::from_millis(100);
 /// Maximum backoff duration cap.
 pub const MAX_BACKOFF: Duration = Duration::from_secs(10);
 
+/// Minimum server-requested backoff duration.
+const MIN_RETRY_BACKOFF: Duration = DEFAULT_INITIAL_BACKOFF;
+
+/// Maximum randomized jitter applied to a retry sleep.
+const MAX_RETRY_JITTER: Duration = Duration::from_secs(1);
+
 /// Configuration for retry behavior.
 #[derive(Debug, Clone)]
 pub struct RetryConfig {
@@ -163,9 +169,14 @@ where
                     metrics.record_push_retry(service_name.to_lowercase().as_str());
                 }
 
-                // Honor Retry-After exactly when the provider supplies one. Only cap
-                // locally-computed exponential backoff to avoid runaway delays.
-                let wait_duration = retry_wait_duration(retry_after, backoff);
+                // Honor provider-supplied Retry-After values, but floor zero
+                // or tiny values and jitter every sleep so concurrent failures
+                // do not retry in synchronized waves. Only cap locally-computed
+                // exponential backoff to avoid runaway delays.
+                let wait_duration = retry_sleep_duration(
+                    retry_wait_duration(retry_after, backoff),
+                    retry_after.is_some(),
+                );
 
                 warn!(
                     service = service_name,
@@ -191,8 +202,9 @@ where
                     sleep(wait_duration).await;
                 }
 
-                // Exponential backoff for next iteration (if not using Retry-After)
-                backoff = next_fallback_backoff(backoff, retry_after);
+                // Advance the fallback backoff every time so repeated tiny
+                // Retry-After values degrade gracefully once the header stops.
+                backoff = next_fallback_backoff(backoff);
             }
             SendAttemptResult::Retriable { status_code, .. } => {
                 warn!(
@@ -208,19 +220,51 @@ where
     }
 }
 
-fn next_fallback_backoff(backoff: Duration, retry_after: Option<Duration>) -> Duration {
-    if retry_after.is_some() {
-        backoff
-    } else {
-        (backoff * 2).min(MAX_BACKOFF)
-    }
+fn next_fallback_backoff(backoff: Duration) -> Duration {
+    (backoff * 2).min(MAX_BACKOFF)
 }
 
 fn retry_wait_duration(retry_after: Option<Duration>, backoff: Duration) -> Duration {
+    let fallback = backoff.min(MAX_BACKOFF);
     match retry_after {
-        Some(server_delay) => server_delay,
-        None => backoff.min(MAX_BACKOFF),
+        Some(Duration::ZERO) => MIN_RETRY_BACKOFF.max(fallback),
+        Some(server_delay) => server_delay.max(MIN_RETRY_BACKOFF),
+        None => fallback,
     }
+}
+
+fn retry_sleep_duration(base: Duration, retry_after_supplied: bool) -> Duration {
+    let jitter = random_retry_jitter(base);
+    if retry_after_supplied {
+        delay_retry_jitter(base, jitter)
+    } else {
+        apply_retry_jitter(base, jitter)
+    }
+}
+
+fn random_retry_jitter(base: Duration) -> Duration {
+    let max_jitter_micros = max_retry_jitter(base).as_micros() as u64;
+    if max_jitter_micros == 0 {
+        return Duration::ZERO;
+    }
+
+    Duration::from_micros(rand::random_range(0..=max_jitter_micros))
+}
+
+fn max_retry_jitter(base: Duration) -> Duration {
+    let max_jitter_micros = (base.as_micros() / 2)
+        .min(MAX_RETRY_JITTER.as_micros())
+        .min(u128::from(u64::MAX)) as u64;
+
+    Duration::from_micros(max_jitter_micros)
+}
+
+fn apply_retry_jitter(base: Duration, jitter: Duration) -> Duration {
+    base.saturating_sub(jitter.min(max_retry_jitter(base)))
+}
+
+fn delay_retry_jitter(base: Duration, jitter: Duration) -> Duration {
+    base.saturating_add(jitter.min(max_retry_jitter(base)))
 }
 
 /// Decide whether a transport (`reqwest`) error is safe to retry.
@@ -474,6 +518,73 @@ mod tests {
     }
 
     #[test]
+    fn test_retry_wait_duration_floors_zero_retry_after() {
+        assert_eq!(
+            retry_wait_duration(Some(Duration::ZERO), Duration::from_millis(1)),
+            MIN_RETRY_BACKOFF
+        );
+    }
+
+    #[test]
+    fn test_retry_wait_duration_uses_fallback_backoff_when_retry_after_is_zero() {
+        assert_eq!(
+            retry_wait_duration(Some(Duration::ZERO), Duration::from_millis(400)),
+            Duration::from_millis(400)
+        );
+        assert_eq!(
+            retry_wait_duration(Some(Duration::ZERO), Duration::from_secs(60)),
+            MAX_BACKOFF
+        );
+    }
+
+    #[test]
+    fn test_retry_wait_duration_floors_tiny_nonzero_retry_after_without_fallback() {
+        assert_eq!(
+            retry_wait_duration(Some(Duration::from_millis(1)), Duration::from_secs(60)),
+            MIN_RETRY_BACKOFF
+        );
+    }
+
+    #[test]
+    fn test_retry_jitter_bounds_delay_between_half_and_full() {
+        let base = Duration::from_millis(100);
+
+        assert_eq!(apply_retry_jitter(base, Duration::ZERO), base);
+        assert_eq!(
+            apply_retry_jitter(base, Duration::from_millis(25)),
+            Duration::from_millis(75)
+        );
+        assert_eq!(
+            apply_retry_jitter(base, Duration::from_millis(500)),
+            Duration::from_millis(50)
+        );
+    }
+
+    #[test]
+    fn test_retry_after_jitter_never_retries_before_server_delay() {
+        let base = Duration::from_millis(100);
+
+        assert_eq!(delay_retry_jitter(base, Duration::ZERO), base);
+        assert_eq!(
+            delay_retry_jitter(base, Duration::from_millis(25)),
+            Duration::from_millis(125)
+        );
+        assert_eq!(
+            delay_retry_jitter(base, Duration::from_millis(500)),
+            Duration::from_millis(150)
+        );
+    }
+
+    #[test]
+    fn test_retry_jitter_is_capped() {
+        assert_eq!(
+            max_retry_jitter(Duration::from_millis(100)),
+            Duration::from_millis(50)
+        );
+        assert_eq!(max_retry_jitter(Duration::from_secs(10)), MAX_RETRY_JITTER);
+    }
+
+    #[test]
     fn test_retry_wait_duration_caps_exponential_backoff() {
         assert_eq!(
             retry_wait_duration(None, Duration::from_secs(60)),
@@ -642,65 +753,29 @@ mod tests {
     }
 
     #[test]
-    fn test_retry_after_does_not_advance_fallback_backoff() {
+    fn test_retry_after_still_advances_fallback_backoff() {
         let initial_backoff = Duration::from_millis(200);
 
-        let backoff_after_retry_after_retries = (0..3).fold(initial_backoff, |backoff, _| {
-            next_fallback_backoff(backoff, Some(Duration::from_millis(1)))
-        });
+        let backoff_after_retry_after_retries =
+            (0..3).fold(initial_backoff, |backoff, _| next_fallback_backoff(backoff));
 
-        assert_eq!(backoff_after_retry_after_retries, initial_backoff);
         assert_eq!(
-            next_fallback_backoff(backoff_after_retry_after_retries, None),
-            Duration::from_millis(400)
+            backoff_after_retry_after_retries,
+            Duration::from_millis(1600)
+        );
+        assert_eq!(
+            next_fallback_backoff(backoff_after_retry_after_retries),
+            Duration::from_millis(3200)
         );
     }
 
-    #[tokio::test(start_paused = true)]
-    async fn test_with_retry_does_not_advance_backoff_while_retry_after_is_used() {
-        let config = RetryConfig {
-            max_retries: 4,
-            initial_backoff: Duration::from_millis(200),
-        };
-        let attempt_count = Arc::new(AtomicU32::new(0));
-        let attempt_count_clone = attempt_count.clone();
-
-        let result = tokio::time::timeout(
-            Duration::from_millis(250),
-            with_retry(
-                &config,
-                "test",
-                || {
-                    let count = attempt_count_clone.clone();
-                    async move {
-                        let attempts = count.fetch_add(1, Ordering::SeqCst) + 1;
-                        if attempts <= 3 {
-                            SendAttemptResult::Retriable {
-                                status_code: 429,
-                                retry_after: Some(Duration::from_millis(1)),
-                            }
-                        } else if attempts == 4 {
-                            SendAttemptResult::Retriable {
-                                status_code: 503,
-                                retry_after: None,
-                            }
-                        } else {
-                            SendAttemptResult::Success(true)
-                        }
-                    }
-                },
-                None,
-                None,
-            ),
-        )
-        .await;
-
-        assert!(
-            result.is_ok(),
-            "fallback backoff was advanced by Retry-After retries"
+    #[test]
+    fn test_next_fallback_backoff_caps_at_max_backoff() {
+        assert_eq!(next_fallback_backoff(MAX_BACKOFF), MAX_BACKOFF);
+        assert_eq!(
+            next_fallback_backoff(MAX_BACKOFF + Duration::from_secs(1)),
+            MAX_BACKOFF
         );
-        assert!(result.unwrap().unwrap());
-        assert_eq!(attempt_count.load(Ordering::SeqCst), 5);
     }
 
     #[tokio::test]

--- a/src/push/retry.rs
+++ b/src/push/retry.rs
@@ -173,10 +173,7 @@ where
                 // or tiny values and jitter every sleep so concurrent failures
                 // do not retry in synchronized waves. Only cap locally-computed
                 // exponential backoff to avoid runaway delays.
-                let wait_duration = retry_sleep_duration(
-                    retry_wait_duration(retry_after, backoff),
-                    retry_after.is_some(),
-                );
+                let wait_duration = retry_sleep_duration(retry_after, backoff);
 
                 warn!(
                     service = service_name,
@@ -204,7 +201,7 @@ where
 
                 // Advance the fallback backoff every time so repeated tiny
                 // Retry-After values degrade gracefully once the header stops.
-                backoff = next_fallback_backoff(backoff);
+                backoff = (backoff * 2).min(MAX_BACKOFF);
             }
             SendAttemptResult::Retriable { status_code, .. } => {
                 warn!(
@@ -220,51 +217,36 @@ where
     }
 }
 
-fn next_fallback_backoff(backoff: Duration) -> Duration {
-    (backoff * 2).min(MAX_BACKOFF)
-}
-
-fn retry_wait_duration(retry_after: Option<Duration>, backoff: Duration) -> Duration {
+fn retry_sleep_base(retry_after: Option<Duration>, backoff: Duration) -> (Duration, bool) {
     let fallback = backoff.min(MAX_BACKOFF);
     match retry_after {
-        Some(Duration::ZERO) => MIN_RETRY_BACKOFF.max(fallback),
-        Some(server_delay) => server_delay.max(MIN_RETRY_BACKOFF),
-        None => fallback,
+        Some(Duration::ZERO) => (MIN_RETRY_BACKOFF.max(fallback), true),
+        Some(server_delay) => (server_delay.max(MIN_RETRY_BACKOFF), true),
+        None => (fallback, false),
     }
 }
 
-fn retry_sleep_duration(base: Duration, retry_after_supplied: bool) -> Duration {
+fn retry_sleep_duration(retry_after: Option<Duration>, backoff: Duration) -> Duration {
+    let (base, retry_after_supplied) = retry_sleep_base(retry_after, backoff);
     let jitter = random_retry_jitter(base);
     if retry_after_supplied {
-        delay_retry_jitter(base, jitter)
+        // Retry-After is a provider-requested minimum, so jitter is additive:
+        // this may wait up to one bounded-jitter window longer, but never less.
+        base.saturating_add(jitter)
     } else {
-        apply_retry_jitter(base, jitter)
+        base.saturating_sub(jitter)
     }
 }
 
 fn random_retry_jitter(base: Duration) -> Duration {
-    let max_jitter_micros = max_retry_jitter(base).as_micros() as u64;
-    if max_jitter_micros == 0 {
-        return Duration::ZERO;
-    }
-
-    Duration::from_micros(rand::random_range(0..=max_jitter_micros))
+    max_retry_jitter(base).mul_f64(rand::random_range(0.0..1.0))
 }
 
 fn max_retry_jitter(base: Duration) -> Duration {
-    let max_jitter_micros = (base.as_micros() / 2)
-        .min(MAX_RETRY_JITTER.as_micros())
-        .min(u128::from(u64::MAX)) as u64;
-
-    Duration::from_micros(max_jitter_micros)
-}
-
-fn apply_retry_jitter(base: Duration, jitter: Duration) -> Duration {
-    base.saturating_sub(jitter.min(max_retry_jitter(base)))
-}
-
-fn delay_retry_jitter(base: Duration, jitter: Duration) -> Duration {
-    base.saturating_add(jitter.min(max_retry_jitter(base)))
+    // The jitter window is bounded, not a strict 50% multiplier at every size:
+    // large sleeps desynchronize within one second instead of stretching or
+    // shrinking by many seconds.
+    (base / 2).min(MAX_RETRY_JITTER)
 }
 
 /// Decide whether a transport (`reqwest`) error is safe to retry.
@@ -509,69 +491,71 @@ mod tests {
         assert_eq!(retry_after_from_headers(&headers), None);
     }
 
-    #[test]
-    fn test_retry_wait_duration_honors_retry_after_above_max_backoff() {
-        assert_eq!(
-            retry_wait_duration(Some(Duration::from_secs(60)), Duration::from_millis(100)),
-            Duration::from_secs(60)
+    fn assert_duration_between(actual: Duration, min: Duration, max: Duration) {
+        assert!(
+            actual >= min && actual <= max,
+            "expected {actual:?} to be between {min:?} and {max:?}"
         );
     }
 
     #[test]
-    fn test_retry_wait_duration_floors_zero_retry_after() {
-        assert_eq!(
-            retry_wait_duration(Some(Duration::ZERO), Duration::from_millis(1)),
-            MIN_RETRY_BACKOFF
+    fn test_retry_sleep_duration_honors_retry_after_above_max_backoff() {
+        let sleep = retry_sleep_duration(Some(Duration::from_secs(60)), Duration::from_millis(100));
+
+        assert_duration_between(sleep, Duration::from_secs(60), Duration::from_secs(61));
+    }
+
+    #[test]
+    fn test_retry_sleep_duration_floors_zero_retry_after() {
+        let sleep = retry_sleep_duration(Some(Duration::ZERO), Duration::from_millis(1));
+
+        assert_duration_between(
+            sleep,
+            MIN_RETRY_BACKOFF,
+            MIN_RETRY_BACKOFF + max_retry_jitter(MIN_RETRY_BACKOFF),
         );
     }
 
     #[test]
-    fn test_retry_wait_duration_uses_fallback_backoff_when_retry_after_is_zero() {
-        assert_eq!(
-            retry_wait_duration(Some(Duration::ZERO), Duration::from_millis(400)),
-            Duration::from_millis(400)
+    fn test_retry_sleep_duration_uses_fallback_backoff_when_retry_after_is_zero() {
+        let sleep = retry_sleep_duration(Some(Duration::ZERO), Duration::from_millis(400));
+        assert_duration_between(
+            sleep,
+            Duration::from_millis(400),
+            Duration::from_millis(600),
         );
-        assert_eq!(
-            retry_wait_duration(Some(Duration::ZERO), Duration::from_secs(60)),
-            MAX_BACKOFF
+
+        let capped_sleep = retry_sleep_duration(Some(Duration::ZERO), Duration::from_secs(60));
+        assert_duration_between(capped_sleep, MAX_BACKOFF, MAX_BACKOFF + MAX_RETRY_JITTER);
+    }
+
+    #[test]
+    fn test_retry_sleep_duration_floors_tiny_nonzero_retry_after_without_fallback() {
+        let sleep = retry_sleep_duration(Some(Duration::from_millis(1)), Duration::from_secs(60));
+
+        assert_duration_between(
+            sleep,
+            MIN_RETRY_BACKOFF,
+            MIN_RETRY_BACKOFF + max_retry_jitter(MIN_RETRY_BACKOFF),
         );
     }
 
     #[test]
-    fn test_retry_wait_duration_floors_tiny_nonzero_retry_after_without_fallback() {
-        assert_eq!(
-            retry_wait_duration(Some(Duration::from_millis(1)), Duration::from_secs(60)),
-            MIN_RETRY_BACKOFF
-        );
-    }
+    fn test_retry_sleep_duration_jitters_fallback_between_window_and_base() {
+        let sleep = retry_sleep_duration(None, Duration::from_millis(100));
 
-    #[test]
-    fn test_retry_jitter_bounds_delay_between_half_and_full() {
-        let base = Duration::from_millis(100);
-
-        assert_eq!(apply_retry_jitter(base, Duration::ZERO), base);
-        assert_eq!(
-            apply_retry_jitter(base, Duration::from_millis(25)),
-            Duration::from_millis(75)
-        );
-        assert_eq!(
-            apply_retry_jitter(base, Duration::from_millis(500)),
-            Duration::from_millis(50)
-        );
+        assert_duration_between(sleep, Duration::from_millis(50), Duration::from_millis(100));
     }
 
     #[test]
     fn test_retry_after_jitter_never_retries_before_server_delay() {
-        let base = Duration::from_millis(100);
+        let server_delay = Duration::from_millis(100);
+        let sleep = retry_sleep_duration(Some(server_delay), Duration::from_millis(1));
 
-        assert_eq!(delay_retry_jitter(base, Duration::ZERO), base);
-        assert_eq!(
-            delay_retry_jitter(base, Duration::from_millis(25)),
-            Duration::from_millis(125)
-        );
-        assert_eq!(
-            delay_retry_jitter(base, Duration::from_millis(500)),
-            Duration::from_millis(150)
+        assert_duration_between(
+            sleep,
+            server_delay,
+            server_delay + max_retry_jitter(server_delay),
         );
     }
 
@@ -585,11 +569,10 @@ mod tests {
     }
 
     #[test]
-    fn test_retry_wait_duration_caps_exponential_backoff() {
-        assert_eq!(
-            retry_wait_duration(None, Duration::from_secs(60)),
-            MAX_BACKOFF
-        );
+    fn test_retry_sleep_duration_caps_exponential_backoff() {
+        let sleep = retry_sleep_duration(None, Duration::from_secs(60));
+
+        assert_duration_between(sleep, MAX_BACKOFF - MAX_RETRY_JITTER, MAX_BACKOFF);
     }
 
     #[tokio::test]
@@ -752,30 +735,75 @@ mod tests {
         assert!(elapsed < Duration::from_secs(1));
     }
 
-    #[test]
-    fn test_retry_after_still_advances_fallback_backoff() {
-        let initial_backoff = Duration::from_millis(200);
+    #[tokio::test]
+    async fn test_with_retry_repeated_retry_after_zero_sleeps_before_each_retry() {
+        tokio::time::pause();
 
-        let backoff_after_retry_after_retries =
-            (0..3).fold(initial_backoff, |backoff, _| next_fallback_backoff(backoff));
+        let config = RetryConfig {
+            max_retries: 3,
+            initial_backoff: Duration::from_millis(100),
+        };
+        let attempt_count = Arc::new(AtomicU32::new(0));
+        let attempt_count_clone = attempt_count.clone();
 
-        assert_eq!(
-            backoff_after_retry_after_retries,
-            Duration::from_millis(1600)
-        );
-        assert_eq!(
-            next_fallback_backoff(backoff_after_retry_after_retries),
-            Duration::from_millis(3200)
-        );
-    }
+        let task = tokio::spawn(async move {
+            with_retry(
+                &config,
+                "test",
+                || {
+                    let count = attempt_count_clone.clone();
+                    async move {
+                        let attempt = count.fetch_add(1, Ordering::SeqCst) + 1;
+                        if attempt <= 3 {
+                            SendAttemptResult::Retriable {
+                                status_code: 429,
+                                retry_after: Some(Duration::ZERO),
+                            }
+                        } else {
+                            SendAttemptResult::Success(true)
+                        }
+                    }
+                },
+                None,
+                None,
+            )
+            .await
+        });
 
-    #[test]
-    fn test_next_fallback_backoff_caps_at_max_backoff() {
-        assert_eq!(next_fallback_backoff(MAX_BACKOFF), MAX_BACKOFF);
-        assert_eq!(
-            next_fallback_backoff(MAX_BACKOFF + Duration::from_secs(1)),
-            MAX_BACKOFF
-        );
+        tokio::task::yield_now().await;
+        assert_eq!(attempt_count.load(Ordering::SeqCst), 1);
+        assert!(!task.is_finished());
+
+        // First Retry-After: 0 sleep is floored to at least 100ms, then can add
+        // up to 50ms of jitter. It must not retry before the floor elapses.
+        tokio::time::advance(Duration::from_millis(99)).await;
+        tokio::task::yield_now().await;
+        assert_eq!(attempt_count.load(Ordering::SeqCst), 1);
+
+        tokio::time::advance(Duration::from_millis(51)).await;
+        tokio::task::yield_now().await;
+        assert_eq!(attempt_count.load(Ordering::SeqCst), 2);
+
+        // The fallback backoff advances even while Retry-After is supplied, so
+        // the next zero-header sleep is based on 200ms, not 100ms again.
+        tokio::time::advance(Duration::from_millis(199)).await;
+        tokio::task::yield_now().await;
+        assert_eq!(attempt_count.load(Ordering::SeqCst), 2);
+
+        tokio::time::advance(Duration::from_millis(101)).await;
+        tokio::task::yield_now().await;
+        assert_eq!(attempt_count.load(Ordering::SeqCst), 3);
+
+        // The third zero-header retry uses the next 400ms fallback slot.
+        tokio::time::advance(Duration::from_millis(399)).await;
+        tokio::task::yield_now().await;
+        assert_eq!(attempt_count.load(Ordering::SeqCst), 3);
+
+        tokio::time::advance(Duration::from_millis(201)).await;
+        let result = task.await.unwrap();
+        assert!(result.is_ok());
+        assert!(result.unwrap());
+        assert_eq!(attempt_count.load(Ordering::SeqCst), 4);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- floor server-supplied `Retry-After` values at the default retry backoff so `Retry-After: 0` cannot produce immediate retry bursts
- add bounded jitter to retry sleeps to desynchronize concurrent retry waves while preserving server `Retry-After` minimums
- continue advancing fallback exponential backoff even when `Retry-After` headers are present

## Test Plan
- `cargo test -j 2 push::retry::tests -- --nocapture`
- `RUSTFLAGS='-Dwarnings' cargo fmt --all -- --check && cargo check -j 2 --all-targets && cargo clippy -j 2 --all-targets -- -D warnings && cargo test -j 2 --all-targets && ./scripts/cargo-audit.sh`

Fixes #96


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/transponder/pull/204">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Push retries now wait more consistently when a service asks the app to retry later, with safer minimum delays and limited jitter to avoid retrying too early.
* **Bug Fixes**
  * Improved handling of very short or zero retry delays so requests back off instead of retrying immediately.
  * Retry timing is now more predictable across repeated failures, reducing rapid-fire retry loops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->