### PR TITLE
test: deflake two timing-dependent tests

### DIFF
--- a/src/nostr/events.rs
+++ b/src/nostr/events.rs
@@ -1764,10 +1764,16 @@ mod tests {
         let content = NotificationContentBuilder::new(&server_keys)
             .with_apns_token("deadbeef12345678deadbeef12345678deadbeef12345678deadbeef12345678")
             .build();
+        // One hour beyond the skew tolerance, not +1s: `process()` re-reads
+        // `Timestamp::now()` (1-second granularity) when it validates freshness,
+        // so a whole-second wall-clock tick between here and that read would
+        // collapse a +1s margin onto the exact threshold (`>` becomes `==`) and
+        // spuriously accept the event under load. A large margin exercises the
+        // same "created_at exceeds now + skew" rejection path, drift-proof.
         let future_created_at = Timestamp::from_secs(
             Timestamp::now()
                 .as_secs()
-                .saturating_add(DEFAULT_MAX_NOTIFICATION_FUTURE_SKEW_SECS + 1),
+                .saturating_add(DEFAULT_MAX_NOTIFICATION_FUTURE_SKEW_SECS + 3600),
         );
         let event = GiftWrapBuilder::new(server_keys.clone(), sender_keys)
             .build_with_created_at(&content, future_created_at)

--- a/src/shutdown.rs
+++ b/src/shutdown.rs
@@ -315,21 +315,31 @@ mod tests {
 
     #[tokio::test]
     async fn wait_for_signal_or_trigger_returns_on_internal_trigger() {
+        use std::future::Future;
+        use std::task::{Context, Poll, Waker};
+
         let handler = ShutdownHandler::new();
         let trigger = handler.trigger_handle();
 
         let wait = handler.wait_for_signal_or_trigger();
         tokio::pin!(wait);
 
-        // No signal and no trigger yet: the wait must still be pending.
-        let pending = timeout(Duration::from_millis(10), &mut wait).await;
-        assert!(pending.is_err());
+        // No signal and no trigger yet: the wait must still be pending. Poll
+        // once with a no-op waker instead of racing a wall-clock timeout — the
+        // first poll subscribes the receiver and registers the signal handlers,
+        // and with neither fired the future is deterministically `Pending`.
+        let mut cx = Context::from_waker(Waker::noop());
+        assert!(
+            matches!(wait.as_mut().poll(&mut cx), Poll::Pending),
+            "wait must be pending before any signal or trigger"
+        );
 
         trigger.trigger();
 
-        let reason = timeout(Duration::from_secs(1), &mut wait)
-            .await
-            .expect("internal trigger must complete the shutdown wait");
+        // The trigger set the watch to `true`; awaiting the same future now
+        // resolves deterministically (a hang here would be a real bug the outer
+        // test harness surfaces, not a timing flake).
+        let reason = wait.await;
         assert_eq!(reason, ShutdownReason::InternalTrigger);
     }
 

--- a/src/shutdown.rs
+++ b/src/shutdown.rs
@@ -316,7 +316,7 @@ mod tests {
     #[tokio::test]
     async fn wait_for_signal_or_trigger_returns_on_internal_trigger() {
         use std::future::Future;
-        use std::task::{Context, Poll, Waker};
+        use std::task::{Context, Waker};
 
         let handler = ShutdownHandler::new();
         let trigger = handler.trigger_handle();
@@ -330,7 +330,7 @@ mod tests {
         // and with neither fired the future is deterministically `Pending`.
         let mut cx = Context::from_waker(Waker::noop());
         assert!(
-            matches!(wait.as_mut().poll(&mut cx), Poll::Pending),
+            wait.as_mut().poll(&mut cx).is_pending(),
             "wait must be pending before any signal or trigger"
         );
 

--- a/src/shutdown.rs
+++ b/src/shutdown.rs
@@ -392,6 +392,13 @@ mod tests {
         assert_eq!(signal, ShutdownSignal::Sigterm);
     }
 
+    #[test]
+    fn shutdown_signal_name_labels_each_variant() {
+        // These strings appear in the operator-facing shutdown logs.
+        assert_eq!(ShutdownSignal::CtrlC.name(), "Ctrl+C");
+        assert_eq!(ShutdownSignal::Sigterm.name(), "SIGTERM");
+    }
+
     #[cfg(unix)]
     #[tokio::test]
     async fn wait_for_shutdown_signal_receives_sigterm() {


### PR DESCRIPTION
Fixes the two pre-existing intermittent flakes surfaced during the root-cause refactor program (both pass in isolation, fail occasionally under full-suite concurrency / coverage instrumentation).

**`shutdown::wait_for_signal_or_trigger_returns_on_internal_trigger`** relied on two real wall-clock timeouts — a 10ms window to prove the wait was still pending, and a 1s window for it to resolve after the trigger (exceedable when a starved task isn't polled within 1s under load). Now: a single deterministic poll with a no-op waker proves `Pending` (the first poll subscribes the receiver and registers the signal handlers, so with neither fired the future is provably pending), and the triggered future is awaited directly. No wall-clock remains.

**`events::test_process_rejects_future_notification_rumor`** dated the event only `+1s` beyond the future-skew tolerance. `validate_notification_freshness` re-reads `Timestamp::now()` (1-second granularity) at process time, so a whole-second tick between building the event and that read collapsed the `+1` margin onto the exact threshold (`>` became `==`) and spuriously accepted the event. Widened to `+1h`; there's no injectable clock at the check site, so a drift-proof margin is the deterministic fix without a production API change. No assertion weakened — it still exercises the `created_at > now + skew` rejection path.

**Verified:** 20/20 each under `cargo llvm-cov` (the instrumentation that surfaced the flakes), full suite 647 pass, clippy `-D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/transponder/pull/235">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved shutdown and notification tests to be more deterministic and less flaky.
  * Strengthened future-dated notification coverage by using a larger time offset, avoiding boundary timing issues.
  * Reworked a shutdown assertion to check for pending state directly before confirming the internal trigger completes the operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->