### PR TITLE
fix: distinguish push retry exhaustion

### DIFF
--- a/src/push/apns.rs
+++ b/src/push/apns.rs
@@ -507,6 +507,9 @@ impl ApnsClient {
                 }
             }
             _ => {
+                // Unknown statuses are provider/protocol errors, not evidence
+                // that the device token is dead. Keep them out of the
+                // invalid-token path so operators do not prune live tokens.
                 warn!(
                     payload_mode = %self.config.payload_mode,
                     status = %status,

--- a/src/push/apns.rs
+++ b/src/push/apns.rs
@@ -15,7 +15,7 @@ use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 use crate::config::{ApnsConfig, ApnsPayloadMode};
 use crate::error::{Error, Result};
 use crate::metrics::Metrics;
-use crate::push::retry::{self, RetryConfig, SendAttemptResult};
+use crate::push::retry::{self, PushSendOutcome, RetryConfig, SendAttemptResult};
 
 /// APNs JWT token lifetime (50 minutes, less than the 1 hour max).
 const TOKEN_LIFETIME: Duration = Duration::from_secs(50 * 60);
@@ -161,7 +161,7 @@ struct ApnsErrorResponse {
 #[derive(Debug, PartialEq, Eq)]
 enum Apns400Classification {
     /// The provider explicitly identified the device token as invalid for this
-    /// app; the token should be treated as dead (`Success(false)`).
+    /// app; the token should be treated as dead.
     TokenDead,
     /// A configuration or request-construction error that is permanent for this
     /// provider but unrelated to the device token; must surface as an error
@@ -320,11 +320,12 @@ impl ApnsClient {
 
     /// Send a silent push notification to a device.
     ///
-    /// Returns `Ok(true)` if successful, `Ok(false)` if the token is invalid/expired,
+    /// Returns [`PushSendOutcome::Sent`] if APNs accepted the notification,
+    /// [`PushSendOutcome::InvalidToken`] if the token is invalid/expired,
     /// or `Err` for other failures.
     ///
-    /// This method automatically retries transient failures (429, 5xx) with
-    /// exponential backoff.
+    /// This method automatically retries transient failures (408, 429, 5xx)
+    /// with exponential backoff.
     ///
     /// When `backoff_permit` is `Some`, the dispatcher concurrency permit is
     /// released during backoff sleeps and re-acquired before each retry, so a
@@ -333,14 +334,14 @@ impl ApnsClient {
         &self,
         device_token: &str,
         backoff_permit: Option<&mut crate::push::retry::BackoffPermit>,
-    ) -> Result<bool> {
+    ) -> Result<PushSendOutcome> {
         // Validate token format before sending
         if !is_valid_device_token(device_token) {
             trace!(
                 token_len = device_token.len(),
                 "Invalid APNs device token format"
             );
-            return Ok(false);
+            return Ok(PushSendOutcome::InvalidToken);
         }
 
         let retry_config = RetryConfig::default();
@@ -458,6 +459,19 @@ impl ApnsClient {
                     error.reason
                 )))
             }
+            408 => {
+                // Request timeout - retriable. Honor Retry-After if present.
+                let retry_after = retry::retry_after_from_headers(response.headers());
+                debug!(
+                    payload_mode = %self.config.payload_mode,
+                    status = %status,
+                    "APNs request timeout (retriable)"
+                );
+                SendAttemptResult::Retriable {
+                    status_code: 408,
+                    retry_after,
+                }
+            }
             410 => {
                 // Token is no longer valid (device unregistered)
                 debug!(
@@ -493,12 +507,14 @@ impl ApnsClient {
                 }
             }
             _ => {
-                debug!(
+                warn!(
                     payload_mode = %self.config.payload_mode,
                     status = %status,
                     "APNs unexpected response"
                 );
-                SendAttemptResult::Success(false)
+                SendAttemptResult::Permanent(Error::Apns(format!(
+                    "Unexpected APNs response status: {status}"
+                )))
             }
         }
     }
@@ -807,9 +823,10 @@ mod tests {
 
         // Test with a token that contains non-hex characters
         let result = client.send("tooshort", None).await.unwrap();
-        assert!(
-            !result,
-            "Should return false for token with non-hex characters"
+        assert_eq!(
+            result,
+            PushSendOutcome::InvalidToken,
+            "Should return invalid-token outcome for token with non-hex characters"
         );
 
         // Test with token that has invalid characters
@@ -820,14 +837,19 @@ mod tests {
             )
             .await
             .unwrap();
-        assert!(
-            !result,
-            "Should return false for token with invalid characters"
+        assert_eq!(
+            result,
+            PushSendOutcome::InvalidToken,
+            "Should return invalid-token outcome for token with invalid characters"
         );
 
         // Test with empty token
         let result = client.send("", None).await.unwrap();
-        assert!(!result, "Should return false for empty token");
+        assert_eq!(
+            result,
+            PushSendOutcome::InvalidToken,
+            "Should return invalid-token outcome for empty token"
+        );
     }
 
     #[tokio::test]
@@ -1099,7 +1121,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_handle_response_400_bad_device_token_is_token_dead() {
-        // BadDeviceToken must continue to signal token death (Ok(false)).
+        // BadDeviceToken must continue to signal token death.
         let result = apns_400_result("BadDeviceToken").await;
         assert!(matches!(result, SendAttemptResult::Success(false)));
     }
@@ -1195,6 +1217,29 @@ mod tests {
                 status_code: 429,
                 retry_after: Some(delay),
             } if delay == Duration::from_secs(30)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_handle_response_408_is_retriable() {
+        let result = apns_status_result(408, None).await;
+        assert!(matches!(
+            result,
+            SendAttemptResult::Retriable {
+                status_code: 408,
+                retry_after: None,
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_handle_response_unexpected_status_is_permanent_error() {
+        let result = apns_status_result(404, None).await;
+        assert!(matches!(
+            result,
+            SendAttemptResult::Permanent(Error::Apns(ref message))
+                if message.contains("Unexpected APNs response status")
+                    && message.contains("404")
         ));
     }
 

--- a/src/push/dispatcher.rs
+++ b/src/push/dispatcher.rs
@@ -650,6 +650,14 @@ mod tests {
         ) as u64
     }
 
+    fn push_success_metric_value(metrics: &crate::metrics::Metrics, platform: &str) -> u64 {
+        metric_counter_value(
+            metrics,
+            "transponder_push_success_total",
+            &[("platform", platform)],
+        ) as u64
+    }
+
     #[tokio::test]
     async fn send_push_records_invalid_token_metrics() {
         use crate::config::{ApnsConfig, FcmConfig};
@@ -718,6 +726,7 @@ mod tests {
             PushSendOutcome::RetriesExhausted,
             &metrics_opt,
         );
+        PushDispatcher::record_send_outcome("FCM", "fcm", PushSendOutcome::Sent, &metrics_opt);
 
         assert_eq!(
             push_failed_metric_value(&metrics, "apns", "invalid_token"),
@@ -727,6 +736,7 @@ mod tests {
             push_failed_metric_value(&metrics, "apns", "retries_exhausted"),
             1
         );
+        assert_eq!(push_success_metric_value(&metrics, "fcm"), 1);
     }
 
     #[tokio::test]

--- a/src/push/dispatcher.rs
+++ b/src/push/dispatcher.rs
@@ -28,6 +28,7 @@ use zeroize::Zeroizing;
 use crate::crypto::{Platform, TokenPayload};
 use crate::error::{Error, Result};
 use crate::metrics::Metrics;
+use crate::push::retry::PushSendOutcome;
 use crate::push::{ApnsClient, FcmClient};
 
 /// Maximum concurrent outbound push requests.
@@ -232,6 +233,40 @@ impl PushDispatcher {
         Ok(permit)
     }
 
+    fn record_send_outcome(
+        service_name: &str,
+        platform_str: &str,
+        outcome: PushSendOutcome,
+        metrics: &Option<Metrics>,
+    ) {
+        match outcome {
+            PushSendOutcome::Sent => {
+                trace!(service = service_name, "push notification sent");
+                if let Some(m) = metrics {
+                    m.record_push_success(platform_str);
+                }
+            }
+            PushSendOutcome::InvalidToken => {
+                trace!(
+                    service = service_name,
+                    "push notification failed (invalid token)"
+                );
+                if let Some(m) = metrics {
+                    m.record_push_failed(platform_str, "invalid_token");
+                }
+            }
+            PushSendOutcome::RetriesExhausted => {
+                trace!(
+                    service = service_name,
+                    "push notification failed (retries exhausted)"
+                );
+                if let Some(m) = metrics {
+                    m.record_push_failed(platform_str, "retries_exhausted");
+                }
+            }
+        }
+    }
+
     async fn send_push(
         platform: Platform,
         token: Zeroizing<String>,
@@ -249,17 +284,8 @@ impl PushDispatcher {
             Platform::Apns => {
                 if let Some(client) = apns_client {
                     match client.send(token.as_str(), backoff_permit).await {
-                        Ok(true) => {
-                            trace!("APNs notification sent");
-                            if let Some(ref m) = metrics {
-                                m.record_push_success(platform_str);
-                            }
-                        }
-                        Ok(false) => {
-                            trace!("APNs notification failed (invalid token)");
-                            if let Some(ref m) = metrics {
-                                m.record_push_failed(platform_str, "invalid_token");
-                            }
+                        Ok(outcome) => {
+                            Self::record_send_outcome("APNs", platform_str, outcome, &metrics);
                         }
                         Err(e) => {
                             debug!(error = %e, "APNs send error");
@@ -273,17 +299,8 @@ impl PushDispatcher {
             Platform::Fcm => {
                 if let Some(client) = fcm_client {
                     match client.send(token.as_str(), backoff_permit).await {
-                        Ok(true) => {
-                            trace!("FCM notification sent");
-                            if let Some(ref m) = metrics {
-                                m.record_push_success(platform_str);
-                            }
-                        }
-                        Ok(false) => {
-                            trace!("FCM notification failed (invalid token)");
-                            if let Some(ref m) = metrics {
-                                m.record_push_failed(platform_str, "invalid_token");
-                            }
+                        Ok(outcome) => {
+                            Self::record_send_outcome("FCM", platform_str, outcome, &metrics);
                         }
                         Err(e) => {
                             debug!(error = %e, "FCM send error");
@@ -621,6 +638,18 @@ mod tests {
         (0..count).map(|_| apns_test_payload()).collect()
     }
 
+    fn push_failed_metric_value(
+        metrics: &crate::metrics::Metrics,
+        platform: &str,
+        reason: &str,
+    ) -> u64 {
+        metric_counter_value(
+            metrics,
+            "transponder_push_failed_total",
+            &[("platform", platform), ("reason", reason)],
+        ) as u64
+    }
+
     #[tokio::test]
     async fn send_push_records_invalid_token_metrics() {
         use crate::config::{ApnsConfig, FcmConfig};
@@ -663,20 +692,40 @@ mod tests {
         .await;
 
         assert_eq!(
-            metric_counter_value(
-                &metrics,
-                "transponder_push_failed_total",
-                &[("platform", "apns"), ("reason", "invalid_token")]
-            ),
-            1.0
+            push_failed_metric_value(&metrics, "apns", "invalid_token"),
+            1
         );
         assert_eq!(
-            metric_counter_value(
-                &metrics,
-                "transponder_push_failed_total",
-                &[("platform", "fcm"), ("reason", "invalid_token")]
-            ),
-            1.0
+            push_failed_metric_value(&metrics, "fcm", "invalid_token"),
+            1
+        );
+    }
+
+    #[test]
+    fn test_send_outcome_metrics_distinguish_invalid_token_and_retries_exhausted() {
+        let metrics = crate::metrics::Metrics::default();
+        let metrics_opt = Some(metrics.clone());
+
+        PushDispatcher::record_send_outcome(
+            "APNs",
+            "apns",
+            PushSendOutcome::InvalidToken,
+            &metrics_opt,
+        );
+        PushDispatcher::record_send_outcome(
+            "APNs",
+            "apns",
+            PushSendOutcome::RetriesExhausted,
+            &metrics_opt,
+        );
+
+        assert_eq!(
+            push_failed_metric_value(&metrics, "apns", "invalid_token"),
+            1
+        );
+        assert_eq!(
+            push_failed_metric_value(&metrics, "apns", "retries_exhausted"),
+            1
         );
     }
 
@@ -1553,7 +1602,7 @@ mod tests {
                 None,
             )
             .await;
-            assert!(matches!(result, Ok(true)));
+            assert!(matches!(result, Ok(PushSendOutcome::Sent)));
         });
 
         // Let the task reach its backoff sleep (first attempt + release of permit).

--- a/src/push/fcm.rs
+++ b/src/push/fcm.rs
@@ -16,7 +16,7 @@ use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 use crate::config::FcmConfig;
 use crate::error::{Error, Result};
 use crate::metrics::Metrics;
-use crate::push::retry::{self, RetryConfig, SendAttemptResult};
+use crate::push::retry::{self, PushSendOutcome, RetryConfig, SendAttemptResult};
 
 /// FCM OAuth2 token endpoint.
 const OAUTH_TOKEN_URL: &str = "https://oauth2.googleapis.com/token";
@@ -156,7 +156,7 @@ struct FcmErrorDetail {
 #[derive(Debug, PartialEq, Eq)]
 enum FcmClassification {
     /// The provider explicitly reported the token as unregistered; the token
-    /// should be treated as dead (`Success(false)`).
+    /// should be treated as dead.
     TokenDead,
     /// A configuration, payload, or path error that is permanent for this
     /// provider but unrelated to the device token; must surface as an error
@@ -375,11 +375,12 @@ impl FcmClient {
 
     /// Send a silent push notification to a device.
     ///
-    /// Returns `Ok(true)` if successful, `Ok(false)` if the token is invalid/expired,
+    /// Returns [`PushSendOutcome::Sent`] if FCM accepted the notification,
+    /// [`PushSendOutcome::InvalidToken`] if the token is invalid/expired,
     /// or `Err` for other failures.
     ///
-    /// This method automatically retries transient failures (429, 5xx) with
-    /// exponential backoff.
+    /// This method automatically retries transient failures (408, 429, 5xx)
+    /// with exponential backoff.
     ///
     /// When `backoff_permit` is `Some`, the dispatcher concurrency permit is
     /// released during backoff sleeps and re-acquired before each retry, so a
@@ -388,7 +389,7 @@ impl FcmClient {
         &self,
         device_token: &str,
         backoff_permit: Option<&mut crate::push::retry::BackoffPermit>,
-    ) -> Result<bool> {
+    ) -> Result<PushSendOutcome> {
         // Validate token format before spending an OAuth-authenticated round-trip
         // and FCM quota on a clearly-malformed token (mirrors APNs).
         if !is_valid_fcm_token(device_token) {
@@ -396,7 +397,7 @@ impl FcmClient {
                 token_len = device_token.len(),
                 "Invalid FCM device token format"
             );
-            return Ok(false);
+            return Ok(PushSendOutcome::InvalidToken);
         }
 
         let retry_config = RetryConfig::default();
@@ -556,6 +557,15 @@ impl FcmClient {
             404 => {
                 self.classify_error_response(response, 404, "NOT_FOUND")
                     .await
+            }
+            408 => {
+                // Request timeout - retriable. Honor Retry-After if present.
+                let retry_after = retry::retry_after_from_headers(response.headers());
+                debug!(status = %status, "FCM request timeout (retriable)");
+                SendAttemptResult::Retriable {
+                    status_code: 408,
+                    retry_after,
+                }
             }
             429 => {
                 // Rate limited - retriable
@@ -1259,6 +1269,18 @@ mod tests {
             result,
             SendAttemptResult::Retriable {
                 status_code: 500,
+                retry_after: None,
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_handle_response_408_is_retriable() {
+        let result = fcm_status_result(408, None).await;
+        assert!(matches!(
+            result,
+            SendAttemptResult::Retriable {
+                status_code: 408,
                 retry_after: None,
             }
         ));
@@ -2321,7 +2343,7 @@ mod tests {
     async fn test_send_rejects_invalid_token_without_oauth() {
         // A client with no service account / encoding key would error on the
         // OAuth round-trip if it ever reached it. Invalid tokens must instead
-        // short-circuit to Ok(false) before any auth lookup or request build.
+        // short-circuit to InvalidToken before any auth lookup or request build.
         let config = FcmConfig {
             enabled: true,
             service_account_path: String::new(),
@@ -2329,20 +2351,27 @@ mod tests {
         };
         let client = FcmClient::mock(config, false);
 
-        assert!(!client.send("", None).await.unwrap(), "empty token");
-        assert!(
-            !client.send("token with space", None).await.unwrap(),
+        assert_eq!(
+            client.send("", None).await.unwrap(),
+            PushSendOutcome::InvalidToken,
+            "empty token"
+        );
+        assert_eq!(
+            client.send("token with space", None).await.unwrap(),
+            PushSendOutcome::InvalidToken,
             "whitespace token"
         );
-        assert!(
-            !client.send("tokén-with-unicode", None).await.unwrap(),
+        assert_eq!(
+            client.send("tokén-with-unicode", None).await.unwrap(),
+            PushSendOutcome::InvalidToken,
             "unicode token"
         );
-        assert!(
-            !client
+        assert_eq!(
+            client
                 .send(&"a".repeat(MAX_FCM_TOKEN_LEN + 1), None)
                 .await
                 .unwrap(),
+            PushSendOutcome::InvalidToken,
             "overlong token"
         );
     }

--- a/src/push/fcm.rs
+++ b/src/push/fcm.rs
@@ -587,6 +587,9 @@ impl FcmClient {
                 }
             }
             _ => {
+                // Unknown statuses are provider/protocol errors, not evidence
+                // that the device token is dead. Keep them out of the
+                // invalid-token path so operators do not prune live tokens.
                 warn!(status = %status, "FCM unexpected response");
                 SendAttemptResult::Permanent(Error::Fcm(format!(
                     "Unexpected FCM response status: {status}"

--- a/src/push/retry.rs
+++ b/src/push/retry.rs
@@ -107,10 +107,22 @@ impl RetryConfig {
     }
 }
 
+/// Final outcome of a push send operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PushSendOutcome {
+    /// The push provider accepted the notification.
+    Sent,
+    /// The provider or local validation identified a dead/invalid device token.
+    InvalidToken,
+    /// A transient provider failure consumed the bounded retry budget.
+    RetriesExhausted,
+}
+
 /// Result of a single send attempt.
 #[derive(Debug)]
 pub enum SendAttemptResult {
-    /// Request succeeded.
+    /// Request reached a terminal non-error state (`true` = sent,
+    /// `false` = invalid token).
     Success(bool),
     /// Transient error that should be retried (429, 5xx).
     Retriable {
@@ -132,7 +144,8 @@ pub enum SendAttemptResult {
 /// for the duration of each backoff sleep and re-acquired before the next
 /// attempt. This keeps sleeping retries from occupying in-flight concurrency
 /// slots. If re-acquisition fails because the semaphore was closed (shutdown),
-/// the retry loop is aborted and `Ok(false)` is returned (the request is shed).
+/// the retry loop is aborted and returns [`PushSendOutcome::RetriesExhausted`]
+/// so the request is not mislabeled as an invalid token.
 #[must_use = "retry result indicates success/failure and should not be ignored"]
 pub async fn with_retry<F, Fut>(
     config: &RetryConfig,
@@ -140,7 +153,7 @@ pub async fn with_retry<F, Fut>(
     mut operation: F,
     backoff_permit: Option<&mut BackoffPermit>,
     metrics: Option<&Metrics>,
-) -> crate::error::Result<bool>
+) -> crate::error::Result<PushSendOutcome>
 where
     F: FnMut() -> Fut,
     Fut: std::future::Future<Output = SendAttemptResult>,
@@ -152,7 +165,8 @@ where
 
     loop {
         match operation().await {
-            SendAttemptResult::Success(result) => return Ok(result),
+            SendAttemptResult::Success(true) => return Ok(PushSendOutcome::Sent),
+            SendAttemptResult::Success(false) => return Ok(PushSendOutcome::InvalidToken),
             SendAttemptResult::Retriable {
                 status_code,
                 retry_after,
@@ -183,8 +197,9 @@ where
                     permit.update_available_metric(metrics);
                     sleep(wait_duration).await;
                     if permit.reacquire().await.is_err() {
-                        // Semaphore closed (shutdown): shed this request.
-                        return Ok(false);
+                        // Semaphore closed (shutdown): shed this request without
+                        // classifying it as a dead device token.
+                        return Ok(PushSendOutcome::RetriesExhausted);
                     }
                     permit.update_available_metric(metrics);
                 } else {
@@ -201,7 +216,7 @@ where
                     retries = retries,
                     "Max retries exceeded for push notification"
                 );
-                return Ok(false);
+                return Ok(PushSendOutcome::RetriesExhausted);
             }
             SendAttemptResult::Permanent(e) => return Err(e),
         }
@@ -503,7 +518,7 @@ mod tests {
         .await;
 
         assert!(result.is_ok());
-        assert!(result.unwrap());
+        assert_eq!(result.unwrap(), PushSendOutcome::Sent);
         assert_eq!(attempt_count.load(Ordering::SeqCst), 1);
     }
 
@@ -539,7 +554,7 @@ mod tests {
         .await;
 
         assert!(result.is_ok());
-        assert!(result.unwrap());
+        assert_eq!(result.unwrap(), PushSendOutcome::Sent);
         assert_eq!(attempt_count.load(Ordering::SeqCst), 3);
     }
 
@@ -571,7 +586,7 @@ mod tests {
         .await;
 
         assert!(result.is_ok());
-        assert!(!result.unwrap()); // Returns false when max retries exceeded
+        assert_eq!(result.unwrap(), PushSendOutcome::RetriesExhausted);
         // Initial attempt + max_retries = 1 + 2 = 3
         assert_eq!(attempt_count.load(Ordering::SeqCst), 3);
     }
@@ -699,7 +714,7 @@ mod tests {
             result.is_ok(),
             "fallback backoff was advanced by Retry-After retries"
         );
-        assert!(result.unwrap().unwrap());
+        assert_eq!(result.unwrap().unwrap(), PushSendOutcome::Sent);
         assert_eq!(attempt_count.load(Ordering::SeqCst), 5);
     }
 
@@ -717,7 +732,7 @@ mod tests {
         .await;
 
         assert!(result.is_ok());
-        assert!(!result.unwrap());
+        assert_eq!(result.unwrap(), PushSendOutcome::InvalidToken);
     }
 
     #[tokio::test]
@@ -755,7 +770,7 @@ mod tests {
         .await;
 
         assert!(result.is_ok());
-        assert!(result.unwrap());
+        assert_eq!(result.unwrap(), PushSendOutcome::Sent);
         assert_eq!(attempt_count.load(Ordering::SeqCst), 2);
 
         // Verify metrics were recorded - gather metrics and check they're non-empty
@@ -816,7 +831,7 @@ mod tests {
 
         let result = task.await.unwrap();
         assert!(result.is_ok());
-        assert!(result.unwrap());
+        assert_eq!(result.unwrap(), PushSendOutcome::Sent);
         assert_eq!(attempt_count.load(Ordering::SeqCst), 2);
     }
 
@@ -909,7 +924,7 @@ mod tests {
             .expect("second attempt should still be waiting for test assertion");
         let result = task.await.unwrap();
         assert!(result.is_ok());
-        assert!(result.unwrap());
+        assert_eq!(result.unwrap(), PushSendOutcome::Sent);
         assert_eq!(attempt_count.load(Ordering::SeqCst), 2);
     }
 


### PR DESCRIPTION
## Summary
- Return a `PushSendOutcome` from APNs/FCM send paths so the dispatcher can distinguish sent, invalid-token, and retry-exhausted outcomes.
- Record retry exhaustion as `transponder_push_failed_total{reason="retries_exhausted"}` instead of `invalid_token`.
- Treat APNs/FCM `408 Request Timeout` as retriable and surface unexpected APNs/FCM non-retriable statuses as provider/protocol errors rather than token death; only explicit provider token-death signals reach `invalid_token`.

Fixes #90

## Test plan
- Address-review follow-up: documented the unknown-status provider-error policy and added a direct `PushSendOutcome::Sent` metric assertion.
- `cargo fmt --all -- --check`
- `RUSTFLAGS='-Dwarnings' cargo check --all-targets`
- `RUSTFLAGS='-Dwarnings' cargo test --all-targets`
- `RUSTFLAGS='-Dwarnings' cargo clippy --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-Dwarnings' cargo doc --no-deps --document-private-items`
- `./scripts/cargo-audit.sh`
- `RUSTFLAGS='-Dwarnings' cargo check --all-targets --features tor`
- `RUSTFLAGS='-Dwarnings' cargo test --all-targets --features tor`


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/transponder/pull/213">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->
