### PR TITLE
refactor: remove unreachable empty-token-bytes guard in process_inner

### DIFF
--- a/src/nostr/events.rs
+++ b/src/nostr/events.rs
@@ -808,10 +808,9 @@ impl EventProcessor {
             }
         };
 
-        if token_bytes.is_empty() {
-            return Ok(ProcessOutcome::Admitted(0));
-        }
-
+        // `parse_tokens_with_limit` rejects empty blobs with `InvalidToken`, so
+        // `token_bytes` is non-empty on the `Ok` path; the "nothing admitted"
+        // case is handled after the per-token loop.
         debug!(token_count = token_bytes.len(), "Decrypting tokens");
 
         // Decrypt each token and dispatch notifications, with rate limiting.


### PR DESCRIPTION
Fixes #178.

`parse_tokens_with_limit` rejects empty decoded blobs with `InvalidToken` (src/crypto/nip59.rs), so on the `Ok` path `token_bytes` always has length ≥ 1 and the `is_empty()` early-return was unreachable — dead defensive code implying an "empty-but-Ok" case that cannot occur. Removed and replaced with a comment naming the invariant; the "nothing admitted" case remains handled after the per-token loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/transponder/pull/226">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->