### PR TITLE
fix: make rate-limit rollback reservation-aware

### DIFF
--- a/src/nostr/events.rs
+++ b/src/nostr/events.rs
@@ -802,6 +802,9 @@ impl EventProcessor {
                 }
                 continue;
             }
+            let encrypted_reservation = encrypted_result
+                .reservation()
+                .expect("allowed encrypted-token admission must carry a reservation");
 
             // Decrypt the token
             let decrypt_started_at = StageTimer::start();
@@ -848,11 +851,19 @@ impl EventProcessor {
                 }
                 continue;
             }
+            let device_reservation = device_result
+                .reservation()
+                .expect("allowed device-token admission must carry a reservation");
 
             payloads.push(payload);
             // Keep this paired with `payloads`: dispatch admission failure
             // rolls back exactly the rate-limit increments for admitted work.
-            admitted_rate_limit_keys.push((encrypted_key, device_key));
+            admitted_rate_limit_keys.push((
+                encrypted_key,
+                encrypted_reservation,
+                device_key,
+                device_reservation,
+            ));
         }
 
         if payloads.is_empty() {
@@ -876,12 +887,14 @@ impl EventProcessor {
                 Ok(count)
             }
             Err(e) => {
-                for (encrypted_key, device_key) in &admitted_rate_limit_keys {
+                for (encrypted_key, encrypted_reservation, device_key, device_reservation) in
+                    &admitted_rate_limit_keys
+                {
                     self.encrypted_token_limiter
-                        .rollback_increment(encrypted_key)
+                        .rollback_increment(encrypted_key, *encrypted_reservation)
                         .await;
                     self.device_token_limiter
-                        .rollback_increment(device_key)
+                        .rollback_increment(device_key, *device_reservation)
                         .await;
                 }
 

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -6,6 +6,7 @@
 use std::collections::VecDeque;
 use std::hash::Hash;
 use std::num::NonZeroUsize;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use lru::LruCache;
@@ -40,11 +41,18 @@ pub const DEFAULT_GLOBAL_UNWRAP_LIMIT_PER_HOUR: u32 = 30_000;
 /// Maximum entries to scan per cleanup cycle.
 const CLEANUP_BATCH_SIZE: usize = 1000;
 
+/// Token identifying one admitted hit for identity-aware rollback.
+///
+/// IDs are unique within a limiter instance, including across entry eviction and
+/// recreation, so a delayed rollback cannot remove a newer hit for the same key.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RateLimitReservation(u64);
+
 /// Result of a rate limit check.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RateLimitResult {
     /// Request is allowed.
-    Allowed,
+    Allowed(RateLimitReservation),
     /// Exceeded per-minute limit.
     ExceededMinuteLimit,
     /// Exceeded per-hour limit.
@@ -57,17 +65,26 @@ impl RateLimitResult {
     /// Returns `true` if the request was allowed.
     #[must_use]
     pub fn is_allowed(self) -> bool {
-        matches!(self, Self::Allowed)
+        matches!(self, Self::Allowed(_))
     }
 
     /// Returns the reason string for metrics/logging (if rate limited).
     #[must_use]
     pub fn limit_reason(self) -> Option<&'static str> {
         match self {
-            Self::Allowed => None,
+            Self::Allowed(_) => None,
             Self::ExceededMinuteLimit => Some("minute"),
             Self::ExceededHourLimit => Some("hour"),
             Self::ExceededCapacityLimit => Some("capacity"),
+        }
+    }
+
+    /// Returns the reservation for an allowed request.
+    #[must_use]
+    pub fn reservation(self) -> Option<RateLimitReservation> {
+        match self {
+            Self::Allowed(reservation) => Some(reservation),
+            _ => None,
         }
     }
 }
@@ -75,8 +92,8 @@ impl RateLimitResult {
 /// Entry tracking rate limit counters for a single key.
 #[derive(Debug, Clone)]
 struct RateLimitEntry {
-    minute_hits: VecDeque<Instant>,
-    hour_hits: VecDeque<Instant>,
+    minute_hits: VecDeque<(Instant, u64)>,
+    hour_hits: VecDeque<(Instant, u64)>,
 }
 
 impl RateLimitEntry {
@@ -102,12 +119,12 @@ impl RateLimitEntry {
     }
 }
 
-fn prune_hits(hits: &mut VecDeque<Instant>, now: Instant, window: Duration) {
+fn prune_hits(hits: &mut VecDeque<(Instant, u64)>, now: Instant, window: Duration) {
     let old_len = hits.len();
 
     while hits
         .front()
-        .is_some_and(|hit| now.duration_since(*hit) >= window)
+        .is_some_and(|(hit, _)| now.duration_since(*hit) >= window)
     {
         hits.pop_front();
     }
@@ -159,19 +176,18 @@ impl Default for RateLimitConfig {
 
 /// Sliding-window rate limiter with per-minute and per-hour limits.
 ///
-/// Each active entry stores admitted request timestamps for true sliding-window
-/// enforcement, so memory scales with the number of admitted hits per key. With
-/// the defaults, a hot key can hold up to roughly 5,240 `Instant` values across
-/// the minute and hour windows before older hits are pruned.
+/// Each active entry stores admitted request hit records for true
+/// sliding-window enforcement, so memory scales with the number of admitted hits
+/// per key. With the defaults, a hot key can hold up to roughly 5,240 records
+/// across the minute and hour windows before older hits are pruned.
 ///
 /// The aggregate bound is the per-key bound multiplied by the configured cache
-/// size: `max_entries * (max_per_minute + max_per_hour)` timestamp values per
+/// size: `max_entries * (max_per_minute + max_per_hour)` hit records per
 /// limiter. With the default 100,000-key cache and 240/minute plus 5,000/hour
-/// limits, one fully saturated limiter can retain roughly 524,000,000 `Instant`
-/// values before pruning (about 8.4 GB at 16 bytes per timestamp, before
-/// `VecDeque` overhead). Production event processing owns separate encrypted-
-/// token and device-token limiters, so size `max_entries` and process memory for
-/// both caches.
+/// limits, one fully saturated limiter can retain roughly 524,000,000 records
+/// before pruning. Production event processing owns separate encrypted-token and
+/// device-token limiters, so size `max_entries` and process memory for both
+/// caches.
 ///
 /// Uses a bounded cache to limit tracked key cardinality. When the cache is
 /// full, admission first evicts the least-recently-used stale entry; if none is
@@ -183,6 +199,7 @@ pub struct RateLimiter<K: Hash + Eq + Clone + Send + Sync + 'static> {
     entries: RwLock<LruCache<K, RateLimitEntry>>,
     max_per_minute: u32,
     max_per_hour: u32,
+    next_hit_id: AtomicU64,
 }
 
 impl<K: Hash + Eq + Clone + Send + Sync + 'static> RateLimiter<K> {
@@ -195,6 +212,7 @@ impl<K: Hash + Eq + Clone + Send + Sync + 'static> RateLimiter<K> {
             entries: RwLock::new(LruCache::new(size)),
             max_per_minute: config.max_per_minute,
             max_per_hour: config.max_per_hour,
+            next_hit_id: AtomicU64::new(0),
         }
     }
 
@@ -275,23 +293,27 @@ impl<K: Hash + Eq + Clone + Send + Sync + 'static> RateLimiter<K> {
         }
 
         // Increment counters
-        entry.minute_hits.push_back(now);
-        entry.hour_hits.push_back(now);
+        let hit_id = self.next_hit_id.fetch_add(1, Ordering::Relaxed);
+        entry.minute_hits.push_back((now, hit_id));
+        entry.hour_hits.push_back((now, hit_id));
 
-        RateLimitResult::Allowed
+        RateLimitResult::Allowed(RateLimitReservation(hit_id))
     }
 
     /// Rolls back one previously allowed increment for a key.
     ///
     /// This is used when downstream admission fails after a rate-limit check
-    /// has already reserved capacity for work that will not run. If both
-    /// counters reach zero, the entry is removed so the failed admission leaves
-    /// no window-start trace for the next real request.
-    pub async fn rollback_increment(&self, key: &K) {
+    /// has already reserved capacity for work that will not run. The
+    /// [`RateLimitReservation`] returned by [`Self::check_and_increment`] must
+    /// be passed so concurrent admits for the same key cannot remove another
+    /// task's hit. If both counters reach zero, the entry is removed so the
+    /// failed admission leaves no window-start trace for the next real request.
+    pub async fn rollback_increment(&self, key: &K, reservation: RateLimitReservation) {
+        let hit_id = reservation.0;
         let mut entries = self.entries.write().await;
         let should_remove = if let Some(entry) = entries.get_mut(key) {
-            entry.minute_hits.pop_back();
-            entry.hour_hits.pop_back();
+            remove_hit(&mut entry.minute_hits, hit_id);
+            remove_hit(&mut entry.hour_hits, hit_id);
             entry.minute_hits.is_empty() && entry.hour_hits.is_empty()
         } else {
             false
@@ -319,7 +341,7 @@ impl<K: Hash + Eq + Clone + Send + Sync + 'static> RateLimiter<K> {
             .rev()
             .take(CLEANUP_BATCH_SIZE)
             .filter(|(_, entry)| match entry.hour_hits.back() {
-                Some(hit) => now.duration_since(*hit) >= hour,
+                Some((hit, _)) => now.duration_since(*hit) >= hour,
                 None => true,
             })
             .map(|(k, _)| k.clone())
@@ -351,6 +373,12 @@ impl<K: Hash + Eq + Clone + Send + Sync + 'static> RateLimiter<K> {
     }
 }
 
+fn remove_hit(hits: &mut VecDeque<(Instant, u64)>, hit_id: u64) {
+    if let Some(pos) = hits.iter().position(|(_, id)| *id == hit_id) {
+        hits.remove(pos);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -364,10 +392,7 @@ mod tests {
         });
 
         for _ in 0..10 {
-            assert_eq!(
-                limiter.check_and_increment(&1u64).await,
-                RateLimitResult::Allowed
-            );
+            assert!(limiter.check_and_increment(&1u64).await.is_allowed());
         }
     }
 
@@ -400,13 +425,60 @@ mod tests {
             max_entries: 100,
         });
 
-        assert!(limiter.check_and_increment(&1u64).await.is_allowed());
+        let reservation = limiter
+            .check_and_increment(&1u64)
+            .await
+            .reservation()
+            .expect("first admit");
         assert!(!limiter.check_and_increment(&1u64).await.is_allowed());
 
-        limiter.rollback_increment(&1u64).await;
+        limiter.rollback_increment(&1u64, reservation).await;
 
         assert_eq!(limiter.len().await, 0);
         assert!(limiter.check_and_increment(&1u64).await.is_allowed());
+    }
+
+    #[tokio::test]
+    async fn test_rollback_increment_removes_only_reserved_hit() {
+        let limiter: RateLimiter<u64> = RateLimiter::new(RateLimitConfig {
+            max_per_minute: 10,
+            max_per_hour: 100,
+            max_entries: 100,
+        });
+
+        let first = limiter
+            .check_and_increment(&1u64)
+            .await
+            .reservation()
+            .expect("first admit");
+        assert!(limiter.check_and_increment(&1u64).await.is_allowed());
+
+        limiter.rollback_increment(&1u64, first).await;
+
+        assert_eq!(limiter.peek_counts(&1u64).await, Some((1, 1)));
+    }
+
+    #[tokio::test]
+    async fn test_rollback_increment_ignores_recreated_entry_with_same_key() {
+        let limiter: RateLimiter<u64> = RateLimiter::new(RateLimitConfig {
+            max_per_minute: 10,
+            max_per_hour: 100,
+            max_entries: 1,
+        });
+
+        let first = limiter
+            .check_and_increment(&1u64)
+            .await
+            .reservation()
+            .expect("first admit");
+
+        assert!(limiter.check_and_increment(&2u64).await.is_allowed());
+        assert_eq!(limiter.peek_counts(&1u64).await, None);
+
+        assert!(limiter.check_and_increment(&1u64).await.is_allowed());
+        limiter.rollback_increment(&1u64, first).await;
+
+        assert_eq!(limiter.peek_counts(&1u64).await, Some((1, 1)));
     }
 
     #[tokio::test]
