### PR TITLE
fix: record shed events under their own histogram outcome

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -177,6 +177,10 @@ pub enum EventOutcome {
     /// Every token the event carried was shed by the per-token rate limiters,
     /// so no notification was admitted. Transient: the event stays retryable.
     RateLimited,
+    /// Event was shed by the global pre-unwrap admission limiter. Transient
+    /// back-pressure, not a failure: the event stays retryable and must not
+    /// inflate the `failed` bucket.
+    Shed,
 }
 
 impl EventOutcome {
@@ -187,6 +191,7 @@ impl EventOutcome {
             Self::Processed => "processed",
             Self::Duplicate => "duplicate",
             Self::RateLimited => "rate_limited",
+            Self::Shed => "shed",
         }
     }
 }

--- a/src/nostr/events.rs
+++ b/src/nostr/events.rs
@@ -640,10 +640,7 @@ impl EventProcessor {
             );
             if let Some(ref m) = self.metrics {
                 m.record_event_shed();
-                m.observe_event_processing_duration(
-                    EventOutcome::Failed,
-                    started_at.elapsed_secs(),
-                );
+                m.observe_event_processing_duration(EventOutcome::Shed, started_at.elapsed_secs());
             }
             return Ok(false);
         }
@@ -3006,6 +3003,25 @@ mod tests {
         assert_eq!(
             counter_value(&metrics, "transponder_events_shed_total", &[]),
             1.0
+        );
+
+        // The shed is recorded under its own duration-histogram outcome, not
+        // as a failure: back-pressure must not inflate the failed bucket.
+        assert_eq!(
+            histogram_count(
+                &metrics,
+                "transponder_event_processing_duration_seconds",
+                &[("outcome", EventOutcome::Shed.as_str())],
+            ),
+            1
+        );
+        assert_eq!(
+            histogram_count(
+                &metrics,
+                "transponder_event_processing_duration_seconds",
+                &[("outcome", EventOutcome::Failed.as_str())],
+            ),
+            0
         );
 
         // The shed event was NOT unwrapped: only `limit` unwraps were observed.


### PR DESCRIPTION
Fixes #152.

The global admission shed branch recorded `transponder_event_processing_duration_seconds` with `outcome="failed"`, inflating the failure bucket under healthy back-pressure. This adds an `EventOutcome::Shed` variant (label `shed`, mirroring #203's `rate_limited` outcome for the per-token path) and uses it in the shed branch. The flood-shed test now asserts the sample lands in `shed` and not `failed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/transponder/pull/224">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->