### PR TITLE
fix: zeroize derived device token strings

### DIFF
--- a/src/crypto/token.rs
+++ b/src/crypto/token.rs
@@ -186,16 +186,18 @@ impl TokenPayload {
         })
     }
 
-    /// Get the device token as a hex string (for APNs).
+    /// Get the device token as a zeroized hex string (for APNs).
     #[must_use]
-    pub fn device_token_hex(&self) -> String {
-        hex::encode(&self.device_token)
+    pub fn device_token_hex(&self) -> Zeroizing<String> {
+        Zeroizing::new(hex::encode(&self.device_token))
     }
 
-    /// Get the device token as a string (for FCM).
+    /// Get the device token as a zeroized string (for FCM).
     #[must_use]
-    pub fn device_token_string(&self) -> Option<String> {
-        String::from_utf8(self.device_token.clone()).ok()
+    pub fn device_token_string(&self) -> Option<Zeroizing<String>> {
+        std::str::from_utf8(&self.device_token)
+            .ok()
+            .map(|token| Zeroizing::new(token.to_owned()))
     }
 }
 
@@ -422,7 +424,8 @@ mod tests {
             platform: Platform::Apns,
             device_token: vec![0xde, 0xad, 0xbe, 0xef],
         };
-        assert_eq!(payload.device_token_hex(), "deadbeef");
+        let token: Zeroizing<String> = payload.device_token_hex();
+        assert_eq!(token.as_str(), "deadbeef");
     }
 
     #[test]
@@ -431,10 +434,8 @@ mod tests {
             platform: Platform::Fcm,
             device_token: b"test-token-123".to_vec(),
         };
-        assert_eq!(
-            payload.device_token_string(),
-            Some("test-token-123".to_string())
-        );
+        let token: Option<Zeroizing<String>> = payload.device_token_string();
+        assert_eq!(token.as_ref().map(|s| s.as_str()), Some("test-token-123"));
     }
 
     #[test]

--- a/src/push/apns.rs
+++ b/src/push/apns.rs
@@ -128,6 +128,10 @@ fn redacted_device_token_id(_device_token: &str) -> &'static str {
     "<redacted_device_token>"
 }
 
