### PR TITLE
fix: record real received content size in notification_content_size_bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ Transponder exposes Prometheus metrics at `/metrics` on the health server port (
 | `transponder_gift_wrap_unwrap_duration_seconds` | Histogram | `outcome` | Duration of NIP-59 gift-wrap unwraps |
 | `transponder_notification_parse_duration_seconds` | Histogram | `outcome` | Duration of notification tag validation, base64 decode, and token splitting |
 | `transponder_tokens_per_event` | Histogram | - | Number of encrypted tokens carried by each parsed event |
-| `transponder_notification_content_size_bytes` | Histogram | - | Size in bytes of the base64-decoded encrypted token blob from kind 446 notification content |
+| `transponder_notification_content_size_bytes` | Histogram | - | Size in bytes of the raw base64 token content received in kind 446 notification requests |
 | `transponder_dedup_cache_size` | Gauge | - | Current deduplication cache size |
 | `transponder_dedup_cache_evictions_total` | Counter | - | Total dedup cache evictions |
 | `transponder_tokens_decrypted_total` | Counter | - | Total tokens successfully decrypted |

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -60,8 +60,8 @@ pub struct Metrics {
     /// Number of encrypted tokens carried by each parsed event.
     pub tokens_per_event: Histogram,
 
-    /// Size in bytes of the base64-decoded encrypted token blob from kind 446
-    /// notification content.
+    /// Size in bytes of the raw base64 token content received in kind 446
+    /// notification requests (as-received size, including encoding overhead).
     pub notification_content_size_bytes: Histogram,
 
     /// Current size of the deduplication cache.
@@ -324,7 +324,7 @@ impl Metrics {
         let notification_content_size_bytes = Histogram::with_opts(
             HistogramOpts::new(
                 "transponder_notification_content_size_bytes",
-                "Size in bytes of the base64-decoded encrypted token blob from kind 446 notification content",
+                "Size in bytes of the raw base64 token content received in kind 446 notification requests",
             )
             .buckets(NOTIFICATION_CONTENT_SIZE_BUCKETS.to_vec()),
         )?;

--- a/src/nostr/events.rs
+++ b/src/nostr/events.rs
@@ -21,7 +21,6 @@ use tokio::time::Instant;
 use tracing::{debug, info, trace, warn};
 
 use crate::crypto::nip59::DEFAULT_MAX_TOKENS_PER_EVENT;
-use crate::crypto::token::ENCRYPTED_TOKEN_SIZE;
 use crate::crypto::{Nip59Handler, TokenDecryptor, TokenPayload};
 use crate::error::{Error, Result};
 use crate::metrics::{EventOutcome, Metrics, OperationOutcome};
@@ -791,9 +790,7 @@ impl EventProcessor {
                         parse_started_at.elapsed_secs(),
                     );
                     m.observe_tokens_per_event(token_bytes.len());
-                    m.observe_notification_content_size_bytes(
-                        token_bytes.len() * ENCRYPTED_TOKEN_SIZE,
-                    );
+                    m.observe_notification_content_size_bytes(notification.content.len());
                 }
                 token_bytes
             }
@@ -1427,9 +1424,11 @@ mod tests {
             ),
             1
         );
+        // One encrypted token is 1084 bytes, transported as base64 text; the
+        // metric records the received content size, not a reconstruction.
         assert_eq!(
             histogram_sample_sum(&metrics, "transponder_notification_content_size_bytes", &[]),
-            ENCRYPTED_TOKEN_SIZE as f64
+            (ENCRYPTED_TOKEN_SIZE.div_ceil(3) * 4) as f64
         );
     }
 


### PR DESCRIPTION
Fixes #127.

On the success path the decoded blob length always equals `token_count × ENCRYPTED_TOKEN_SIZE` (the parser rejects non-multiples), so the metric was pure redundancy with `tokens_per_event`. It now records `notification.content.len()` — the as-received base64 size — which can actually surface encoding bloat and size anomalies. Metric help text and README updated; test updated to assert the base64-encoded size of one token (1448 bytes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/transponder/pull/225">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->