### PR TITLE
fix: surface rate-limit admission evictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,8 +432,11 @@ Transponder exposes Prometheus metrics at `/metrics` on the health server port (
 | `transponder_tokens_rate_limited_total` | Counter | `type`, `reason` | Tokens skipped due to rate limiting |
 | `transponder_rate_limit_cache_size` | Gauge | `type` | Current rate limit cache size in tracked keys, not stored timestamps |
 | `transponder_rate_limit_evictions_total` | Counter | `type` | Stale rate limit entries removed during cleanup |
+| `transponder_rate_limit_admission_evictions_total` | Counter | `type` | Rate limit entries evicted on the admission hot path to admit a new key |
 
 Label values: `type` = `encrypted_token` or `device_token`; `reason` = `minute`, `hour`, or `capacity`
+
+Under cache pressure, below-limit keys may be evicted to admit new keys. That resets their sliding-window hit counts (a precision trade-off, not a bypass); monitor `transponder_rate_limit_admission_evictions_total` and `transponder_tokens_rate_limited_total{reason="capacity"}` to size `max_rate_limit_cache_size`.
 
 `outcome` values vary by metric group:
 - Event processing: `processed`, `duplicate`, `failed`

--- a/config/default.toml
+++ b/config/default.toml
@@ -45,7 +45,8 @@ shutdown_timeout_secs = 10
 # are max_rate_limit_cache_size * (per_minute + per_hour), or ~524M Instant
 # values with the defaults (~8.4 GB at 16 B/timestamp before overhead).
 # Transponder has two such limiters.
-# Unknown keys are rate limited at capacity until cleanup removes stale entries.
+# At capacity, new keys evict stale or below-limit entries when possible.
+# If no safe eviction candidate exists, the new key is rate limited.
 # Default: 100000 entries per cache
 # max_rate_limit_cache_size = 100000
 

--- a/config/production.toml.example
+++ b/config/production.toml.example
@@ -30,7 +30,8 @@ dedup_state_path = "/var/lib/transponder/dedup-events.log"
 # timestamps per limiter are max_rate_limit_cache_size * (per_minute + per_hour),
 # or ~524M Instant values with the defaults (~8.4 GB at 16 B/timestamp before
 # overhead); Transponder has two limiters.
-# Unknown rate-limit keys are rejected at capacity until stale entries are cleaned up.
+# At capacity, new keys evict stale or below-limit entries when possible.
+# If no safe eviction candidate exists, the new key is rate limited.
 # max_rate_limit_cache_size = 100000
 # max_tokens_per_event = 100
 # encrypted_token_rate_limit_per_minute = 240

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -25,7 +25,7 @@ Why these numbers make sense today:
 - the event deduplication and rate-limit caches default to 100,000 entries each
 - production deployments persist a small replay-suppression log containing only public gift-wrap event IDs and processing timestamps
 - rate-limit cache entries retain admitted-hit timestamps for sliding-window precision; worst-case timestamp storage is `max_rate_limit_cache_size × (per_minute + per_hour)` per limiter (about 8.4 GB at 16 bytes per timestamp with the defaults, before `VecDeque` overhead), and Transponder runs separate encrypted-token and device-token limiters
-- new rate-limit keys are rejected at capacity, so size these caches with headroom for legitimate unique devices, adversarial noise, and process memory limits
+- under cache pressure, new rate-limit keys evict stale or below-limit entries when possible; if no safe victim exists they are rate limited, so size these caches with headroom and monitor `transponder_rate_limit_admission_evictions_total` plus `transponder_tokens_rate_limited_total{reason="capacity"}`
 - Tor adds noticeable memory and connection-management overhead, which is why the default build leaves it disabled
 
 If you need to run on a smaller VM, lower the cache sizes in `config/production.toml`.

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -74,6 +74,9 @@ pub struct Metrics {
     /// Total number of entries evicted from rate limit caches (by type).
     pub rate_limit_evictions_total: IntCounterVec,
 
+    /// Total number of entries evicted during admission when caches are at capacity.
+    pub rate_limit_admission_evictions_total: IntCounterVec,
+
     /// Total number of tokens successfully decrypted.
     pub tokens_decrypted_total: IntCounter,
 
@@ -345,11 +348,20 @@ impl Metrics {
         let rate_limit_evictions_total = IntCounterVec::new(
             Opts::new(
                 "transponder_rate_limit_evictions_total",
-                "Total number of entries evicted from rate limit caches",
+                "Total number of stale rate limit entries removed during cleanup",
             ),
             &["type"],
         )?;
         registry.register(Box::new(rate_limit_evictions_total.clone()))?;
+
+        let rate_limit_admission_evictions_total = IntCounterVec::new(
+            Opts::new(
+                "transponder_rate_limit_admission_evictions_total",
+                "Total number of rate limit entries evicted on the admission hot path to admit a new key",
+            ),
+            &["type"],
+        )?;
+        registry.register(Box::new(rate_limit_admission_evictions_total.clone()))?;
 
         let tokens_decrypted_total = IntCounter::with_opts(Opts::new(
             "transponder_tokens_decrypted_total",
@@ -565,6 +577,7 @@ impl Metrics {
             tokens_rate_limited_total,
             rate_limit_cache_size,
             rate_limit_evictions_total,
+            rate_limit_admission_evictions_total,
             tokens_decrypted_total,
             tokens_decryption_failed_total,
             token_decrypt_duration_seconds,
@@ -703,7 +716,7 @@ impl Metrics {
     /// Record a rate limited token.
     ///
     /// `cache_type` should be "encrypted_token" or "device_token".
-    /// `reason` should be "minute" or "hour".
+    /// `reason` should be "minute", "hour", or "capacity".
     pub fn record_rate_limited(&self, cache_type: &str, reason: Option<&str>) {
         self.tokens_rate_limited_total
             .with_label_values(&[cache_type, reason.unwrap_or("unknown")])
@@ -719,13 +732,22 @@ impl Metrics {
             .set(size as i64);
     }
 
-    /// Record rate limit cache evictions.
+    /// Record rate limit cache evictions during cleanup.
     ///
     /// `cache_type` should be "encrypted_token" or "device_token".
     pub fn record_rate_limit_evictions(&self, cache_type: &str, count: usize) {
         self.rate_limit_evictions_total
             .with_label_values(&[cache_type])
             .inc_by(count as u64);
+    }
+
+    /// Record a single admission-path rate limit cache eviction.
+    ///
+    /// `cache_type` should be "encrypted_token" or "device_token".
+    pub fn record_rate_limit_admission_eviction(&self, cache_type: &str) {
+        self.rate_limit_admission_evictions_total
+            .with_label_values(&[cache_type])
+            .inc();
     }
 
     /// Record a successful token decryption.
@@ -1358,5 +1380,40 @@ mod tests {
 
         assert_eq!(encrypted_evictions, 125);
         assert_eq!(device_evictions, 50);
+    }
+
+    #[test]
+    fn test_rate_limit_admission_evictions_metric_registered() {
+        let metrics = Metrics::new().unwrap();
+
+        metrics.record_rate_limit_admission_eviction("encrypted_token");
+        metrics.record_rate_limit_admission_eviction("device_token");
+
+        let families = metrics.registry.gather();
+        let admission_evictions = families
+            .iter()
+            .find(|f| f.name() == "transponder_rate_limit_admission_evictions_total");
+        assert!(admission_evictions.is_some());
+    }
+
+    #[test]
+    fn test_record_rate_limit_admission_evictions() {
+        let metrics = Metrics::new().unwrap();
+
+        metrics.record_rate_limit_admission_eviction("encrypted_token");
+        metrics.record_rate_limit_admission_eviction("encrypted_token");
+        metrics.record_rate_limit_admission_eviction("device_token");
+
+        let encrypted = metrics
+            .rate_limit_admission_evictions_total
+            .with_label_values(&["encrypted_token"])
+            .get();
+        let device = metrics
+            .rate_limit_admission_evictions_total
+            .with_label_values(&["device_token"])
+            .get();
+
+        assert_eq!(encrypted, 2);
+        assert_eq!(device, 1);
     }
 }

--- a/src/nostr/events.rs
+++ b/src/nostr/events.rs
@@ -792,6 +792,11 @@ impl EventProcessor {
                 .encrypted_token_limiter
                 .check_and_increment(&encrypted_key)
                 .await;
+            if encrypted_result.admission_evicted()
+                && let Some(ref m) = self.metrics
+            {
+                m.record_rate_limit_admission_eviction("encrypted_token");
+            }
             if !encrypted_result.is_allowed() {
                 trace!(
                     reason = encrypted_result.limit_reason(),
@@ -838,6 +843,11 @@ impl EventProcessor {
                 .device_token_limiter
                 .check_and_increment(&device_key)
                 .await;
+            if device_result.admission_evicted()
+                && let Some(ref m) = self.metrics
+            {
+                m.record_rate_limit_admission_eviction("device_token");
+            }
             if !device_result.is_allowed() {
                 trace!(
                     reason = device_result.limit_reason(),
@@ -2807,6 +2817,94 @@ mod tests {
         assert!(processor.process(&event3).await.unwrap());
         assert_eq!(
             counter_value(&metrics, "transponder_events_shed_total", &[]),
+            1.0
+        );
+    }
+
+    #[tokio::test]
+    async fn test_admission_path_eviction_records_metric() {
+        let server_keys = Keys::generate();
+        let sender_keys = Keys::generate();
+        let device_token = "aabbccdd11223344aabbccdd11223344aabbccdd11223344aabbccdd11223344";
+
+        let (processor, metrics) = create_processor_with_metrics_and_rate_limits(
+            &server_keys,
+            TokenRateLimitConfig {
+                max_cache_size: 3,
+                max_tokens_per_event: DEFAULT_MAX_TOKENS_PER_EVENT,
+                encrypted_token_per_minute: 100,
+                encrypted_token_per_hour: 1000,
+                device_token_per_minute: 100,
+                device_token_per_hour: 1000,
+                global_unwrap_per_minute: 1000,
+                global_unwrap_per_hour: 10000,
+            },
+        );
+
+        for _ in 0..3 {
+            let event =
+                scenarios::single_apns_notification(&server_keys, &sender_keys, device_token).await;
+            assert!(processor.process(&event).await.unwrap());
+        }
+
+        let event =
+            scenarios::single_apns_notification(&server_keys, &sender_keys, device_token).await;
+        assert!(processor.process(&event).await.unwrap());
+
+        assert_eq!(
+            counter_value(
+                &metrics,
+                "transponder_rate_limit_admission_evictions_total",
+                &[("type", "encrypted_token")],
+            ),
+            1.0
+        );
+        assert_eq!(
+            counter_value(
+                &metrics,
+                "transponder_rate_limit_admission_evictions_total",
+                &[("type", "device_token")],
+            ),
+            0.0
+        );
+    }
+
+    #[tokio::test]
+    async fn test_capacity_limit_records_metric() {
+        let server_keys = Keys::generate();
+        let sender_keys = Keys::generate();
+        let device_token = "aabbccdd11223344aabbccdd11223344aabbccdd11223344aabbccdd11223344";
+
+        let (processor, metrics) = create_processor_with_metrics_and_rate_limits(
+            &server_keys,
+            TokenRateLimitConfig {
+                max_cache_size: 3,
+                max_tokens_per_event: DEFAULT_MAX_TOKENS_PER_EVENT,
+                encrypted_token_per_minute: 1,
+                encrypted_token_per_hour: 100,
+                device_token_per_minute: 100,
+                device_token_per_hour: 1000,
+                global_unwrap_per_minute: 1000,
+                global_unwrap_per_hour: 10000,
+            },
+        );
+
+        for _ in 0..3 {
+            let event =
+                scenarios::single_apns_notification(&server_keys, &sender_keys, device_token).await;
+            assert!(processor.process(&event).await.unwrap());
+        }
+
+        let event =
+            scenarios::single_apns_notification(&server_keys, &sender_keys, device_token).await;
+        assert!(processor.process(&event).await.unwrap());
+
+        assert_eq!(
+            counter_value(
+                &metrics,
+                "transponder_tokens_rate_limited_total",
+                &[("type", "encrypted_token"), ("reason", "capacity")],
+            ),
             1.0
         );
     }

--- a/src/nostr/events.rs
+++ b/src/nostr/events.rs
@@ -3164,9 +3164,11 @@ mod tests {
             assert!(processor.process(&event).await.unwrap());
         }
 
+        // The sole token is shed by the capacity limit, so the event is a
+        // retryable rate-limit shed (returns false, not marked seen).
         let event =
             scenarios::single_apns_notification(&server_keys, &sender_keys, device_token).await;
-        assert!(processor.process(&event).await.unwrap());
+        assert!(!processor.process(&event).await.unwrap());
 
         assert_eq!(
             counter_value(

--- a/src/push/fcm.rs
+++ b/src/push/fcm.rs
@@ -2691,7 +2691,7 @@ LTP/MQIxLydQxT4+jx2NBu0=
         client.test_oauth_token_url = Some(mock_server.uri());
         client.test_fcm_api_base_url = Some(mock_server.uri());
 
-        let result = client.send("device-token-123", None).await;
+        let result = client.send(zeroizing_token("device-token-123"), None).await;
         assert!(
             result.is_ok(),
             "expected success after OAuth retry: {result:?}"
@@ -2716,7 +2716,7 @@ LTP/MQIxLydQxT4+jx2NBu0=
         client.test_oauth_token_url = Some(mock_server.uri());
         client.test_fcm_api_base_url = Some(mock_server.uri());
 
-        let result = client.send("device-token-123", None).await;
+        let result = client.send(zeroizing_token("device-token-123"), None).await;
         assert!(result.is_err(), "expected permanent OAuth failure");
         let message = result.unwrap_err().to_string();
         assert!(message.contains("OAuth token request failed"));

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -86,6 +86,12 @@ impl RateLimitCheck {
     pub fn admission_evicted(self) -> bool {
         self.admission_evicted
     }
+
+    /// Returns the reservation for an allowed request.
+    #[must_use]
+    pub fn reservation(self) -> Option<RateLimitReservation> {
+        self.result.reservation()
+    }
 }
 
 impl PartialEq<RateLimitResult> for RateLimitCheck {
@@ -728,12 +734,12 @@ mod tests {
 
         for key in 1..=3 {
             let check = limiter.check_and_increment(&key).await;
-            assert_eq!(check, RateLimitResult::Allowed);
+            assert!(check.is_allowed());
             assert!(!check.admission_evicted());
         }
 
         let check = limiter.check_and_increment(&4u64).await;
-        assert_eq!(check, RateLimitResult::Allowed);
+        assert!(check.is_allowed());
         assert!(check.admission_evicted());
     }
 
@@ -746,10 +752,7 @@ mod tests {
         });
 
         for key in 1..=3 {
-            assert_eq!(
-                limiter.check_and_increment(&key).await,
-                RateLimitResult::Allowed
-            );
+            assert!(limiter.check_and_increment(&key).await.is_allowed());
         }
 
         let check = limiter.check_and_increment(&4u64).await;

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -53,6 +53,39 @@ pub enum RateLimitResult {
     ExceededCapacityLimit,
 }
 
+/// Outcome of [`RateLimiter::check_and_increment`], including admission side effects.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RateLimitCheck {
+    result: RateLimitResult,
+    admission_evicted: bool,
+}
+
+impl RateLimitCheck {
+    /// Returns `true` if the request was allowed.
+    #[must_use]
+    pub fn is_allowed(self) -> bool {
+        self.result.is_allowed()
+    }
+
+    /// Returns the reason string for metrics/logging (if rate limited).
+    #[must_use]
+    pub fn limit_reason(self) -> Option<&'static str> {
+        self.result.limit_reason()
+    }
+
+    /// Returns `true` when a stale or below-limit entry was evicted to admit a new key.
+    #[must_use]
+    pub fn admission_evicted(self) -> bool {
+        self.admission_evicted
+    }
+}
+
+impl PartialEq<RateLimitResult> for RateLimitCheck {
+    fn eq(&self, other: &RateLimitResult) -> bool {
+        self.result == *other
+    }
+}
+
 impl RateLimitResult {
     /// Returns `true` if the request was allowed.
     #[must_use]
@@ -178,7 +211,10 @@ impl Default for RateLimitConfig {
 /// found in the bounded scan window, it falls back to a least-recently-used
 /// still-unlimited entry. This favors availability for legitimate new tokens
 /// over perfect accounting for below-limit keys under active cache pressure,
-/// while preserving counters for keys already at their rate limit.
+/// while preserving counters for keys already at their rate limit. Evicting a
+/// below-limit key resets its accumulated sliding-window hits; that weakens
+/// per-key precision but does not bypass limits because the global unwrap
+/// limiter still bounds total admission.
 pub struct RateLimiter<K: Hash + Eq + Clone + Send + Sync + 'static> {
     entries: RwLock<LruCache<K, RateLimitEntry>>,
     max_per_minute: u32,
@@ -237,9 +273,10 @@ impl<K: Hash + Eq + Clone + Send + Sync + 'static> RateLimiter<K> {
     /// - `ExceededHourLimit` if per-hour limit is reached
     /// - `ExceededCapacityLimit` if the cache is full and has no safe eviction
     ///   victim for the unknown key
-    pub async fn check_and_increment(&self, key: &K) -> RateLimitResult {
+    pub async fn check_and_increment(&self, key: &K) -> RateLimitCheck {
         let now = Instant::now();
         let mut entries = self.entries.write().await;
+        let mut admission_evicted = false;
 
         // Get or create entry (updates access position). At capacity, admit an
         // unknown key by evicting an old stale or still-unlimited entry. Entries
@@ -248,15 +285,20 @@ impl<K: Hash + Eq + Clone + Send + Sync + 'static> RateLimiter<K> {
         let entry = if let Some(entry) = entries.get_mut(key) {
             entry
         } else {
-            if entries.len() >= entries.cap().get()
-                && !Self::evict_lru_admission_candidate(
+            if entries.len() >= entries.cap().get() {
+                if Self::evict_lru_admission_candidate(
                     &mut entries,
                     now,
                     self.max_per_minute,
                     self.max_per_hour,
-                )
-            {
-                return RateLimitResult::ExceededCapacityLimit;
+                ) {
+                    admission_evicted = true;
+                } else {
+                    return RateLimitCheck {
+                        result: RateLimitResult::ExceededCapacityLimit,
+                        admission_evicted: false,
+                    };
+                }
             }
             entries.put(key.clone(), RateLimitEntry::new());
             entries.get_mut(key).expect("just inserted")
@@ -266,19 +308,28 @@ impl<K: Hash + Eq + Clone + Send + Sync + 'static> RateLimiter<K> {
 
         // Check minute limit first (more likely to be hit)
         if entry.minute_hits.len() >= self.max_per_minute as usize {
-            return RateLimitResult::ExceededMinuteLimit;
+            return RateLimitCheck {
+                result: RateLimitResult::ExceededMinuteLimit,
+                admission_evicted,
+            };
         }
 
         // Check hour limit
         if entry.hour_hits.len() >= self.max_per_hour as usize {
-            return RateLimitResult::ExceededHourLimit;
+            return RateLimitCheck {
+                result: RateLimitResult::ExceededHourLimit,
+                admission_evicted,
+            };
         }
 
         // Increment counters
         entry.minute_hits.push_back(now);
         entry.hour_hits.push_back(now);
 
-        RateLimitResult::Allowed
+        RateLimitCheck {
+            result: RateLimitResult::Allowed,
+            admission_evicted,
+        }
     }
 
     /// Rolls back one previously allowed increment for a key.
@@ -593,6 +644,45 @@ mod tests {
         let stats = limiter.cleanup().await;
         assert_eq!(stats.evicted, CLEANUP_BATCH_SIZE);
         assert_eq!(stats.remaining, 1);
+    }
+
+    #[tokio::test]
+    async fn test_admission_eviction_reports_side_effect() {
+        let limiter: RateLimiter<u64> = RateLimiter::new(RateLimitConfig {
+            max_per_minute: 10,
+            max_per_hour: 100,
+            max_entries: 3,
+        });
+
+        for key in 1..=3 {
+            let check = limiter.check_and_increment(&key).await;
+            assert_eq!(check, RateLimitResult::Allowed);
+            assert!(!check.admission_evicted());
+        }
+
+        let check = limiter.check_and_increment(&4u64).await;
+        assert_eq!(check, RateLimitResult::Allowed);
+        assert!(check.admission_evicted());
+    }
+
+    #[tokio::test]
+    async fn test_capacity_limit_does_not_report_admission_eviction() {
+        let limiter: RateLimiter<u64> = RateLimiter::new(RateLimitConfig {
+            max_per_minute: 1,
+            max_per_hour: 100,
+            max_entries: 3,
+        });
+
+        for key in 1..=3 {
+            assert_eq!(
+                limiter.check_and_increment(&key).await,
+                RateLimitResult::Allowed
+            );
+        }
+
+        let check = limiter.check_and_increment(&4u64).await;
+        assert_eq!(check, RateLimitResult::ExceededCapacityLimit);
+        assert!(!check.admission_evicted());
     }
 
     #[tokio::test]


### PR DESCRIPTION
Fixes #81

## Summary
- Added `transponder_rate_limit_admission_evictions_total{type}` to expose rate-limiter admission-path evictions separately from timer cleanup evictions.
- `RateLimiter::check_and_increment` now reports whether an admission eviction happened; event processing records it for `encrypted_token` and `device_token` caches.
- Reused the existing `transponder_tokens_rate_limited_total{type,reason="capacity"}` series for `ExceededCapacityLimit` outcomes and added regression coverage.
- Documented the cache-pressure availability-vs-precision trade-off in `src/rate_limiter.rs` and README metrics docs.

## Verification
- `cargo fmt --all -- --check`
- `RUSTFLAGS=-Dwarnings cargo check --all-targets`
- `RUSTFLAGS=-Dwarnings cargo clippy --all-targets -- -D warnings`
- `RUSTFLAGS=-Dwarnings cargo test --all-targets` (463 passed + doc tests)
- `RUSTFLAGS=-Dwarnings cargo check --all-targets --features tor`
- `RUSTFLAGS=-Dwarnings cargo test --all-targets --features tor` (464 passed + doc tests)
- `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --document-private-items`
- `./scripts/cargo-audit.sh` (passed; 3 allowed warnings)

## Sensitive paths
- `src/rate_limiter.rs` — rate-limit / DoS-resistance hot path.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/transponder/pull/210">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->