### PR TITLE
fix: complete NIP-59 unwrap validation

### DIFF
--- a/src/crypto/nip59.rs
+++ b/src/crypto/nip59.rs
@@ -3,7 +3,6 @@
 //! Implements the gift wrap protocol for extracting kind 446 notification requests
 //! from encrypted Nostr events.
 
-use nostr_sdk::nips::nip59::UnwrappedGift;
 use nostr_sdk::prelude::*;
 
 use crate::crypto::token::ENCRYPTED_TOKEN_SIZE;
@@ -19,6 +18,35 @@ const ENCODING_BASE64: &str = "base64";
 
 /// Default maximum number of encrypted tokens accepted in one notification event.
 pub const DEFAULT_MAX_TOKENS_PER_EVENT: usize = 100;
+
+/// Maximum number of characters of attacker-controlled tag content included in
+/// error messages.
+const MAX_TAG_VALUE_ERROR_CHARS: usize = 32;
+
+/// Maximum number of characters of a parse-error detail (which can embed
+/// attacker-controlled decrypted plaintext) included in error messages.
+const MAX_PARSE_ERROR_CHARS: usize = 128;
+
+/// Bound and escape attacker-controlled text before embedding it in an error
+/// message.
+///
+/// Errors from this module are logged verbatim (`warn!(error = %e, ...)` in
+/// the event processor), so any decrypted gift-wrap content that reaches an
+/// error string must be length-bounded and control-character-escaped to
+/// prevent log injection and log-volume amplification.
+fn sanitize_for_error(value: &str, max_chars: usize) -> String {
+    let mut chars = value.chars();
+    let mut sanitized = String::new();
+
+    for ch in chars.by_ref().take(max_chars) {
+        sanitized.extend(ch.escape_default());
+    }
+    if chars.next().is_some() {
+        sanitized.push_str("...");
+    }
+
+    sanitized
+}
 
 fn max_encoded_token_blob_len(max_tokens: usize) -> usize {
     max_tokens
@@ -48,15 +76,21 @@ impl Nip59Handler {
 
     /// Unwrap a gift-wrapped event and extract the notification request rumor.
     ///
+    /// The unwrap is performed manually with nostr-sdk primitives instead of
+    /// delegating to `UnwrappedGift::from_gift_wrap`, because the latter never
+    /// exposes (or validates) the seal kind. Every step below is enforced in
+    /// this function.
+    ///
     /// Process:
     /// 1. Verify the event is kind 1059 (gift wrap)
-    /// 2. Decrypt the gift wrap to get the seal
-    /// 3. Verify the seal is kind 13
-    /// 4. Decrypt the seal to get the rumor
-    /// 5. Verify the rumor is kind 446
-    /// 6. Return the rumor metadata and content
+    /// 2. Decrypt the gift wrap content (NIP-44) to get the seal event
+    /// 3. Verify the seal signature and that the seal is kind 13
+    /// 4. Decrypt the seal content (NIP-44) to get the rumor
+    /// 5. Verify the rumor author matches the seal signer (the rumor is
+    ///    unsigned, so its `pubkey` field is otherwise attacker-chosen)
+    /// 6. Verify the rumor is kind 446 and return its metadata and content
     pub async fn unwrap(&self, event: &Event) -> Result<UnwrappedNotification> {
-        // Verify this is a gift wrap event
+        // Step 1: verify this is a gift wrap event.
         if event.kind != Kind::GiftWrap {
             return Err(Error::Crypto(format!(
                 "Expected gift wrap (kind 1059), got kind {}",
@@ -64,20 +98,62 @@ impl Nip59Handler {
             )));
         }
 
-        // Decrypt the gift wrap to get the rumor (nostr-sdk handles seal internally)
-        let unwrapped = UnwrappedGift::from_gift_wrap(&self.keys, event)
+        // Step 2: decrypt the gift wrap content to get the seal event.
+        let seal_json = self
+            .keys
+            .nip44_decrypt(&event.pubkey, &event.content)
             .await
-            .map_err(|e| Error::Crypto(format!("Failed to extract rumor: {e}")))?;
+            .map_err(|e| Error::Crypto(format!("Failed to decrypt gift wrap: {e}")))?;
+        // Parse-error details can embed the (attacker-controlled) decrypted
+        // plaintext, so they are bounded and escaped before formatting.
+        let seal = Event::from_json(&seal_json).map_err(|e| {
+            Error::Crypto(format!(
+                "Failed to parse seal event: {}",
+                sanitize_for_error(&e.to_string(), MAX_PARSE_ERROR_CHARS)
+            ))
+        })?;
 
-        // Verify the rumor is kind 446 (notification request)
-        if unwrapped.rumor.kind.as_u16() != KIND_NOTIFICATION_REQUEST {
+        // Step 3: verify the seal signature, then the seal kind. nostr-sdk's
+        // `UnwrappedGift::from_gift_wrap` verifies the signature but not the
+        // kind; both are enforced here.
+        seal.verify()
+            .map_err(|e| Error::Crypto(format!("Invalid seal: {e}")))?;
+        if seal.kind != Kind::Seal {
             return Err(Error::Crypto(format!(
-                "Expected notification request (kind 446), got kind {}",
-                unwrapped.rumor.kind.as_u16()
+                "Expected seal (kind 13), got kind {}",
+                seal.kind.as_u16()
             )));
         }
 
-        let rumor = unwrapped.rumor;
+        // Step 4: decrypt the seal content to get the rumor.
+        let rumor_json = self
+            .keys
+            .nip44_decrypt(&seal.pubkey, &seal.content)
+            .await
+            .map_err(|e| Error::Crypto(format!("Failed to decrypt seal: {e}")))?;
+        let rumor = UnsignedEvent::from_json(&rumor_json).map_err(|e| {
+            Error::Crypto(format!(
+                "Failed to parse rumor: {}",
+                sanitize_for_error(&e.to_string(), MAX_PARSE_ERROR_CHARS)
+            ))
+        })?;
+
+        // Step 5: bind the rumor author to the seal signer. The rumor is
+        // unsigned, so its `pubkey` is attacker-chosen; the seal signer is the
+        // only authenticated identity in the wrap.
+        if rumor.pubkey != seal.pubkey {
+            return Err(Error::Crypto(
+                "Rumor author does not match seal signer".to_string(),
+            ));
+        }
+
+        // Step 6: verify the rumor is kind 446 (notification request).
+        if rumor.kind.as_u16() != KIND_NOTIFICATION_REQUEST {
+            return Err(Error::Crypto(format!(
+                "Expected notification request (kind 446), got kind {}",
+                rumor.kind.as_u16()
+            )));
+        }
 
         Ok(UnwrappedNotification {
             content: rumor.content,
@@ -99,8 +175,30 @@ pub struct UnwrappedNotification {
     pub created_at: Timestamp,
 }
 
+/// Whether a validated tag must be present on the rumor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TagPresence {
+    /// At least one tag with the given name must exist.
+    Required,
+    /// Zero tags with the given name is accepted.
+    Optional,
+}
+
 impl UnwrappedNotification {
-    fn require_tag_value(&self, tag_name: &str, expected_value: &str) -> Result<()> {
+    /// Validate every tag named `tag_name` against `expected_value`.
+    ///
+    /// Each present tag must carry exactly `expected_value`. When `presence`
+    /// is [`TagPresence::Required`], at least one such tag must exist; when
+    /// [`TagPresence::Optional`], the tag may be absent entirely.
+    ///
+    /// Tag values are attacker-controlled decrypted content, so they are
+    /// truncated and escaped before being embedded in error messages.
+    fn validate_tag(
+        &self,
+        tag_name: &str,
+        expected_value: &str,
+        presence: TagPresence,
+    ) -> Result<()> {
         let mut found_tag = false;
 
         for tag in self
@@ -114,49 +212,25 @@ impl UnwrappedNotification {
                 Some(value) if value == expected_value => continue,
                 Some(value) => {
                     return Err(Error::InvalidToken(format!(
-                        "Unsupported {tag_name} tag value: {value}"
+                        "Unsupported {tag_name} tag value: {}",
+                        sanitize_for_error(value, MAX_TAG_VALUE_ERROR_CHARS)
                     )));
                 }
                 None => {
-                    return Err(Error::InvalidToken(format!(
-                        "Missing value for required {tag_name} tag"
-                    )));
+                    return Err(Error::InvalidToken(match presence {
+                        TagPresence::Required => {
+                            format!("Missing value for required {tag_name} tag")
+                        }
+                        TagPresence::Optional => format!("Missing value for {tag_name} tag"),
+                    }));
                 }
             }
         }
 
-        if !found_tag {
+        if presence == TagPresence::Required && !found_tag {
             return Err(Error::InvalidToken(format!(
                 "Missing required {tag_name} tag"
             )));
-        }
-
-        Ok(())
-    }
-
-    /// Validates an optional `encoding` tag.
-    ///
-    /// Zero `encoding` tags defaults to base64 (current Darkmatter / Marmot spec).
-    /// If present, every `encoding` tag must carry the value `base64`.
-    fn validate_encoding_tag(&self) -> Result<()> {
-        for tag in self
-            .tags
-            .iter()
-            .filter(|tag| tag.kind() == TagKind::custom(TAG_ENCODING))
-        {
-            match tag.content() {
-                Some(ENCODING_BASE64) => {}
-                Some(value) => {
-                    return Err(Error::InvalidToken(format!(
-                        "Unsupported encoding tag value: {value}"
-                    )));
-                }
-                None => {
-                    return Err(Error::InvalidToken(
-                        "Missing value for encoding tag".to_string(),
-                    ));
-                }
-            }
         }
 
         Ok(())
@@ -180,8 +254,10 @@ impl UnwrappedNotification {
     pub fn parse_tokens_with_limit(&self, max_tokens: usize) -> Result<Vec<Vec<u8>>> {
         use base64::prelude::*;
 
-        self.require_tag_value(TAG_VERSION, VERSION_MIP05_V1)?;
-        self.validate_encoding_tag()?;
+        self.validate_tag(TAG_VERSION, VERSION_MIP05_V1, TagPresence::Required)?;
+        // Zero `encoding` tags defaults to base64 (current Darkmatter / Marmot
+        // spec). If present, every `encoding` tag must carry the value `base64`.
+        self.validate_tag(TAG_ENCODING, ENCODING_BASE64, TagPresence::Optional)?;
 
         let max_encoded_len = max_encoded_token_blob_len(max_tokens);
         if self.content.len() > max_encoded_len {
@@ -282,6 +358,245 @@ mod tests {
         let keys = Keys::generate();
         let handler = Nip59Handler::new(keys.clone());
         assert_eq!(handler.public_key(), keys.public_key());
+    }
+
+    /// Build a kind 446 rumor claiming the given author.
+    fn notification_rumor(author: PublicKey) -> UnsignedEvent {
+        EventBuilder::new(Kind::Custom(KIND_NOTIFICATION_REQUEST), "token-blob").build(author)
+    }
+
+    /// Gift-wrap the given seal JSON to `receiver` with an ephemeral key,
+    /// mirroring the NIP-59 outer layer.
+    async fn wrap_seal_json(receiver: &Keys, seal_json: &str) -> Event {
+        let ephemeral = Keys::generate();
+        let content = ephemeral
+            .nip44_encrypt(&receiver.public_key(), seal_json)
+            .await
+            .unwrap();
+        EventBuilder::new(Kind::GiftWrap, content)
+            .tag(Tag::public_key(receiver.public_key()))
+            .sign(&ephemeral)
+            .await
+            .unwrap()
+    }
+
+    /// Build a full gift wrap manually so the seal kind can be controlled.
+    async fn manual_gift_wrap(
+        seal_signer: &Keys,
+        receiver: &Keys,
+        mut rumor: UnsignedEvent,
+        seal_kind: Kind,
+    ) -> Event {
+        rumor.ensure_id();
+        let seal_content = seal_signer
+            .nip44_encrypt(&receiver.public_key(), &rumor.as_json())
+            .await
+            .unwrap();
+        let seal = EventBuilder::new(seal_kind, seal_content)
+            .sign(seal_signer)
+            .await
+            .unwrap();
+        wrap_seal_json(receiver, &seal.as_json()).await
+    }
+
+    #[tokio::test]
+    async fn test_unwrap_accepts_valid_gift_wrap() {
+        let server_keys = Keys::generate();
+        let sender_keys = Keys::generate();
+        let handler = Nip59Handler::new(server_keys.clone());
+
+        let rumor = notification_rumor(sender_keys.public_key());
+        let gift_wrap = EventBuilder::gift_wrap(
+            &sender_keys,
+            &server_keys.public_key(),
+            rumor,
+            Vec::<Tag>::new(),
+        )
+        .await
+        .unwrap();
+
+        let unwrapped = handler.unwrap(&gift_wrap).await.unwrap();
+        assert_eq!(unwrapped.content, "token-blob");
+    }
+
+    #[tokio::test]
+    async fn test_unwrap_accepts_manually_built_seal_of_kind_13() {
+        // Sanity-check the manual construction against the real unwrap path,
+        // so the rejection tests below fail for the intended reason only.
+        let server_keys = Keys::generate();
+        let sender_keys = Keys::generate();
+        let handler = Nip59Handler::new(server_keys.clone());
+
+        let rumor = notification_rumor(sender_keys.public_key());
+        let gift_wrap = manual_gift_wrap(&sender_keys, &server_keys, rumor, Kind::Seal).await;
+
+        let unwrapped = handler.unwrap(&gift_wrap).await.unwrap();
+        assert_eq!(unwrapped.content, "token-blob");
+    }
+
+    #[tokio::test]
+    async fn test_unwrap_rejects_non_gift_wrap_event() {
+        let server_keys = Keys::generate();
+        let sender_keys = Keys::generate();
+        let handler = Nip59Handler::new(server_keys);
+
+        let event = EventBuilder::text_note("not a gift wrap")
+            .sign(&sender_keys)
+            .await
+            .unwrap();
+
+        let error = handler.unwrap(&event).await.unwrap_err().to_string();
+        assert!(error.contains("Expected gift wrap (kind 1059), got kind 1"));
+    }
+
+    #[tokio::test]
+    async fn test_unwrap_rejects_gift_wrap_for_other_recipient() {
+        let server_keys = Keys::generate();
+        let other_keys = Keys::generate();
+        let sender_keys = Keys::generate();
+        let handler = Nip59Handler::new(server_keys);
+
+        let rumor = notification_rumor(sender_keys.public_key());
+        let gift_wrap = EventBuilder::gift_wrap(
+            &sender_keys,
+            &other_keys.public_key(),
+            rumor,
+            Vec::<Tag>::new(),
+        )
+        .await
+        .unwrap();
+
+        let error = handler.unwrap(&gift_wrap).await.unwrap_err().to_string();
+        assert!(error.contains("Failed to decrypt gift wrap"));
+    }
+
+    #[tokio::test]
+    async fn test_unwrap_rejects_non_event_seal_payload() {
+        let server_keys = Keys::generate();
+        let handler = Nip59Handler::new(server_keys.clone());
+
+        let gift_wrap = wrap_seal_json(&server_keys, "not a seal event").await;
+
+        let error = handler.unwrap(&gift_wrap).await.unwrap_err().to_string();
+        assert!(error.contains("Failed to parse seal event"));
+    }
+
+    #[tokio::test]
+    async fn test_unwrap_rejects_tampered_seal() {
+        let server_keys = Keys::generate();
+        let sender_keys = Keys::generate();
+        let handler = Nip59Handler::new(server_keys.clone());
+
+        let mut rumor = notification_rumor(sender_keys.public_key());
+        rumor.ensure_id();
+        let seal_content = sender_keys
+            .nip44_encrypt(&server_keys.public_key(), &rumor.as_json())
+            .await
+            .unwrap();
+        let seal = EventBuilder::new(Kind::Seal, seal_content)
+            .sign(&sender_keys)
+            .await
+            .unwrap();
+
+        // Tamper with a signed field after signing: id/signature no longer match.
+        let mut seal_value: serde_json::Value = serde_json::from_str(&seal.as_json()).unwrap();
+        seal_value["created_at"] = (seal.created_at.as_secs() + 1).into();
+        let gift_wrap = wrap_seal_json(&server_keys, &seal_value.to_string()).await;
+
+        let error = handler.unwrap(&gift_wrap).await.unwrap_err().to_string();
+        assert!(error.contains("Invalid seal"));
+    }
+
+    #[tokio::test]
+    async fn test_unwrap_rejects_seal_of_wrong_kind() {
+        let server_keys = Keys::generate();
+        let sender_keys = Keys::generate();
+        let handler = Nip59Handler::new(server_keys.clone());
+
+        let rumor = notification_rumor(sender_keys.public_key());
+        let gift_wrap = manual_gift_wrap(&sender_keys, &server_keys, rumor, Kind::TextNote).await;
+
+        let error = handler.unwrap(&gift_wrap).await.unwrap_err().to_string();
+        assert!(error.contains("Expected seal (kind 13), got kind 1"));
+    }
+
+    #[tokio::test]
+    async fn test_unwrap_rejects_undecryptable_seal_content() {
+        let server_keys = Keys::generate();
+        let sender_keys = Keys::generate();
+        let handler = Nip59Handler::new(server_keys.clone());
+
+        let seal = EventBuilder::new(Kind::Seal, "not a nip44 payload")
+            .sign(&sender_keys)
+            .await
+            .unwrap();
+        let gift_wrap = wrap_seal_json(&server_keys, &seal.as_json()).await;
+
+        let error = handler.unwrap(&gift_wrap).await.unwrap_err().to_string();
+        assert!(error.contains("Failed to decrypt seal"));
+    }
+
+    #[tokio::test]
+    async fn test_unwrap_rejects_non_json_rumor() {
+        let server_keys = Keys::generate();
+        let sender_keys = Keys::generate();
+        let handler = Nip59Handler::new(server_keys.clone());
+
+        let seal_content = sender_keys
+            .nip44_encrypt(&server_keys.public_key(), "not a rumor")
+            .await
+            .unwrap();
+        let seal = EventBuilder::new(Kind::Seal, seal_content)
+            .sign(&sender_keys)
+            .await
+            .unwrap();
+        let gift_wrap = wrap_seal_json(&server_keys, &seal.as_json()).await;
+
+        let error = handler.unwrap(&gift_wrap).await.unwrap_err().to_string();
+        assert!(error.contains("Failed to parse rumor"));
+    }
+
+    #[tokio::test]
+    async fn test_unwrap_rejects_forged_rumor_author() {
+        let server_keys = Keys::generate();
+        let sender_keys = Keys::generate();
+        let impersonated_keys = Keys::generate();
+        let handler = Nip59Handler::new(server_keys.clone());
+
+        // Seal signed by the sender, but the (unsigned) rumor claims another
+        // author. The rumor pubkey is attacker-chosen and must be rejected.
+        let rumor = notification_rumor(impersonated_keys.public_key());
+        let gift_wrap = EventBuilder::gift_wrap(
+            &sender_keys,
+            &server_keys.public_key(),
+            rumor,
+            Vec::<Tag>::new(),
+        )
+        .await
+        .unwrap();
+
+        let error = handler.unwrap(&gift_wrap).await.unwrap_err().to_string();
+        assert!(error.contains("Rumor author does not match seal signer"));
+    }
+
+    #[tokio::test]
+    async fn test_unwrap_rejects_wrong_rumor_kind() {
+        let server_keys = Keys::generate();
+        let sender_keys = Keys::generate();
+        let handler = Nip59Handler::new(server_keys.clone());
+
+        let rumor = EventBuilder::text_note("wrong kind").build(sender_keys.public_key());
+        let gift_wrap = EventBuilder::gift_wrap(
+            &sender_keys,
+            &server_keys.public_key(),
+            rumor,
+            Vec::<Tag>::new(),
+        )
+        .await
+        .unwrap();
+
+        let error = handler.unwrap(&gift_wrap).await.unwrap_err().to_string();
+        assert!(error.contains("Expected notification request (kind 446), got kind 1"));
     }
 
     #[test]
@@ -517,7 +832,52 @@ mod tests {
             result
                 .unwrap_err()
                 .to_string()
-                .contains("Unsupported encoding tag value")
+                .contains("Unsupported encoding tag value: hex")
         );
+    }
+
+    #[test]
+    fn test_tag_value_error_escapes_and_truncates_attacker_content() {
+        let long_tail = "B".repeat(512);
+        let injected = format!("mip05-v1\n2026-07-03 ERROR forged line {long_tail}");
+        let notification = UnwrappedNotification {
+            content: BASE64_STANDARD.encode(vec![0x01; ENCRYPTED_TOKEN_SIZE]),
+            tags: Tags::parse([[TAG_VERSION, injected.as_str()]]).unwrap(),
+            created_at: Timestamp::now(),
+        };
+
+        let message = notification.parse_tokens().unwrap_err().to_string();
+
+        assert!(message.contains("Unsupported v tag value"));
+        // The raw value must never appear: no control characters, no
+        // unbounded content.
+        assert!(!message.contains(&injected));
+        assert!(
+            !message.contains('\n'),
+            "control characters must be escaped: {message:?}"
+        );
+        assert!(
+            !message.contains(&long_tail),
+            "value must be truncated: {message:?}"
+        );
+        // The newline survives only in escaped form, and truncation is marked.
+        assert!(message.contains("\\n"));
+        assert!(message.contains("..."));
+    }
+
+    #[test]
+    fn test_sanitize_for_error_keeps_short_printable_values() {
+        assert_eq!(sanitize_for_error("hex", 32), "hex");
+    }
+
+    #[test]
+    fn test_sanitize_for_error_escapes_and_truncates() {
+        let value = format!("a\nb{}", "c".repeat(64));
+        assert_eq!(sanitize_for_error(&value, 8), "a\\nbccccc...");
+    }
+
+    #[test]
+    fn test_sanitize_for_error_no_marker_at_exact_limit() {
+        assert_eq!(sanitize_for_error("abcd", 4), "abcd");
     }
 }


### PR DESCRIPTION
## Design

`Nip59Handler::unwrap` now performs the NIP-59 unwrap manually with public nostr-sdk primitives (`NostrSigner::nip44_decrypt`, `Event::from_json`, `Event::verify`, `UnsignedEvent::from_json`) instead of delegating to `UnwrappedGift::from_gift_wrap`. This mirrors exactly what upstream does internally — no crypto is reimplemented — and makes the seal observable so every invariant in the doc comment is enforced in one place:

1. **Seal kind (#148) — enforced, not just documented.** Upstream (`nostr` 0.44.2, verified against vendored source) decrypts the seal, verifies its signature, and checks `rumor.pubkey == seal.pubkey`, but never asserts `seal.kind == 13`. Since the manual two-step unwrap needs only public APIs and is ~20 lines, the sanctioned fallback (doc-comment correction) was not needed: seals of any kind other than 13 are now rejected.
2. **Author binding (#163).** The rumor is unsigned, so its `pubkey` is attacker-chosen; the seal signer is the only authenticated identity. The `rumor.pubkey == seal.pubkey` check upstream already performed is now explicit in transponder (it would otherwise have become implicit-only once the manual unwrap landed), with tests for both the valid and forged-author cases.
3. **Consolidated tag validation (#157).** `require_tag_value` and `validate_encoding_tag` are replaced by a single `validate_tag(name, expected, TagPresence::{Required,Optional})`. Error messages and accept/reject behavior are unchanged.
4. **No raw attacker content in error strings (#164).** Errors from this module are logged via `warn!(error = %e, ...)` in the event processor. `sanitize_for_error` now bounds and `escape_default`-escapes attacker-controlled content before it reaches an error `Display`: tag values are capped at 32 chars, and seal/rumor JSON parse-error details (serde errors can embed decrypted plaintext; this surface predates this PR via the old `Failed to extract rumor: {e}` interpolation) at 128 chars. A test asserts a tag value with newlines and a 512-char tail appears neither raw nor unbounded. NIP-44 decrypt errors (`SignerError`) carry only static messages and are formatted as-is.

New tests cover every new branch: valid unwrap (builder-built and manually-built seals), non-gift-wrap kind, wrong recipient, non-event seal payload, tampered seal signature, wrong seal kind, undecryptable seal content, non-JSON rumor, forged rumor author, wrong rumor kind, plus sanitizer unit tests (short value, escape+truncate, exact-limit boundary).

Fixes #163
Fixes #148
Fixes #157
Fixes #164
Part of #217.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/transponder/pull/227">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->