### PR TITLE
fix: repair master build after #205/#209 semantic merge conflict

### DIFF
--- a/src/push/fcm.rs
+++ b/src/push/fcm.rs
@@ -2691,7 +2691,7 @@ LTP/MQIxLydQxT4+jx2NBu0=
         client.test_oauth_token_url = Some(mock_server.uri());
         client.test_fcm_api_base_url = Some(mock_server.uri());
 
-        let result = client.send("device-token-123", None).await;
+        let result = client.send(zeroizing_token("device-token-123"), None).await;
         assert!(
             result.is_ok(),
             "expected success after OAuth retry: {result:?}"
@@ -2716,7 +2716,7 @@ LTP/MQIxLydQxT4+jx2NBu0=
         client.test_oauth_token_url = Some(mock_server.uri());
         client.test_fcm_api_base_url = Some(mock_server.uri());
 
-        let result = client.send("device-token-123", None).await;
+        let result = client.send(zeroizing_token("device-token-123"), None).await;
         assert!(result.is_err(), "expected permanent OAuth failure");
         let message = result.unwrap_err().to_string();
         assert!(message.contains("OAuth token request failed"));


### PR DESCRIPTION
PR #205 changed `FcmClient::send` to take `Zeroizing<String>`; PR #209 (written against the pre-#205 base) added two tests calling `send` with `&str`. Both merged cleanly textually, but master no longer compiles (`cargo check --all-targets` fails at src/push/fcm.rs:2694/2719). This converts the two call sites to the existing `zeroizing_token` helper. All 68 `push::fcm` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/transponder/pull/223">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated OAuth retry test coverage for FCM message sending to use a zeroizing device token.
  * Verified both transient and permanent OAuth failure behavior still matches expectations, including preserving the expected error message without exposing provider response details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->