+fn device_token_url(base_url: &str, device_token: &str) -> Zeroizing<String> {
+    Zeroizing::new(format!("{base_url}/3/device/{device_token}"))
+}
+
 #[derive(Debug)]
 struct ApnsRequestParts {
     push_type: &'static str,
@@ -331,11 +335,11 @@ impl ApnsClient {
     /// sleeping retry does not occupy an in-flight concurrency slot.
     pub async fn send(
         &self,
-        device_token: &str,
+        device_token: Zeroizing<String>,
         backoff_permit: Option<&mut crate::push::retry::BackoffPermit>,
     ) -> Result<bool> {
         // Validate token format before sending
-        if !is_valid_device_token(device_token) {
+        if !is_valid_device_token(device_token.as_str()) {
             trace!(
                 token_len = device_token.len(),
                 "Invalid APNs device token format"
@@ -347,7 +351,7 @@ impl ApnsClient {
         retry::with_retry(
             &retry_config,
             "APNs",
-            || self.send_once(device_token),
+            || self.send_once(&device_token),
             backoff_permit,
             self.metrics.as_ref(),
         )
@@ -506,24 +510,24 @@ impl ApnsClient {
     /// Send a single push notification attempt without retry.
     ///
     /// Returns a `SendAttemptResult` indicating success, retriable error, or permanent error.
-    async fn send_once(&self, device_token: &str) -> SendAttemptResult {
+    async fn send_once(&self, device_token: &Zeroizing<String>) -> SendAttemptResult {
         self.send_once_with_transport_retry_config(device_token, &RetryConfig::transport())
             .await
     }
 
     async fn send_once_with_transport_retry_config(
         &self,
-        device_token: &str,
+        device_token: &Zeroizing<String>,
         transport_retry: &RetryConfig,
     ) -> SendAttemptResult {
-        let url = format!("{}/3/device/{}", self.config.base_url(), device_token);
+        let url = device_token_url(self.config.base_url(), device_token.as_str());
 
         debug!(
             payload_mode = %self.config.payload_mode,
             push_type = self.config.payload_mode.push_type(),
             priority = self.config.payload_mode.priority(),
             topic = %self.config.bundle_id,
-            device_token = redacted_device_token_id(device_token),
+            device_token = redacted_device_token_id(device_token.as_str()),
             "Sending APNs notification"
         );
 
@@ -543,7 +547,7 @@ impl ApnsClient {
                 // provider latency.
                 let start = Instant::now();
                 let response = self
-                    .build_request(&url, token.as_str(), &request_parts)
+                    .build_request(url.as_str(), token.as_str(), &request_parts)
                     .send()
                     .await
                     .map_err(Error::from)?;
@@ -623,6 +627,10 @@ mod tests {
         serde_json::from_slice(body).unwrap()
     }
 
+    fn zeroizing_token(token: &str) -> Zeroizing<String> {
+        Zeroizing::new(token.to_owned())
+    }
+
     #[test]
     fn test_apns_payload_serialization() {
         let payload = ApnsPayload::default();
@@ -640,6 +648,19 @@ mod tests {
         assert_eq!(
             redacted_device_token_id("ffeeddccbbaa99887766554433221100"),
             "<redacted_device_token>"
+        );
+    }
+
+    #[test]
+    fn test_device_token_url_buffer_is_zeroizing() {
+        fn assert_zeroizing_string(_: &Zeroizing<String>) {}
+
+        let url = device_token_url("https://api.push.apple.com", "aabbccdd11223344");
+
+        assert_zeroizing_string(&url);
+        assert_eq!(
+            url.as_str(),
+            "https://api.push.apple.com/3/device/aabbccdd11223344"
         );
     }
 
@@ -806,7 +827,10 @@ mod tests {
         };
 
         // Test with a token that contains non-hex characters
-        let result = client.send("tooshort", None).await.unwrap();
+        let result = client
+            .send(zeroizing_token("tooshort"), None)
+            .await
+            .unwrap();
         assert!(
             !result,
             "Should return false for token with non-hex characters"
@@ -815,7 +839,7 @@ mod tests {
         // Test with token that has invalid characters
         let result = client
             .send(
-                "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdeg",
+                zeroizing_token("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdeg"),
                 None,
             )
             .await
@@ -826,7 +850,7 @@ mod tests {
         );
 
         // Test with empty token
-        let result = client.send("", None).await.unwrap();
+        let result = client.send(zeroizing_token(""), None).await.unwrap();
         assert!(!result, "Should return false for empty token");
     }
 
@@ -860,7 +884,10 @@ mod tests {
         };
 
         let result = client
-            .send_once_with_transport_retry_config("aabbccdd11223344", &retry_config)
+            .send_once_with_transport_retry_config(
+                &zeroizing_token("aabbccdd11223344"),
+                &retry_config,
+            )
             .await;
 
         assert!(matches!(

--- a/src/push/dispatcher.rs
+++ b/src/push/dispatcher.rs
@@ -402,7 +402,7 @@ impl PushDispatcher {
                         trace!("APNs not configured, skipping notification");
                         continue;
                     }
-                    (Platform::Apns, Zeroizing::new(payload.device_token_hex()))
+                    (Platform::Apns, payload.device_token_hex())
                 }
                 Platform::Fcm => {
                     if self.fcm_client.is_none() {
@@ -410,7 +410,7 @@ impl PushDispatcher {
                         continue;
                     }
                     match payload.device_token_string() {
-                        Some(t) => (Platform::Fcm, Zeroizing::new(t)),
+                        Some(token) => (Platform::Fcm, token),
                         None => {
                             trace!("Invalid FCM token (not UTF-8)");
                             continue;

--- a/src/push/dispatcher.rs
+++ b/src/push/dispatcher.rs
@@ -12,8 +12,9 @@
 //!
 //! # Security
 //!
-//! Device tokens are wrapped in `Zeroizing<String>` to ensure they are zeroed
-//! from memory when no longer needed, preventing sensitive data from lingering.
+//! Device tokens are wrapped in `Zeroizing<String>` while queued and while
+//! handed to provider clients, reducing avoidable cleartext heap copies before
+//! request serialization.
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -43,8 +44,8 @@ const MAX_PENDING_QUEUE_SIZE: usize = 10_000;
 ///
 /// # Security
 ///
-/// The token field is wrapped in `Zeroizing<String>` to ensure device tokens
-/// are zeroed from memory when the message is dropped.
+/// The token field is wrapped in `Zeroizing<String>` while queued and is moved
+/// intact into the provider client when the message is sent.
 enum PushMessage {
     /// Send a notification to the given platform with the given token.
     Send {
@@ -248,7 +249,7 @@ impl PushDispatcher {
         match platform {
             Platform::Apns => {
                 if let Some(client) = apns_client {
-                    match client.send(token.as_str(), backoff_permit).await {
+                    match client.send(token, backoff_permit).await {
                         Ok(true) => {
                             trace!("APNs notification sent");
                             if let Some(ref m) = metrics {
@@ -272,7 +273,7 @@ impl PushDispatcher {
             }
             Platform::Fcm => {
                 if let Some(client) = fcm_client {
-                    match client.send(token.as_str(), backoff_permit).await {
+                    match client.send(token, backoff_permit).await {
                         Ok(true) => {
                             trace!("FCM notification sent");
                             if let Some(ref m) = metrics {

--- a/src/push/fcm.rs
+++ b/src/push/fcm.rs
@@ -103,14 +103,14 @@ pub(crate) struct CachedToken {
 }
 
 /// FCM message payload.
-#[derive(Debug, Serialize)]
-struct FcmRequest {
-    message: FcmMessage,
+#[derive(Serialize)]
+struct FcmRequest<'a> {
+    message: FcmMessage<'a>,
 }
 
-#[derive(Debug, Serialize)]
-struct FcmMessage {
-    token: String,
+#[derive(Serialize)]
+struct FcmMessage<'a> {
+    token: &'a str,
     android: Option<AndroidConfig>,
     data: Option<std::collections::HashMap<String, String>>,
 }
@@ -386,12 +386,12 @@ impl FcmClient {
     /// sleeping retry does not occupy an in-flight concurrency slot.
     pub async fn send(
         &self,
-        device_token: &str,
+        device_token: Zeroizing<String>,
         backoff_permit: Option<&mut crate::push::retry::BackoffPermit>,
     ) -> Result<bool> {
         // Validate token format before spending an OAuth-authenticated round-trip
         // and FCM quota on a clearly-malformed token (mirrors APNs).
-        if !is_valid_fcm_token(device_token) {
+        if !is_valid_fcm_token(device_token.as_str()) {
             trace!(
                 token_len = device_token.len(),
                 "Invalid FCM device token format"
@@ -403,7 +403,7 @@ impl FcmClient {
         retry::with_retry(
             &retry_config,
             "FCM",
-            || self.send_once(device_token),
+            || self.send_once(&device_token),
             backoff_permit,
             self.metrics.as_ref(),
         )
@@ -421,7 +421,7 @@ impl FcmClient {
 
         let request = FcmRequest {
             message: FcmMessage {
-                token: device_token.to_string(),
+                token: device_token,
                 android: Some(AndroidConfig {
                     priority: "high".to_string(),
                 }),
@@ -588,7 +588,7 @@ impl FcmClient {
     /// Send a single push notification attempt without retry.
     ///
     /// Returns a `SendAttemptResult` indicating success, retriable error, or permanent error.
-    async fn send_once(&self, device_token: &str) -> SendAttemptResult {
+    async fn send_once(&self, device_token: &Zeroizing<String>) -> SendAttemptResult {
         let project_id = match self.project_id() {
             Ok(id) => id,
             Err(e) => return SendAttemptResult::Permanent(e),
@@ -610,7 +610,7 @@ impl FcmClient {
                 // not inflate provider latency.
                 let start = Instant::now();
                 let response = self
-                    .build_request(&url, access_token.as_str(), device_token)
+                    .build_request(&url, access_token.as_str(), device_token.as_str())
                     .send()
                     .await
                     .map_err(Error::from)?;
@@ -719,6 +719,10 @@ mod tests {
     use wiremock::matchers::{body_partial_json, header, method, path_regex};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
+    fn zeroizing_token(token: &str) -> Zeroizing<String> {
+        Zeroizing::new(token.to_owned())
+    }
+
     #[test]
     fn test_cached_token_stores_access_token_in_zeroizing_string() {
         // Compile-time guard: cached credentials must stay zeroizing.
@@ -760,6 +764,25 @@ mod tests {
 
         assert_eq!(response.access_token.as_str(), "provider-access-token");
         assert_zeroizing_string(&response.access_token);
+    }
+
+    #[test]
+    fn test_fcm_request_borrows_device_token_from_zeroizing_string() {
+        // Compile-time guard: request construction must not copy the device
+        // token into an owned plain String before reqwest serializes the body.
+        fn assert_borrowed_token(_: &str) {}
+
+        let token = zeroizing_token("device-token-123");
+        let request = FcmRequest {
+            message: FcmMessage {
+                token: token.as_str(),
+                android: None,
+                data: None,
+            },
+        };
+
+        assert_borrowed_token(request.message.token);
+        assert_eq!(request.message.token, "device-token-123");
     }
 
     #[test]
@@ -824,7 +847,7 @@ mod tests {
 
         let request = FcmRequest {
             message: FcmMessage {
-                token: "test-token".to_string(),
+                token: "test-token",
                 android: Some(AndroidConfig {
                     priority: "high".to_string(),
                 }),
@@ -904,7 +927,7 @@ mod tests {
 
         let request = FcmRequest {
             message: FcmMessage {
-                token: "device-token-123".to_string(),
+                token: "device-token-123",
                 android: Some(AndroidConfig {
                     priority: "high".to_string(),
                 }),
@@ -952,7 +975,7 @@ mod tests {
 
         let request = FcmRequest {
             message: FcmMessage {
-                token: "invalid-token".to_string(),
+                token: "invalid-token",
                 android: None,
                 data: None,
             },
@@ -1000,7 +1023,7 @@ mod tests {
 
         let request = FcmRequest {
             message: FcmMessage {
-                token: "unregistered-token".to_string(),
+                token: "unregistered-token",
                 android: None,
                 data: None,
             },
@@ -1455,7 +1478,7 @@ mod tests {
 
         let request = FcmRequest {
             message: FcmMessage {
-                token: "any-token".to_string(),
+                token: "any-token",
                 android: None,
                 data: None,
             },
@@ -1615,7 +1638,7 @@ mod tests {
 
         let request = FcmRequest {
             message: FcmMessage {
-                token: "any-token".to_string(),
+                token: "any-token",
                 android: None,
                 data: None,
             },
@@ -1717,7 +1740,7 @@ mod tests {
 
         let request = FcmRequest {
             message: FcmMessage {
-                token: "any-token".to_string(),
+                token: "any-token",
                 android: None,
                 data: None,
             },
@@ -1831,7 +1854,7 @@ mod tests {
     fn test_fcm_message_without_android() {
         let request = FcmRequest {
             message: FcmMessage {
-                token: "test-token".to_string(),
+                token: "test-token",
                 android: None,
                 data: None,
             },
@@ -1846,7 +1869,7 @@ mod tests {
     fn test_fcm_message_with_empty_data() {
         let request = FcmRequest {
             message: FcmMessage {
-                token: "test-token".to_string(),
+                token: "test-token",
                 android: Some(AndroidConfig {
                     priority: "high".to_string(),
                 }),
@@ -1979,7 +2002,9 @@ mod tests {
             });
         }
 
-        let result = client.send("test-device-token", None).await;
+        let result = client
+            .send(zeroizing_token("test-device-token"), None)
+            .await;
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("No project ID"));
     }
@@ -1994,7 +2019,9 @@ mod tests {
 
         let client = FcmClient::mock(config, false);
 
-        let result = client.send("test-device-token", None).await;
+        let result = client
+            .send(zeroizing_token("test-device-token"), None)
+            .await;
         assert!(result.is_err());
         assert!(
             result
@@ -2015,7 +2042,9 @@ mod tests {
         let mut client = FcmClient::mock(config, true);
         client.service_account.as_mut().unwrap().project_id = "x/../../admin/v1".to_string();
 
-        let result = client.send("test-device-token", None).await;
+        let result = client
+            .send(zeroizing_token("test-device-token"), None)
+            .await;
         assert!(result.is_err());
         assert!(
             result
@@ -2036,7 +2065,9 @@ mod tests {
         // Client without service account - will fail to get access token
         let client = FcmClient::mock(config, false);
 
-        let result = client.send("test-device-token", None).await;
+        let result = client
+            .send(zeroizing_token("test-device-token"), None)
+            .await;
         assert!(result.is_err());
         assert!(
             result
@@ -2101,7 +2132,7 @@ mod tests {
 
         let request = FcmRequest {
             message: FcmMessage {
-                token: "device-token-123".to_string(),
+                token: "device-token-123",
                 android: None,
                 data: None,
             },
@@ -2143,7 +2174,7 @@ mod tests {
 
         let request = FcmRequest {
             message: FcmMessage {
-                token: "device-token-123".to_string(),
+                token: "device-token-123",
                 android: None,
                 data: None,
             },
@@ -2184,7 +2215,7 @@ mod tests {
 
         let request = FcmRequest {
             message: FcmMessage {
-                token: "device-token-123".to_string(),
+                token: "device-token-123",
                 android: None,
                 data: None,
             },
@@ -2242,7 +2273,7 @@ mod tests {
 
         let request = FcmRequest {
             message: FcmMessage {
-                token: "device-token-123".to_string(),
+                token: "device-token-123",
                 android: None,
                 data: None,
             },
@@ -2329,18 +2360,27 @@ mod tests {
         };
         let client = FcmClient::mock(config, false);
 
-        assert!(!client.send("", None).await.unwrap(), "empty token");
         assert!(
-            !client.send("token with space", None).await.unwrap(),
+            !client.send(zeroizing_token(""), None).await.unwrap(),
+            "empty token"
+        );
+        assert!(
+            !client
+                .send(zeroizing_token("token with space"), None)
+                .await
+                .unwrap(),
             "whitespace token"
         );
         assert!(
-            !client.send("tokén-with-unicode", None).await.unwrap(),
+            !client
+                .send(zeroizing_token("tokén-with-unicode"), None)
+                .await
+                .unwrap(),
             "unicode token"
         );
         assert!(
             !client
-                .send(&"a".repeat(MAX_FCM_TOKEN_LEN + 1), None)
+                .send(Zeroizing::new("a".repeat(MAX_FCM_TOKEN_LEN + 1)), None)
                 .await
                 .unwrap(),
             "overlong token"

--- a/src/test_vectors.rs
+++ b/src/test_vectors.rs
@@ -470,8 +470,8 @@ mod tests {
 
         assert_eq!(payload.platform, crate::crypto::Platform::Fcm);
         assert_eq!(
-            payload.device_token_string(),
-            Some("test-fcm-device-token-12345".to_string())
+            payload.device_token_string().as_ref().map(|s| s.as_str()),
+            Some("test-fcm-device-token-12345")
         );
     }
 
@@ -584,6 +584,6 @@ mod tests {
         // Decrypt token
         let payload = token_decryptor.decrypt_bytes(&token_bytes[0]).unwrap();
         assert_eq!(payload.platform, crate::crypto::Platform::Apns);
-        assert_eq!(payload.device_token_hex(), device_token_hex);
+        assert_eq!(payload.device_token_hex().as_str(), device_token_hex);
     }
 }


### PR DESCRIPTION
## Summary
- Return `TokenPayload::device_token_hex` and `device_token_string` as `Zeroizing<String>`.
- Move dispatcher-to-client APNs/FCM sends to carry the owned `Zeroizing<String>` token instead of unwrapping it at the queue boundary.
- Wrap the APNs device-token URL buffer in `Zeroizing<String>` and serialize FCM request tokens from the borrowed zeroizing buffer instead of copying them into a plain `String`.

## Test Plan
- `RUSTFLAGS='-Dwarnings' cargo test test_device_token -- --nocapture`
- `RUSTFLAGS='-Dwarnings' cargo test fcm_request_borrows_device_token_from_zeroizing_string -- --nocapture`
- `RUSTFLAGS='-Dwarnings' cargo fmt --all -- --check`
- `RUSTFLAGS='-Dwarnings' cargo check --all-targets`
- `RUSTFLAGS='-Dwarnings' cargo clippy --all-targets -- -D warnings`
- `RUSTFLAGS='-Dwarnings' cargo test --all-targets`
- `./scripts/cargo-audit.sh` (passed with 3 repo-allowed warnings)
- `RUSTFLAGS='-Dwarnings' cargo check --all-targets --features tor`
- `RUSTFLAGS='-Dwarnings' cargo test --all-targets --features tor`
- `RUSTDOCFLAGS='-Dwarnings' cargo doc --no-deps --document-private-items`

Fixes #94


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/transponder/pull/205">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->