@@ -608,10 +680,7 @@ mod tests {
         limiter.check_and_increment(&3u64).await;
         assert_eq!(limiter.len().await, 3);
 
-        assert_eq!(
-            limiter.check_and_increment(&4u64).await,
-            RateLimitResult::Allowed
-        );
+        assert!(limiter.check_and_increment(&4u64).await.is_allowed());
         assert_eq!(limiter.len().await, 3);
         assert_eq!(limiter.peek_counts(&1u64).await, None);
         assert_eq!(limiter.peek_counts(&2u64).await, Some((1, 1)));
@@ -625,11 +694,11 @@ mod tests {
             .checked_sub(Duration::from_secs(3601))
             .expect("test instant should support one-hour subtraction");
         let mut below_limit_entry = RateLimitEntry::new();
-        below_limit_entry.minute_hits.push_back(now);
-        below_limit_entry.hour_hits.push_back(now);
+        below_limit_entry.minute_hits.push_back((now, 0));
+        below_limit_entry.hour_hits.push_back((now, 0));
         let mut stale_entry = RateLimitEntry::new();
-        stale_entry.minute_hits.push_back(stale_hit);
-        stale_entry.hour_hits.push_back(stale_hit);
+        stale_entry.minute_hits.push_back((stale_hit, 1));
+        stale_entry.hour_hits.push_back((stale_hit, 1));
 
         let mut entries = LruCache::new(NonZeroUsize::new(3).expect("non-zero test capacity"));
         entries.put(1u64, below_limit_entry);
@@ -666,10 +735,7 @@ mod tests {
         tokio::time::advance(Duration::from_secs(3601)).await;
 
         let new_key = CLEANUP_BATCH_SIZE as u64 + 1;
-        assert_eq!(
-            limiter.check_and_increment(&new_key).await,
-            RateLimitResult::Allowed
-        );
+        assert!(limiter.check_and_increment(&new_key).await.is_allowed());
 
         assert_eq!(limiter.len().await, CLEANUP_BATCH_SIZE + 1);
         assert_eq!(limiter.peek_counts(&0u64).await, None);
@@ -709,19 +775,13 @@ mod tests {
             max_entries: 2,
         });
 
-        assert_eq!(
-            limiter.check_and_increment(&1u64).await,
-            RateLimitResult::Allowed
-        );
+        assert!(limiter.check_and_increment(&1u64).await.is_allowed());
         assert_eq!(
             limiter.check_and_increment(&1u64).await,
             RateLimitResult::ExceededMinuteLimit
         );
 
-        assert_eq!(
-            limiter.check_and_increment(&2u64).await,
-            RateLimitResult::Allowed
-        );
+        assert!(limiter.check_and_increment(&2u64).await.is_allowed());
         assert!(!limiter.check_and_increment(&3u64).await.is_allowed());
 
         assert_eq!(
@@ -732,12 +792,15 @@ mod tests {
 
     #[tokio::test]
     async fn test_result_helpers() {
-        assert!(RateLimitResult::Allowed.is_allowed());
+        assert!(RateLimitResult::Allowed(RateLimitReservation(0)).is_allowed());
         assert!(!RateLimitResult::ExceededMinuteLimit.is_allowed());
         assert!(!RateLimitResult::ExceededHourLimit.is_allowed());
         assert!(!RateLimitResult::ExceededCapacityLimit.is_allowed());
 
-        assert_eq!(RateLimitResult::Allowed.limit_reason(), None);
+        assert_eq!(
+            RateLimitResult::Allowed(RateLimitReservation(0)).limit_reason(),
+            None
+        );
         assert_eq!(
             RateLimitResult::ExceededMinuteLimit.limit_reason(),
             Some("minute")


### PR DESCRIPTION
Fixes #87

## Summary
- Made rate-limit rollback identity-aware by returning a `RateLimitReservation` from successful `check_and_increment` calls.
- `rollback_increment` now removes the exact reserved hit from both sliding windows instead of popping the newest hit.
- Updated event processing to store encrypted-token and device-token reservations for dispatch-admission rollback.
- Added regressions for concurrent same-key rollback and delayed rollback after cache eviction/recreation.

## Verification
- `cargo fmt --all -- --check`
- `cargo test rollback_increment`
- `cargo check --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets` (459 unit tests + 4 integration tests)
- `cargo check --all-targets --features tor`
- `cargo test --all-targets --features tor` (460 unit tests + 4 integration tests)
- `cargo doc --no-deps --document-private-items`
- `./scripts/cargo-audit.sh` (passed with 3 allowed warnings: RUSTSEC-2026-0190, RUSTSEC-2026-0186, RUSTSEC-2026-0097)

## Sensitive paths
- `src/rate_limiter.rs` — rate-limit accounting correctness under concurrency.

## Notes
- `src/nostr/events.rs` changed only to carry the reservation token needed for precise rollback.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/transponder/pull/206">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->