### PR TITLE
Add mutable APNs alert mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,8 +182,20 @@ Example environment overrides:
 TRANSPONDER_SERVER_PRIVATE_KEY=abc123...
 TRANSPONDER_APNS_ENABLED=true
 TRANSPONDER_APNS_KEY_ID=ABCD123456
-TRANSPONDER_RELAYS_CLEARNET='["wss://relay.example.com"]'
+TRANSPONDER_APNS_PAYLOAD_MODE=mutable_alert
+TRANSPONDER_APNS_ALERT_TITLE="New activity"
+TRANSPONDER_APNS_ALERT_BODY="You have a new notification"
+TRANSPONDER_APNS_COLLAPSE_ID=message-sync
+TRANSPONDER_RELAYS_CLEARNET=wss://relay.example.com
 ```
+
+APNs supports three payload modes:
+
+- `silent` (default) sends a background push with no visible alert.
+- `generic_alert` sends the operator-configured, product-neutral fallback title and body.
+- `mutable_alert` sends the same fallback with Apple's `mutable-content` flag, allowing a Notification Service Extension already provided and configured by the iOS app to process and replace it. Transponder does not provide or configure the extension.
+
+`apns.alert_title` and `apns.alert_body` (or `TRANSPONDER_APNS_ALERT_TITLE` and `TRANSPONDER_APNS_ALERT_BODY`) configure the fallback copy for both alert modes. When APNs is enabled in an alert mode, at least one must be non-empty and the serialized payload must fit APNs' 4096-byte limit. `apns.collapse_id` / `TRANSPONDER_APNS_COLLAPSE_ID` is optional and must be at most 64 header-safe bytes.
 
 ## PR Guidelines
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-Transponder is a privacy-preserving push notification server targeting the adopted [Marmot push-notifications feature](https://github.com/marmot-protocol/marmot/blob/master/features/push-notifications.md) and [Nostr transport binding](https://github.com/marmot-protocol/marmot/blob/master/transports/nostr.md). It listens for gift-wrapped Nostr events (kind 1059) on configured relays, decrypts notification triggers, and dispatches content-free push notifications to APNs and FCM. APNs delivery is silent by default and may use the opt-in, product-neutral `generic_alert` mode.
+Transponder is a privacy-preserving push notification server targeting the adopted [Marmot push-notifications feature](https://github.com/marmot-protocol/marmot/blob/master/features/push-notifications.md) and [Nostr transport binding](https://github.com/marmot-protocol/marmot/blob/master/transports/nostr.md). It listens for gift-wrapped Nostr events (kind 1059) on configured relays, decrypts notification triggers, and dispatches content-free push notifications to APNs and FCM. APNs delivery is silent by default and may use the opt-in, product-neutral `generic_alert` or `mutable_alert` modes.
 
 The Marmot repository's adopted surface documents are normative. The MIP-era documents are deprecated; use [mip-coverage.md](https://github.com/marmot-protocol/marmot/blob/master/mip-coverage.md) only as a historical map. The current source implements the `marmot-push-v1` server surface and must retain exact wire compatibility with those adopted documents.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added opt-in, product-neutral APNs `generic_alert` and `mutable_alert` payload modes with configurable title/body copy and optional `apns-collapse-id` coalescing. `mutable_alert` sets Apple's `mutable-content` flag so an iOS Notification Service Extension can replace the fallback alert. Configuration rejects empty alerts, oversized serialized payloads, overlong collapse identifiers, and invalid header values at startup.
+- Added opt-in, product-neutral APNs `generic_alert` and `mutable_alert` payload modes with configurable title/body copy and optional `apns-collapse-id` coalescing. `mutable_alert` sets Apple's `mutable-content` flag so an iOS Notification Service Extension configured by the app can replace the fallback alert. For enabled APNs configurations, startup validation rejects empty alerts, oversized serialized payloads, overlong collapse identifiers, and invalid header values.
 - Optional error and panic reporting to a GlitchTip (Sentry-compatible) instance, enabled by setting `glitchtip.dsn` (or `TRANSPONDER_GLITCHTIP_DSN`). Only Transponder's own `ERROR` events and panics are sent, over a self-contained TLS transport (bundled roots, no system CA store dependency); dependency-crate errors and lower log levels are dropped, and Transponder never logs or panics with secret material.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added an opt-in, product-neutral APNs `generic_alert` payload mode with configurable title/body copy and optional `apns-collapse-id` coalescing. Configuration now rejects empty alerts, oversized serialized payloads, overlong collapse identifiers, and invalid header values at startup.
+- Added opt-in, product-neutral APNs `generic_alert` and `mutable_alert` payload modes with configurable title/body copy and optional `apns-collapse-id` coalescing. `mutable_alert` sets Apple's `mutable-content` flag so an iOS Notification Service Extension can replace the fallback alert. Configuration rejects empty alerts, oversized serialized payloads, overlong collapse identifiers, and invalid header values at startup.
 - Optional error and panic reporting to a GlitchTip (Sentry-compatible) instance, enabled by setting `glitchtip.dsn` (or `TRANSPONDER_GLITCHTIP_DSN`). Only Transponder's own `ERROR` events and panics are sent, over a self-contained TLS transport (bundled roots, no system CA store dependency); dependency-crate errors and lower log levels are dropped, and Transponder never logs or panics with secret material.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -148,8 +148,9 @@ environment = "production"
 # Your iOS app's bundle identifier (e.g., "com.example.myapp")
 bundle_id = ""
 
-# APNs payload mode: "silent" or "generic_alert".
-# generic_alert uses only the product-neutral copy configured below.
+# APNs payload mode: "silent", "generic_alert", or "mutable_alert".
+# Both alert modes use only the product-neutral fallback copy configured below;
+# mutable_alert also invokes an iOS Notification Service Extension.
 payload_mode = "silent"
 alert_title = "New activity"
 alert_body = "You have a new notification"
@@ -237,8 +238,10 @@ export TRANSPONDER_APNS_TEAM_ID="TEAM123456"
 export TRANSPONDER_APNS_PRIVATE_KEY_PATH="/path/to/AuthKey.p8"
 export TRANSPONDER_APNS_BUNDLE_ID="com.example.app"
 export TRANSPONDER_APNS_PAYLOAD_MODE="silent"
-# Optional visible, product-neutral APNs mode:
+# Optional visible, product-neutral APNs modes:
 # export TRANSPONDER_APNS_PAYLOAD_MODE="generic_alert"
+# Or let an iOS Notification Service Extension replace the fallback alert:
+# export TRANSPONDER_APNS_PAYLOAD_MODE="mutable_alert"
 # export TRANSPONDER_APNS_ALERT_TITLE="New activity"
 # export TRANSPONDER_APNS_ALERT_BODY="You have a new notification"
 # export TRANSPONDER_APNS_COLLAPSE_ID="message-sync"
@@ -539,7 +542,7 @@ To preserve the server's privacy guarantees, only `ERROR`-level events emitted b
 
 3. **Decrypt**: Each encrypted token in the request is decrypted using ECDH + HKDF + ChaCha20-Poly1305. The adopted domain-separation values are defined by the [Marmot push-notifications feature](https://github.com/marmot-protocol/marmot/blob/master/features/push-notifications.md); see [Protocol Status](#protocol-status) for the exact implemented surface.
 
-4. **Dispatch**: Tokens are routed to APNs or FCM based on platform identifier, sending content-free push notifications. APNs uses the configured `silent` or `generic_alert` payload mode.
+4. **Dispatch**: Tokens are routed to APNs or FCM based on platform identifier, sending content-free push notifications. APNs uses the configured `silent`, `generic_alert`, or `mutable_alert` payload mode. `mutable_alert` includes Apple's `mutable-content` flag so an iOS Notification Service Extension can fetch and replace the product-neutral fallback alert.
 
 5. **Wake**: Client apps wake up, fetch messages from relays, and display notifications locally.
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,8 @@ bundle_id = ""
 
 # APNs payload mode: "silent", "generic_alert", or "mutable_alert".
 # Both alert modes use only the product-neutral fallback copy configured below;
-# mutable_alert also invokes an iOS Notification Service Extension.
+# mutable_alert allows a configured iOS Notification Service Extension to
+# process and replace that fallback. The app must provide and configure it.
 payload_mode = "silent"
 alert_title = "New activity"
 alert_body = "You have a new notification"
@@ -240,7 +241,7 @@ export TRANSPONDER_APNS_BUNDLE_ID="com.example.app"
 export TRANSPONDER_APNS_PAYLOAD_MODE="silent"
 # Optional visible, product-neutral APNs modes:
 # export TRANSPONDER_APNS_PAYLOAD_MODE="generic_alert"
-# Or let an iOS Notification Service Extension replace the fallback alert:
+# Or allow the app's configured Notification Service Extension to replace it:
 # export TRANSPONDER_APNS_PAYLOAD_MODE="mutable_alert"
 # export TRANSPONDER_APNS_ALERT_TITLE="New activity"
 # export TRANSPONDER_APNS_ALERT_BODY="You have a new notification"

--- a/config/default.toml
+++ b/config/default.toml
@@ -137,14 +137,15 @@ environment = "production"
 # iOS app bundle identifier
 bundle_id = ""
 
-# APNs payload mode: "silent" or "generic_alert".
-# Silent remains the privacy-preserving default. generic_alert sends only the
-# product-neutral copy configured below; it never contains message or sender data.
+# APNs payload mode: "silent", "generic_alert", or "mutable_alert".
+# Silent remains the privacy-preserving default. Both alert modes send only the
+# product-neutral fallback copy configured below; mutable_alert additionally sets
+# Apple's mutable-content flag for an iOS Notification Service Extension.
 payload_mode = "silent"
 
-# Visible copy used only when payload_mode = "generic_alert". An empty title or
-# body omits that field, but at least one must be non-empty. The serialized JSON
-# payload is checked against APNs' 4096-byte limit at startup.
+# Visible fallback copy used by generic_alert and mutable_alert. An empty title
+# or body omits that field, but at least one must be non-empty. The serialized
+# JSON payload is checked against APNs' 4096-byte limit at startup.
 alert_title = "New activity"
 alert_body = "You have a new notification"
 

--- a/config/default.toml
+++ b/config/default.toml
@@ -139,13 +139,15 @@ bundle_id = ""
 
 # APNs payload mode: "silent", "generic_alert", or "mutable_alert".
 # Silent remains the privacy-preserving default. Both alert modes send only the
-# product-neutral fallback copy configured below; mutable_alert additionally sets
-# Apple's mutable-content flag for an iOS Notification Service Extension.
+# product-neutral fallback copy configured below; mutable_alert additionally
+# allows an iOS Notification Service Extension configured by the app to process
+# and replace that fallback.
 payload_mode = "silent"
 
 # Visible fallback copy used by generic_alert and mutable_alert. An empty title
-# or body omits that field, but at least one must be non-empty. The serialized
-# JSON payload is checked against APNs' 4096-byte limit at startup.
+# or body omits that field. When APNs is enabled in either alert mode, at least
+# one must be non-empty and the serialized JSON is checked against APNs'
+# 4096-byte payload limit at startup.
 alert_title = "New activity"
 alert_body = "You have a new notification"
 

--- a/config/production.toml.example
+++ b/config/production.toml.example
@@ -62,8 +62,9 @@ team_id = ""
 private_key_path = "/credentials/AuthKey_XXXXXXXXXX.p8"
 environment = "production"
 bundle_id = ""
-# "silent", "generic_alert", or "mutable_alert". mutable_alert invokes an iOS
-# Notification Service Extension while retaining the configured fallback copy.
+# "silent", "generic_alert", or "mutable_alert". mutable_alert allows an iOS
+# Notification Service Extension configured by the app to process and replace
+# the configured fallback copy; Transponder does not provide that extension.
 payload_mode = "silent"
 alert_title = "New activity"
 alert_body = "You have a new notification"

--- a/config/production.toml.example
+++ b/config/production.toml.example
@@ -62,6 +62,8 @@ team_id = ""
 private_key_path = "/credentials/AuthKey_XXXXXXXXXX.p8"
 environment = "production"
 bundle_id = ""
+# "silent", "generic_alert", or "mutable_alert". mutable_alert invokes an iOS
+# Notification Service Extension while retaining the configured fallback copy.
 payload_mode = "silent"
 alert_title = "New activity"
 alert_body = "You have a new notification"

--- a/src/config.rs
+++ b/src/config.rs
@@ -368,11 +368,11 @@ pub struct ApnsConfig {
     #[serde(default)]
     pub payload_mode: ApnsPayloadMode,
 
-    /// Product-neutral title for the `generic_alert` payload mode.
+    /// Product-neutral title for the visible alert payload modes.
     #[serde(default = "default_apns_alert_title")]
     pub alert_title: String,
 
-    /// Product-neutral body for the `generic_alert` payload mode.
+    /// Product-neutral body for the visible alert payload modes.
     #[serde(default = "default_apns_alert_body")]
     pub alert_body: String,
 
@@ -418,21 +418,32 @@ pub enum ApnsPayloadMode {
 
     /// Visible, content-free alert with operator-configured title and body.
     GenericAlert,
+
+    /// Visible, content-free alert that an iOS Notification Service Extension may replace.
+    MutableAlert,
 }
 
 impl ApnsPayloadMode {
     pub(crate) fn push_type(self) -> &'static str {
         match self {
             Self::Silent => "background",
-            Self::GenericAlert => "alert",
+            Self::GenericAlert | Self::MutableAlert => "alert",
         }
     }
 
     pub(crate) fn priority(self) -> &'static str {
         match self {
             Self::Silent => "5",
-            Self::GenericAlert => "10",
+            Self::GenericAlert | Self::MutableAlert => "10",
         }
+    }
+
+    fn is_alert(self) -> bool {
+        matches!(self, Self::GenericAlert | Self::MutableAlert)
+    }
+
+    fn uses_mutable_content(self) -> bool {
+        matches!(self, Self::MutableAlert)
     }
 }
 
@@ -441,6 +452,7 @@ impl std::fmt::Display for ApnsPayloadMode {
         match self {
             Self::Silent => f.write_str("silent"),
             Self::GenericAlert => f.write_str("generic_alert"),
+            Self::MutableAlert => f.write_str("mutable_alert"),
         }
     }
 }
@@ -1233,9 +1245,9 @@ impl GlitchtipConfig {
 }
 
 impl ApnsConfig {
-    /// Build the canonical content-free generic-alert payload used for both
-    /// startup size validation and outbound APNs requests.
-    pub(crate) fn generic_alert_payload(&self) -> serde_json::Value {
+    /// Build the canonical content-free alert payload used for both startup
+    /// size validation and outbound APNs requests.
+    pub(crate) fn alert_payload(&self) -> serde_json::Value {
         let mut alert = serde_json::Map::new();
         if !self.alert_title.is_empty() {
             alert.insert(
@@ -1250,12 +1262,17 @@ impl ApnsConfig {
             );
         }
 
-        serde_json::json!({
-            "aps": {
-                "alert": alert,
-                "sound": "default"
-            }
-        })
+        let mut aps = serde_json::Map::new();
+        aps.insert("alert".to_string(), serde_json::Value::Object(alert));
+        if self.payload_mode.uses_mutable_content() {
+            aps.insert("mutable-content".to_string(), serde_json::Value::from(1));
+        }
+        aps.insert(
+            "sound".to_string(),
+            serde_json::Value::String("default".to_string()),
+        );
+
+        serde_json::json!({ "aps": aps })
     }
 
     /// Rejects enabled APNs configuration that cannot produce valid requests.
@@ -1279,26 +1296,27 @@ impl ApnsConfig {
             }
         }
 
-        if self.payload_mode == ApnsPayloadMode::GenericAlert
+        if self.payload_mode.is_alert()
             && self.alert_title.trim().is_empty()
             && self.alert_body.trim().is_empty()
         {
-            return Err(config::ConfigError::Message(
-                "apns.alert_title or apns.alert_body must be set when apns.payload_mode = \"generic_alert\"".to_string(),
-            ));
+            return Err(config::ConfigError::Message(format!(
+                "apns.alert_title or apns.alert_body must be set when apns.payload_mode = \"{}\"",
+                self.payload_mode
+            )));
         }
 
-        if self.payload_mode == ApnsPayloadMode::GenericAlert {
-            let payload_size = serde_json::to_vec(&self.generic_alert_payload())
+        if self.payload_mode.is_alert() {
+            let payload_size = serde_json::to_vec(&self.alert_payload())
                 .map_err(|error| {
                     config::ConfigError::Message(format!(
-                        "failed to serialize the configured APNs generic alert: {error}"
+                        "failed to serialize the configured APNs alert: {error}"
                     ))
                 })?
                 .len();
             if payload_size > APNS_MAX_PAYLOAD_BYTES {
                 return Err(config::ConfigError::Message(format!(
-                    "configured APNs generic alert serializes to {payload_size} bytes; APNs permits at most {APNS_MAX_PAYLOAD_BYTES} bytes"
+                    "configured APNs alert serializes to {payload_size} bytes; APNs permits at most {APNS_MAX_PAYLOAD_BYTES} bytes"
                 )));
             }
         }
@@ -2006,6 +2024,7 @@ mod tests {
     fn test_apns_payload_mode_display_is_stable() {
         assert_eq!(ApnsPayloadMode::Silent.to_string(), "silent");
         assert_eq!(ApnsPayloadMode::GenericAlert.to_string(), "generic_alert");
+        assert_eq!(ApnsPayloadMode::MutableAlert.to_string(), "mutable_alert");
     }
 
     #[test]
@@ -2048,31 +2067,55 @@ mod tests {
     }
 
     #[test]
-    fn test_enabled_generic_alert_requires_title_or_body() {
-        let mut config = enabled_apns_config();
-        config.payload_mode = ApnsPayloadMode::GenericAlert;
-        config.alert_title = "  ".to_string();
-        config.alert_body = String::new();
+    fn test_apns_mutable_alert_parses_from_environment_with_custom_copy() {
+        let config = from_test_env(&[
+            ("TRANSPONDER_APNS_PAYLOAD_MODE", "mutable_alert"),
+            ("TRANSPONDER_APNS_ALERT_TITLE", "Messages"),
+            (
+                "TRANSPONDER_APNS_ALERT_BODY",
+                "Open the app to check for updates",
+            ),
+            ("TRANSPONDER_APNS_COLLAPSE_ID", "message-sync"),
+        ])
+        .unwrap();
 
-        let error = config.validate().unwrap_err();
-        assert!(error.to_string().contains("apns.alert_title"), "{error}");
-        assert!(error.to_string().contains("apns.alert_body"), "{error}");
+        assert_eq!(config.apns.payload_mode, ApnsPayloadMode::MutableAlert);
+        assert_eq!(config.apns.alert_title, "Messages");
+        assert_eq!(config.apns.alert_body, "Open the app to check for updates");
+        assert_eq!(config.apns.collapse_id, "message-sync");
     }
 
     #[test]
-    fn test_enabled_generic_alert_rejects_payload_over_apns_limit() {
-        let mut config = enabled_apns_config();
-        config.payload_mode = ApnsPayloadMode::GenericAlert;
-        config.alert_body = "\"".repeat(APNS_MAX_PAYLOAD_BYTES);
+    fn test_enabled_alert_modes_require_title_or_body() {
+        for mode in [ApnsPayloadMode::GenericAlert, ApnsPayloadMode::MutableAlert] {
+            let mut config = enabled_apns_config();
+            config.payload_mode = mode;
+            config.alert_title = "  ".to_string();
+            config.alert_body = String::new();
 
-        let error = config.validate().unwrap_err();
-        assert!(error.to_string().contains("serializes to"), "{error}");
-        assert!(
-            error
-                .to_string()
-                .contains(&APNS_MAX_PAYLOAD_BYTES.to_string()),
-            "{error}"
-        );
+            let error = config.validate().unwrap_err();
+            assert!(error.to_string().contains("apns.alert_title"), "{error}");
+            assert!(error.to_string().contains("apns.alert_body"), "{error}");
+            assert!(error.to_string().contains(&mode.to_string()), "{error}");
+        }
+    }
+
+    #[test]
+    fn test_enabled_alert_modes_reject_payload_over_apns_limit() {
+        for mode in [ApnsPayloadMode::GenericAlert, ApnsPayloadMode::MutableAlert] {
+            let mut config = enabled_apns_config();
+            config.payload_mode = mode;
+            config.alert_body = "\"".repeat(APNS_MAX_PAYLOAD_BYTES);
+
+            let error = config.validate().unwrap_err();
+            assert!(error.to_string().contains("serializes to"), "{error}");
+            assert!(
+                error
+                    .to_string()
+                    .contains(&APNS_MAX_PAYLOAD_BYTES.to_string()),
+                "{error}"
+            );
+        }
     }
 
     #[test]
@@ -2087,7 +2130,7 @@ mod tests {
             .validate()
             .expect("valid generic alert configuration");
         assert_eq!(
-            config.generic_alert_payload(),
+            config.alert_payload(),
             serde_json::json!({
                 "aps": {
                     "alert": {

--- a/src/push/apns.rs
+++ b/src/push/apns.rs
@@ -39,7 +39,7 @@ struct ApnsClaims {
 #[serde(untagged)]
 enum ApnsPayload {
     Silent(ApnsSilentPayload),
-    GenericAlert(serde_json::Value),
+    Alert(serde_json::Value),
 }
 
 #[derive(Debug, Serialize)]
@@ -67,7 +67,9 @@ impl ApnsPayload {
     fn for_config(config: &ApnsConfig) -> Self {
         match config.payload_mode {
             ApnsPayloadMode::Silent => Self::default(),
-            ApnsPayloadMode::GenericAlert => Self::GenericAlert(config.generic_alert_payload()),
+            ApnsPayloadMode::GenericAlert | ApnsPayloadMode::MutableAlert => {
+                Self::Alert(config.alert_payload())
+            }
         }
     }
 }
@@ -813,6 +815,42 @@ mod tests {
                         "title": "New activity",
                         "body": "You have a new notification"
                     },
+                    "sound": "default"
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn test_mutable_alert_mode_builds_service_extension_payload() {
+        let mut config = test_config();
+        config.payload_mode = ApnsPayloadMode::MutableAlert;
+        config.alert_title = "New activity".to_string();
+        config.alert_body = "You have a new notification".to_string();
+        let client = ApnsClient::mock(config, false);
+        let request_parts = ApnsRequestParts::for_config(&client.config).unwrap();
+
+        let request = client
+            .build_request(
+                "https://api.push.apple.com/3/device/aabbccdd11223344",
+                "test-token",
+                &request_parts,
+            )
+            .build()
+            .unwrap();
+
+        assert_eq!(header_value(&request, "apns-push-type"), "alert");
+        assert_eq!(header_value(&request, "apns-priority"), "10");
+        assert_eq!(header_value(&request, "apns-topic"), "com.example.app");
+        assert_eq!(
+            request_json(&request),
+            serde_json::json!({
+                "aps": {
+                    "alert": {
+                        "title": "New activity",
+                        "body": "You have a new notification"
+                    },
+                    "mutable-content": 1,
                     "sound": "default"
                 }
             })


### PR DESCRIPTION
## Summary

- add `mutable_alert` alongside `silent` and `generic_alert`
- send the operator-configured fallback alert with APNs `mutable-content: 1` so an iOS Notification Service Extension can replace it
- apply existing alert validation and payload-size checks to both visible modes
- document the three modes and their environment variables

## Validation

- `just ci`
- 726 unit tests plus integration and doc tests passed
- repository audit policy passed (four existing allowed warnings)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/transponder/pull/368">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the APNs `mutable_alert` payload mode alongside `silent` and `generic_alert`.
  - When enabled, iOS Notification Service Extensions can replace the product-neutral fallback alert.
  - Preserves the configured fallback title and body for mutable alerts.
  - Updated configuration examples and documentation to cover all supported APNs payload modes.
- **Bug Fixes**
  - Improved validation to consistently require alert title/body and enforce serialized payload limits across all alert modes.
- **Tests**
  - Added coverage for `mutable_alert` payload generation and related validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->