### PR TITLE
Prevent duplicate pushes with live-only relay subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ shutdown_timeout_secs = 10
 # max_dedup_cache_size = 100000
 
 # Short-lived volatile content-hash retention (default: 300 seconds).
+# This controls decoded-trigger deduplication only, not relay catch-up.
 # Trigger/replay material is never persisted.
 # dedup_retention_secs = 300
 
@@ -507,6 +508,8 @@ Under cache pressure, below-limit keys may be evicted to admit new keys. That re
 | `transponder_relays_configured` | Gauge | `type` | Configured relays |
 | `transponder_relay_notifications_lagged_total` | Counter | - | Number of times the relay notification receiver reported lag |
 | `transponder_relay_notifications_dropped_total` | Counter | - | Total relay notifications dropped because the receiver lagged |
+| `transponder_relay_backlog_events_ignored_total` | Counter | - | Stored, pre-EOSE, or stale-subscription relay events ignored before processing |
+| `transponder_relay_subscription_lookback_seconds` | Gauge | - | Timestamp-filter lookback retained for the NIP-59 timestamp randomization window |
 
 #### Server Info
 
@@ -537,7 +540,7 @@ To preserve the server's privacy guarantees, only `ERROR`-level events emitted b
 
 ## How It Works
 
-1. **Subscribe**: Transponder connects to configured Nostr relays and subscribes to `kind:1059` (gift-wrapped) events addressed to its public key.
+1. **Subscribe**: Transponder connects to configured Nostr relays and opens a live-only `kind:1059` subscription addressed to its public key. Each relay gets a fresh subscription ID with `limit:0`; events are admitted only after that relay's matching EOSE.
 
 2. **Unwrap**: When an event arrives, it unwraps the NIP-59 gift wrap to extract the inner `kind:446` notification trigger.
 
@@ -546,6 +549,12 @@ To preserve the server's privacy guarantees, only `ERROR`-level events emitted b
 4. **Dispatch**: Tokens are routed to APNs or FCM based on platform identifier, sending content-free push notifications. APNs uses the configured `silent`, `generic_alert`, or `mutable_alert` payload mode. `mutable_alert` includes Apple's `mutable-content` flag so an iOS Notification Service Extension can fetch and replace the product-neutral fallback alert.
 
 5. **Wake**: Client apps wake up, fetch messages from relays, and display notifications locally.
+
+Push hints are advisory. Transponder intentionally does not recover hints
+published while it was offline or while a relay was disconnected, and it
+ignores any stored events returned before EOSE. Normal Marmot message
+synchronization is independent of this push path and still recovers messages
+from relays when the client wakes or reconnects.
 
 ```
 Nostr Relays (ClearNet/Tor)

--- a/config/default.toml
+++ b/config/default.toml
@@ -30,7 +30,8 @@ shutdown_timeout_secs = 10
 # Default: 100000
 # max_dedup_cache_size = 100000
 
-# Short-lived decoded-content hash retention, in seconds. Trigger material is
+# Short-lived decoded-content hash retention, in seconds. This controls
+# decoded-trigger deduplication only, not relay catch-up. Trigger material is
 # volatile and is never written to disk. Default: 5 minutes.
 # dedup_retention_secs = 300
 

--- a/docs/marmot-push-v1-conformance.md
+++ b/docs/marmot-push-v1-conformance.md
@@ -21,6 +21,22 @@ whose `marmot-app` notification implementation emits the adopted token and rumor
 - ChaCha20-Poly1305 token encryption with the fixed-size platform, length, token, and padding plaintext layout
 - short-lived in-memory replay suppression keyed by SHA-256 of decoded kind `446` content
 
+## Live-Only Relay Delivery
+
+Push hints are advisory and are not a message-recovery mechanism. Transponder
+opens a fresh, unregistered subscription for every relay connection with kind
+`1059`, the server public-key tag, the full NIP-59 timestamp-randomization
+window, and `limit:0`. Event processing begins only after the matching EOSE.
+Stored events returned before EOSE and events from superseded subscription IDs
+are ignored.
+
+Consequently, push hints published while Transponder is offline or a relay is
+disconnected are intentionally not recovered. Normal Marmot message
+synchronization is unaffected: clients still fetch the underlying messages
+from their relays after waking or reconnecting. `dedup_retention_secs` remains
+solely the short-lived, in-memory decoded-content-hash replay window and does
+not control relay subscription history.
+
 ## Executable Evidence
 
 The independent test-side encoder in `src/test_vectors.rs` constructs full Marmot Push v1 triggers and NIP-59 envelopes. It is exercised through the event processor and provider mocks. The production decoder is additionally covered by:
@@ -28,6 +44,7 @@ The independent test-side encoder in `src/test_vectors.rs` constructs full Marmo
 - the fixed HKDF vector in `crypto::token::tests::marmot_push_v1_hkdf_conformance_vector`
 - positive and negative kind/tag/base64/token-size cases in `crypto::nip59::tests`
 - rewrapping and decoded-content-hash replay cases in `nostr::events::processor::tests`
+- live-only filter, EOSE admission, reconnect rotation, and mock-relay backlog cases in `nostr::client::tests` and `app::tests`
 - end-to-end application startup, dispatch, and shutdown cases in `app::tests`
 
 Run the release-candidate gate with:

--- a/src/app.rs
+++ b/src/app.rs
@@ -316,7 +316,17 @@ async fn run_event_loop(
 
                         match classify_notification_receive_error(&e) {
                             NotificationReceiveAction::Continue => {
-                                warn!(error = %e, "Lagged relay notifications, continuing");
+                                // The dropped range may contain an EOSE. Clear
+                                // every current ID immediately and ask the
+                                // relay monitor to install fresh subscriptions
+                                // on relays that are still connected.
+                                gift_wrap_subscriptions
+                                    .recover_after_notification_lag()
+                                    .await;
+                                warn!(
+                                    error = %e,
+                                    "Lagged relay notifications; rebuilding live subscriptions"
+                                );
                             }
                             NotificationReceiveAction::Shutdown => {
                                 error!(error = %e, "Notification channel closed");
@@ -558,11 +568,10 @@ pub async fn run(mut config: AppConfig) -> Result<()> {
 
     // Initialize relay client
     let relay_client = Arc::new(
-        RelayClient::with_metrics_and_server_config(
+        RelayClient::with_metrics_and_shutdown_trigger(
             keys.clone(),
             config.relays.clone(),
             metrics.clone(),
-            &config.server,
             shutdown.trigger_handle(),
         )
         .await
@@ -1336,6 +1345,13 @@ mod tests {
     }
 
     async fn test_event_notification(server_keys: &Keys) -> RelayPoolNotification {
+        test_event_notification_with_subscription(server_keys, test_subscription_id()).await
+    }
+
+    async fn test_event_notification_with_subscription(
+        server_keys: &Keys,
+        subscription_id: SubscriptionId,
+    ) -> RelayPoolNotification {
         let sender_keys = Keys::generate();
         let event = crate::test_vectors::scenarios::single_apns_notification(
             server_keys,
@@ -1345,7 +1361,7 @@ mod tests {
         .await;
         RelayPoolNotification::Event {
             relay_url: test_relay_url(),
-            subscription_id: test_subscription_id(),
+            subscription_id,
             event: Box::new(event),
         }
     }
@@ -1665,21 +1681,30 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn run_event_loop_continues_after_lagged_notifications() {
-        // Capacity 1: the second pre-loop send overwrites the first, so the
-        // loop's first recv yields `Lagged` and must keep consuming.
+    async fn run_event_loop_rebuilds_after_lagged_eose() {
+        // Capacity 1: the filler overwrites EOSE before the loop starts, so the
+        // first recv reports `Lagged`. Recovery must invalidate the pending ID
+        // and request a fresh subscription instead of blackholing it forever.
         let (notification_tx, notifications) = broadcast::channel(1);
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
         let metrics = Metrics::new().unwrap();
         let (processor, server_keys) = test_event_processor_with_keys();
         let event_tasks = TaskTracker::new();
-        let subscriptions = test_live_subscriptions().await;
+        let subscriptions = LiveGiftWrapSubscriptions::default();
+        subscriptions
+            .replace_pending(test_relay_url(), test_subscription_id())
+            .await;
 
         notification_tx
-            .send(test_event_notification(&server_keys).await)
+            .send(RelayPoolNotification::Message {
+                relay_url: test_relay_url(),
+                message: RelayMessage::EndOfStoredEvents(std::borrow::Cow::Owned(
+                    test_subscription_id(),
+                )),
+            })
             .unwrap();
         notification_tx
-            .send(test_event_notification(&server_keys).await)
+            .send(RelayPoolNotification::Shutdown)
             .unwrap();
 
         let loop_handle = tokio::spawn(run_event_loop(
@@ -1688,17 +1713,59 @@ mod tests {
             Arc::new(Semaphore::new(1)),
             Arc::clone(&processor),
             event_tasks.clone(),
-            subscriptions,
+            subscriptions.clone(),
             metrics.clone(),
         ));
 
-        // The surviving (newest) event is still processed after the lag.
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            subscriptions.wait_for_rebuild_request(),
+        )
+        .await
+        .expect("losing EOSE must request a live-subscription rebuild");
         assert!(
-            wait_for_cache_len(&processor, 1).await,
-            "the loop must keep processing after a lag"
+            !subscriptions
+                .is_live(&test_relay_url(), &test_subscription_id())
+                .await
         );
         assert_eq!(metrics.relay_notifications_lagged_total.get(), 1);
         assert_eq!(metrics.relay_notifications_dropped_total.get(), 1);
+
+        let replacement_id = SubscriptionId::new("replacement");
+        subscriptions
+            .replace_pending(test_relay_url(), replacement_id.clone())
+            .await;
+        notification_tx
+            .send(RelayPoolNotification::Message {
+                relay_url: test_relay_url(),
+                message: RelayMessage::EndOfStoredEvents(std::borrow::Cow::Owned(
+                    replacement_id.clone(),
+                )),
+            })
+            .unwrap();
+        for _ in 0..100 {
+            if subscriptions
+                .is_live(&test_relay_url(), &replacement_id)
+                .await
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(
+            subscriptions
+                .is_live(&test_relay_url(), &replacement_id)
+                .await,
+            "replacement EOSE must establish a new live boundary"
+        );
+
+        notification_tx
+            .send(test_event_notification_with_subscription(&server_keys, replacement_id).await)
+            .unwrap();
+        assert!(
+            wait_for_cache_len(&processor, 1).await,
+            "events must resume after the replacement subscription reaches EOSE"
+        );
 
         shutdown_tx.send(true).unwrap();
         let exit = tokio::time::timeout(Duration::from_secs(1), loop_handle)

--- a/src/app.rs
+++ b/src/app.rs
@@ -18,7 +18,7 @@ use zeroize::Zeroizing;
 use crate::config::AppConfig;
 use crate::crypto::{Nip59Handler, TokenDecryptor};
 use crate::metrics::Metrics;
-use crate::nostr::client::RelayClient;
+use crate::nostr::client::{LiveGiftWrapSubscriptions, RelayClient};
 use crate::nostr::events::EventProcessor;
 use crate::push::{ApnsClient, FcmClient, PushDispatcher};
 use crate::server::HealthServer;
@@ -235,6 +235,7 @@ async fn run_event_loop(
     event_semaphore: Arc<Semaphore>,
     processor: Arc<EventProcessor>,
     event_tasks: TaskTracker,
+    gift_wrap_subscriptions: LiveGiftWrapSubscriptions,
     metrics: Metrics,
 ) -> EventLoopExit {
     loop {
@@ -246,8 +247,31 @@ async fn run_event_loop(
             result = notifications.recv() => {
                 match result {
                     Ok(notification) => {
-                        let RelayPoolNotification::Event { event, .. } = notification else {
-                            continue;
+                        let event = match notification {
+                            RelayPoolNotification::Message {
+                                relay_url,
+                                message: RelayMessage::EndOfStoredEvents(subscription_id),
+                            } => {
+                                gift_wrap_subscriptions
+                                    .mark_eose(&relay_url, subscription_id.as_ref())
+                                    .await;
+                                continue;
+                            }
+                            RelayPoolNotification::Event {
+                                relay_url,
+                                subscription_id,
+                                event,
+                            } => {
+                                if !gift_wrap_subscriptions
+                                    .is_live(&relay_url, &subscription_id)
+                                    .await
+                                {
+                                    metrics.record_relay_backlog_event_ignored();
+                                    continue;
+                                }
+                                event
+                            }
+                            _ => continue,
                         };
 
                         // Acquire a permit before spawning so total in-flight
@@ -604,21 +628,16 @@ pub async fn run(mut config: AppConfig) -> Result<()> {
 
     // Obtain the broadcast receiver BEFORE issuing the subscription REQ.
     //
-    // `notifications()` returns a fresh `tokio::sync::broadcast::Receiver`, which
-    // only observes messages broadcast after it is created. The subscription uses a
-    // 2-day lookback, so relays immediately stream the stored backlog of gift wraps.
-    // If the receiver were created after `subscribe()` (e.g. inside the spawned event
-    // task), any backlog delivered before the task is first polled would be broadcast
-    // to zero receivers and silently dropped — broadcast channels do not replay
-    // history. Creating the receiver first closes that startup window entirely.
+    // `notifications()` returns a fresh `tokio::sync::broadcast::Receiver`,
+    // which only observes messages broadcast after it is created. The live-only
+    // subscription remains pending until this receiver observes the matching
+    // EOSE, so it must exist before the raw REQ is issued.
     let notifications = relay_client.notifications();
+    let gift_wrap_subscriptions = relay_client.gift_wrap_subscriptions();
 
-    // Spawn the event consumer BEFORE `subscribe()` streams the backlog and
-    // before the `publish_inbox_relays()` network round-trip below. The early
-    // receiver above only prevents the "zero receivers" drop; a consumer must
-    // also be POLLING before any startup await that can block for a meaningful
-    // duration, or the backlog can overflow the bounded broadcast buffer while
-    // nothing drains it and the oldest gift wraps are silently lost.
+    // Spawn the event consumer before `subscribe()` so it can establish the
+    // per-relay EOSE boundary. Stored events (including any sent by a relay
+    // despite `limit = 0`) and events from stale subscription IDs are ignored.
     //
     // The loop runs under supervision: an unexpected exit (notification
     // channel closed) triggers global shutdown instead of leaving a zombie
@@ -640,6 +659,7 @@ pub async fn run(mut config: AppConfig) -> Result<()> {
                 event_semaphore,
                 processor,
                 event_tasks,
+                gift_wrap_subscriptions,
                 event_metrics,
             )
             .await;
@@ -1324,10 +1344,29 @@ mod tests {
         )
         .await;
         RelayPoolNotification::Event {
-            relay_url: RelayUrl::parse("ws://127.0.0.1:7777").unwrap(),
-            subscription_id: SubscriptionId::new("test-sub"),
+            relay_url: test_relay_url(),
+            subscription_id: test_subscription_id(),
             event: Box::new(event),
         }
+    }
+
+    fn test_relay_url() -> RelayUrl {
+        RelayUrl::parse("ws://127.0.0.1:7777").unwrap()
+    }
+
+    fn test_subscription_id() -> SubscriptionId {
+        SubscriptionId::new("test-sub")
+    }
+
+    async fn test_live_subscriptions() -> LiveGiftWrapSubscriptions {
+        let subscriptions = LiveGiftWrapSubscriptions::default();
+        let relay_url = test_relay_url();
+        let subscription_id = test_subscription_id();
+        subscriptions
+            .replace_pending(relay_url.clone(), subscription_id.clone())
+            .await;
+        assert!(subscriptions.mark_eose(&relay_url, &subscription_id).await);
+        subscriptions
     }
 
     fn test_relay_client_config() -> crate::config::RelayConfig {
@@ -1415,6 +1454,7 @@ mod tests {
                 Arc::new(Semaphore::new(1)),
                 test_event_processor(),
                 TaskTracker::new(),
+                LiveGiftWrapSubscriptions::default(),
                 Metrics::disabled(),
             ),
         )
@@ -1438,6 +1478,7 @@ mod tests {
                 Arc::new(Semaphore::new(1)),
                 test_event_processor(),
                 TaskTracker::new(),
+                LiveGiftWrapSubscriptions::default(),
                 Metrics::disabled(),
             ),
         )
@@ -1454,6 +1495,7 @@ mod tests {
         let semaphore = Arc::new(Semaphore::new(2));
         let (processor, server_keys) = test_event_processor_with_keys();
         let event_tasks = TaskTracker::new();
+        let subscriptions = test_live_subscriptions().await;
 
         let loop_handle = tokio::spawn(run_event_loop(
             notifications,
@@ -1461,6 +1503,7 @@ mod tests {
             Arc::clone(&semaphore),
             Arc::clone(&processor),
             event_tasks.clone(),
+            subscriptions,
             Metrics::disabled(),
         ));
 
@@ -1490,6 +1533,101 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn run_event_loop_ignores_events_until_matching_eose() {
+        let (notification_tx, notifications) = broadcast::channel(16);
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let metrics = Metrics::new().unwrap();
+        let (processor, server_keys) = test_event_processor_with_keys();
+        let event_tasks = TaskTracker::new();
+        let subscriptions = LiveGiftWrapSubscriptions::default();
+        subscriptions
+            .replace_pending(test_relay_url(), test_subscription_id())
+            .await;
+
+        let loop_handle = tokio::spawn(run_event_loop(
+            notifications,
+            shutdown_rx,
+            Arc::new(Semaphore::new(1)),
+            Arc::clone(&processor),
+            event_tasks.clone(),
+            subscriptions,
+            metrics.clone(),
+        ));
+
+        notification_tx
+            .send(test_event_notification(&server_keys).await)
+            .unwrap();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(processor.cache_len(), 0);
+        assert_eq!(metrics.relay_backlog_events_ignored_total.get(), 1);
+
+        notification_tx
+            .send(RelayPoolNotification::Message {
+                relay_url: test_relay_url(),
+                message: RelayMessage::EndOfStoredEvents(std::borrow::Cow::Owned(
+                    test_subscription_id(),
+                )),
+            })
+            .unwrap();
+        notification_tx
+            .send(test_event_notification(&server_keys).await)
+            .unwrap();
+        assert!(
+            wait_for_cache_len(&processor, 1).await,
+            "the matching EOSE must activate live event processing"
+        );
+
+        shutdown_tx.send(true).unwrap();
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(1), loop_handle)
+                .await
+                .expect("loop must exit on shutdown")
+                .expect("loop task must not panic"),
+            EventLoopExit::ShutdownRequested
+        );
+        event_tasks.close();
+        event_tasks.wait().await;
+    }
+
+    #[tokio::test]
+    async fn run_event_loop_ignores_superseded_subscription_ids() {
+        let (notification_tx, notifications) = broadcast::channel(4);
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let metrics = Metrics::new().unwrap();
+        let (processor, server_keys) = test_event_processor_with_keys();
+        let subscriptions = test_live_subscriptions().await;
+        subscriptions
+            .replace_pending(test_relay_url(), SubscriptionId::new("replacement"))
+            .await;
+
+        let loop_handle = tokio::spawn(run_event_loop(
+            notifications,
+            shutdown_rx,
+            Arc::new(Semaphore::new(1)),
+            Arc::clone(&processor),
+            TaskTracker::new(),
+            subscriptions,
+            metrics.clone(),
+        ));
+
+        notification_tx
+            .send(test_event_notification(&server_keys).await)
+            .unwrap();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(processor.cache_len(), 0);
+        assert_eq!(metrics.relay_backlog_events_ignored_total.get(), 1);
+
+        shutdown_tx.send(true).unwrap();
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(1), loop_handle)
+                .await
+                .expect("loop must exit on shutdown")
+                .expect("loop task must not panic"),
+            EventLoopExit::ShutdownRequested
+        );
+    }
+
+    #[tokio::test]
     async fn run_event_loop_skips_non_event_notifications() {
         let (notification_tx, notifications) = broadcast::channel(4);
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
@@ -1502,6 +1640,7 @@ mod tests {
             Arc::new(Semaphore::new(1)),
             Arc::clone(&processor),
             event_tasks.clone(),
+            LiveGiftWrapSubscriptions::default(),
             Metrics::disabled(),
         ));
 
@@ -1534,6 +1673,7 @@ mod tests {
         let metrics = Metrics::new().unwrap();
         let (processor, server_keys) = test_event_processor_with_keys();
         let event_tasks = TaskTracker::new();
+        let subscriptions = test_live_subscriptions().await;
 
         notification_tx
             .send(test_event_notification(&server_keys).await)
@@ -1548,6 +1688,7 @@ mod tests {
             Arc::new(Semaphore::new(1)),
             Arc::clone(&processor),
             event_tasks.clone(),
+            subscriptions,
             metrics.clone(),
         ));
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -162,7 +162,10 @@ pub struct Metrics {
     /// Total number of relay notifications dropped because the receiver lagged.
     pub relay_notifications_dropped_total: IntCounter,
 
-    /// Relay subscription lookback window in seconds.
+    /// Total stored or stale relay events ignored before live admission.
+    pub relay_backlog_events_ignored_total: IntCounter,
+
+    /// Relay subscription timestamp-filter lookback in seconds.
     pub relay_subscription_lookback_seconds: IntGauge,
 
     /// Total number of kind-10050 inbox-relay-list publications that failed to
@@ -582,9 +585,15 @@ impl Metrics {
         ))?;
         registry.register(Box::new(relay_notifications_dropped_total.clone()))?;
 
+        let relay_backlog_events_ignored_total = IntCounter::with_opts(Opts::new(
+            "transponder_relay_backlog_events_ignored_total",
+            "Total number of stored or stale relay events ignored before live admission",
+        ))?;
+        registry.register(Box::new(relay_backlog_events_ignored_total.clone()))?;
+
         let relay_subscription_lookback_seconds = IntGauge::with_opts(Opts::new(
             "transponder_relay_subscription_lookback_seconds",
-            "Relay subscription lookback window in seconds",
+            "Relay subscription timestamp-filter lookback in seconds",
         ))?;
         registry.register(Box::new(relay_subscription_lookback_seconds.clone()))?;
 
@@ -655,6 +664,7 @@ impl Metrics {
             relays_configured,
             relay_notifications_lagged_total,
             relay_notifications_dropped_total,
+            relay_backlog_events_ignored_total,
             relay_subscription_lookback_seconds,
             inbox_relay_publish_failed_total,
             server_start_time_seconds,
@@ -1104,7 +1114,15 @@ impl Metrics {
         self.relay_notifications_dropped_total.inc_by(count);
     }
 
-    /// Set the relay subscription lookback window.
+    /// Record a stored or stale relay event ignored before live admission.
+    pub fn record_relay_backlog_event_ignored(&self) {
+        if !self.enabled {
+            return;
+        }
+        self.relay_backlog_events_ignored_total.inc();
+    }
+
+    /// Set the relay subscription timestamp-filter lookback.
     pub fn set_relay_subscription_lookback(&self, seconds: u64) {
         if !self.enabled {
             return;
@@ -1417,6 +1435,7 @@ mod tests {
         metrics.set_relays_connected("onion", 1);
         metrics.record_relay_notifications_lagged();
         metrics.record_relay_notifications_dropped(4);
+        metrics.record_relay_backlog_event_ignored();
         metrics.set_relay_subscription_lookback(172_800);
         metrics.record_inbox_relay_publish_failed();
 
@@ -1467,6 +1486,14 @@ mod tests {
                 &[]
             ),
             4.0
+        );
+        assert_eq!(
+            counter_value(
+                &metrics,
+                "transponder_relay_backlog_events_ignored_total",
+                &[]
+            ),
+            1.0
         );
         assert_eq!(
             gauge_value(

--- a/src/nostr/client.rs
+++ b/src/nostr/client.rs
@@ -308,14 +308,18 @@ async fn run_live_subscription_monitor(
     subscriptions: LiveGiftWrapSubscriptions,
     server_pubkey: PublicKey,
 ) {
+    let rebuild_request = subscriptions.wait_for_rebuild_request();
+    tokio::pin!(rebuild_request);
+
     loop {
         tokio::select! {
-            _ = subscriptions.wait_for_rebuild_request() => {
+            _ = &mut rebuild_request => {
                 warn!("Relay notifications were lost; rebuilding live gift-wrap subscriptions");
                 // The event loop clears state before signaling, but clear again
                 // here so a concurrent install cannot leave an old ID eligible.
                 subscriptions.clear().await;
                 install_for_connected_relays(&client, &subscriptions, server_pubkey).await;
+                rebuild_request.set(subscriptions.wait_for_rebuild_request());
             }
             result = notifications.recv() => match result {
                 Ok(MonitorNotification::StatusChanged { relay_url, status }) => match status {

--- a/src/nostr/client.rs
+++ b/src/nostr/client.rs
@@ -10,7 +10,7 @@ use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::Duration;
 
 use nostr_sdk::prelude::*;
-use tokio::sync::{RwLock, broadcast};
+use tokio::sync::{Notify, RwLock, broadcast};
 use tracing::{debug, error, info, warn};
 
 use crate::config::RelayConfig;
@@ -43,6 +43,7 @@ struct LiveGiftWrapSubscription {
 #[derive(Debug, Clone, Default)]
 pub(crate) struct LiveGiftWrapSubscriptions {
     subscriptions: Arc<RwLock<BTreeMap<RelayUrl, LiveGiftWrapSubscription>>>,
+    rebuild: Arc<Notify>,
 }
 
 impl LiveGiftWrapSubscriptions {
@@ -72,6 +73,19 @@ impl LiveGiftWrapSubscriptions {
 
     async fn clear(&self) {
         self.subscriptions.write().await.clear();
+    }
+
+    /// Fail closed after relay-pool notification loss and request fresh
+    /// subscriptions for every relay that is still connected.
+    pub(crate) async fn recover_after_notification_lag(&self) {
+        self.clear().await;
+        self.rebuild.notify_one();
+    }
+
+    /// Wait until the event loop requests a rebuild after losing relay-pool
+    /// notifications.
+    pub(crate) async fn wait_for_rebuild_request(&self) {
+        self.rebuild.notified().await;
     }
 
     /// Mark a relay/subscription pair live after receiving its matching EOSE.
@@ -228,13 +242,23 @@ async fn install_live_gift_wrap_subscription(
         .await;
 
     let filter = live_gift_wrap_subscription_filter(server_pubkey, Timestamp::now().as_secs());
-    let output = client
+    let output = match client
         .send_msg_to(
             [relay_url.clone()],
             ClientMessage::req(subscription_id.clone(), filter),
         )
         .await
-        .map_err(|e| Error::Nostr(format!("Failed to send live subscription: {e}")))?;
+    {
+        Ok(output) => output,
+        Err(error) => {
+            subscriptions
+                .invalidate_if_current(&relay_url, &subscription_id)
+                .await;
+            return Err(Error::Nostr(format!(
+                "Failed to send live subscription: {error}"
+            )));
+        }
+    };
 
     if output.success.contains(&relay_url) {
         return Ok(());
@@ -285,46 +309,55 @@ async fn run_live_subscription_monitor(
     server_pubkey: PublicKey,
 ) {
     loop {
-        match notifications.recv().await {
-            Ok(MonitorNotification::StatusChanged { relay_url, status }) => match status {
-                NostrRelayStatus::Connected => {
-                    if let Err(error) = install_live_gift_wrap_subscription(
-                        &client,
-                        &subscriptions,
-                        relay_url,
-                        server_pubkey,
-                    )
-                    .await
-                    {
-                        warn!(
-                            error = %error,
-                            "Failed to install live gift-wrap subscription after relay connection"
-                        );
-                    }
-                }
-                NostrRelayStatus::Initialized
-                | NostrRelayStatus::Pending
-                | NostrRelayStatus::Connecting
-                | NostrRelayStatus::Disconnected
-                | NostrRelayStatus::Sleeping
-                | NostrRelayStatus::Terminated
-                | NostrRelayStatus::Banned => {
-                    subscriptions.invalidate(&relay_url).await;
-                }
-            },
-            Err(broadcast::error::RecvError::Lagged(skipped)) => {
-                warn!(
-                    skipped,
-                    "Relay live-subscription monitor lagged; rebuilding current relay subscriptions"
-                );
-
-                // A lost status transition may hide a complete connection
-                // flap. Fail closed by invalidating every old ID, then install
-                // fresh raw subscriptions only on relays connected now.
+        tokio::select! {
+            _ = subscriptions.wait_for_rebuild_request() => {
+                warn!("Relay notifications were lost; rebuilding live gift-wrap subscriptions");
+                // The event loop clears state before signaling, but clear again
+                // here so a concurrent install cannot leave an old ID eligible.
                 subscriptions.clear().await;
                 install_for_connected_relays(&client, &subscriptions, server_pubkey).await;
             }
-            Err(broadcast::error::RecvError::Closed) => break,
+            result = notifications.recv() => match result {
+                Ok(MonitorNotification::StatusChanged { relay_url, status }) => match status {
+                    NostrRelayStatus::Connected => {
+                        if let Err(error) = install_live_gift_wrap_subscription(
+                            &client,
+                            &subscriptions,
+                            relay_url,
+                            server_pubkey,
+                        )
+                        .await
+                        {
+                            warn!(
+                                error = %error,
+                                "Failed to install live gift-wrap subscription after relay connection"
+                            );
+                        }
+                    }
+                    NostrRelayStatus::Initialized
+                    | NostrRelayStatus::Pending
+                    | NostrRelayStatus::Connecting
+                    | NostrRelayStatus::Disconnected
+                    | NostrRelayStatus::Sleeping
+                    | NostrRelayStatus::Terminated
+                    | NostrRelayStatus::Banned => {
+                        subscriptions.invalidate(&relay_url).await;
+                    }
+                },
+                Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                    warn!(
+                        skipped,
+                        "Relay live-subscription monitor lagged; rebuilding current relay subscriptions"
+                    );
+
+                    // A lost status transition may hide a complete connection
+                    // flap. Fail closed by invalidating every old ID, then install
+                    // fresh raw subscriptions only on relays connected now.
+                    subscriptions.clear().await;
+                    install_for_connected_relays(&client, &subscriptions, server_pubkey).await;
+                }
+                Err(broadcast::error::RecvError::Closed) => break,
+            }
         }
     }
 }
@@ -436,20 +469,20 @@ impl RelayClient {
 
     /// Create a new relay client with metrics.
     pub async fn with_metrics(keys: Keys, config: RelayConfig, metrics: Metrics) -> Result<Self> {
-        Self::with_metrics_and_shutdown_trigger(keys, config, metrics, None).await
+        Self::with_optional_shutdown_trigger(keys, config, metrics, None).await
     }
 
-    pub async fn with_metrics_and_server_config(
+    /// Create a relay client with metrics and critical-task shutdown signaling.
+    pub async fn with_metrics_and_shutdown_trigger(
         keys: Keys,
         config: RelayConfig,
         metrics: Metrics,
-        _server: &crate::config::ServerConfig,
         shutdown_trigger: ShutdownTrigger,
     ) -> Result<Self> {
-        Self::with_metrics_and_shutdown_trigger(keys, config, metrics, Some(shutdown_trigger)).await
+        Self::with_optional_shutdown_trigger(keys, config, metrics, Some(shutdown_trigger)).await
     }
 
-    async fn with_metrics_and_shutdown_trigger(
+    async fn with_optional_shutdown_trigger(
         keys: Keys,
         config: RelayConfig,
         metrics: Metrics,
@@ -1832,6 +1865,7 @@ mod tests {
         let old_id = SubscriptionId::new("old");
         let new_id = SubscriptionId::new("new");
 
+        assert!(!subscriptions.mark_eose(&relay_url, &old_id).await);
         subscriptions
             .replace_pending(relay_url.clone(), old_id.clone())
             .await;
@@ -1865,6 +1899,12 @@ mod tests {
         sender
             .send(MonitorNotification::StatusChanged {
                 relay_url: relay_url.clone(),
+                status: NostrRelayStatus::Connected,
+            })
+            .unwrap();
+        sender
+            .send(MonitorNotification::StatusChanged {
+                relay_url: relay_url.clone(),
                 status: NostrRelayStatus::Disconnected,
             })
             .unwrap();
@@ -1882,6 +1922,50 @@ mod tests {
         .await
         .expect("closed notification channel must stop the monitor");
         assert!(!subscriptions.is_live(&relay_url, &subscription_id).await);
+    }
+
+    #[tokio::test]
+    async fn connected_rebuild_skips_disconnected_relays_and_invalidates_state() {
+        let client = Client::default();
+        let relay_url = RelayUrl::parse("wss://relay.example.com").unwrap();
+        client.add_relay(&relay_url).await.unwrap();
+        let subscriptions = LiveGiftWrapSubscriptions::default();
+        let subscription_id = SubscriptionId::new("stale");
+        subscriptions
+            .replace_pending(relay_url.clone(), subscription_id.clone())
+            .await;
+        assert!(subscriptions.mark_eose(&relay_url, &subscription_id).await);
+
+        assert_eq!(
+            install_for_connected_relays(&client, &subscriptions, Keys::generate().public_key(),)
+                .await,
+            0
+        );
+        assert!(!subscriptions.is_live(&relay_url, &subscription_id).await);
+    }
+
+    #[tokio::test]
+    async fn failed_live_subscription_send_invalidates_pending_state() {
+        let client = Client::default();
+        let relay_url = RelayUrl::parse("wss://relay.example.com").unwrap();
+        client.add_relay(&relay_url).await.unwrap();
+        let subscriptions = LiveGiftWrapSubscriptions::default();
+
+        let error = install_live_gift_wrap_subscription(
+            &client,
+            &subscriptions,
+            relay_url,
+            Keys::generate().public_key(),
+        )
+        .await
+        .expect_err("an unconnected relay must reject the raw subscription");
+
+        assert!(
+            error
+                .to_string()
+                .contains("Failed to send live subscription")
+        );
+        assert!(subscriptions.subscriptions.read().await.is_empty());
     }
 
     #[tokio::test]
@@ -1954,6 +2038,50 @@ mod tests {
                 .await
         );
 
+        client.disconnect().await;
+    }
+
+    #[tokio::test]
+    async fn live_subscription_monitor_rebuilds_after_event_notification_lag() {
+        use nostr_relay_builder::MockRelay;
+
+        let mock = MockRelay::run().await.unwrap();
+        let relay_url = mock.url().await;
+        let client = Client::default();
+        client.add_relay(&relay_url).await.unwrap();
+        client.connect().await;
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let server_pubkey = Keys::generate().public_key();
+        let subscriptions = LiveGiftWrapSubscriptions::default();
+        let stale_id = SubscriptionId::new("stale");
+        subscriptions
+            .replace_pending(relay_url.clone(), stale_id.clone())
+            .await;
+        assert!(subscriptions.mark_eose(&relay_url, &stale_id).await);
+
+        let (_monitor_sender, monitor_notifications) = broadcast::channel(8);
+        let mut relay_notifications = client.notifications();
+        let monitor_handle = tokio::spawn(run_live_subscription_monitor(
+            monitor_notifications,
+            client.clone(),
+            subscriptions.clone(),
+            server_pubkey,
+        ));
+
+        subscriptions.recover_after_notification_lag().await;
+        assert!(!subscriptions.is_live(&relay_url, &stale_id).await);
+
+        let replacement_id =
+            receive_eose(&mut relay_notifications, &relay_url, Duration::from_secs(2))
+                .await
+                .expect("event-notification lag must install a fresh subscription");
+        assert_ne!(replacement_id, stale_id);
+        assert!(subscriptions.mark_eose(&relay_url, &replacement_id).await);
+        assert!(subscriptions.is_live(&relay_url, &replacement_id).await);
+
+        monitor_handle.abort();
+        let _ = monitor_handle.await;
         client.disconnect().await;
     }
 

--- a/src/nostr/client.rs
+++ b/src/nostr/client.rs
@@ -32,7 +32,22 @@ const DEGRADED_RELAY_CLASS_WARNING_GRACE: Duration = Duration::from_secs(10);
 #[derive(Debug, Clone)]
 struct LiveGiftWrapSubscription {
     id: SubscriptionId,
-    received_eose: bool,
+    state: LiveGiftWrapSubscriptionState,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LiveGiftWrapSubscriptionState {
+    Pending,
+    Live,
+    Invalidated,
+}
+
+enum LiveGiftWrapInstall {
+    Current,
+    Replace {
+        subscription_id: SubscriptionId,
+        previous: Option<LiveGiftWrapSubscription>,
+    },
 }
 
 /// Relay-scoped state for live-only gift-wrap subscriptions.
@@ -47,38 +62,75 @@ pub(crate) struct LiveGiftWrapSubscriptions {
 }
 
 impl LiveGiftWrapSubscriptions {
+    #[cfg(test)]
     pub(crate) async fn replace_pending(&self, relay_url: RelayUrl, id: SubscriptionId) {
         self.subscriptions.write().await.insert(
             relay_url,
             LiveGiftWrapSubscription {
                 id,
-                received_eose: false,
+                state: LiveGiftWrapSubscriptionState::Pending,
             },
         );
+    }
+
+    async fn prepare_install(
+        &self,
+        relay_url: RelayUrl,
+        subscription_id: SubscriptionId,
+    ) -> LiveGiftWrapInstall {
+        let mut subscriptions = self.subscriptions.write().await;
+        if subscriptions.get(&relay_url).is_some_and(|subscription| {
+            subscription.state != LiveGiftWrapSubscriptionState::Invalidated
+        }) {
+            return LiveGiftWrapInstall::Current;
+        }
+
+        let previous = subscriptions.insert(
+            relay_url,
+            LiveGiftWrapSubscription {
+                id: subscription_id.clone(),
+                state: LiveGiftWrapSubscriptionState::Pending,
+            },
+        );
+        LiveGiftWrapInstall::Replace {
+            subscription_id,
+            previous,
+        }
     }
 
     async fn invalidate(&self, relay_url: &RelayUrl) {
         self.subscriptions.write().await.remove(relay_url);
     }
 
-    async fn invalidate_if_current(&self, relay_url: &RelayUrl, id: &SubscriptionId) {
+    async fn restore_if_current(
+        &self,
+        relay_url: &RelayUrl,
+        id: &SubscriptionId,
+        previous: Option<LiveGiftWrapSubscription>,
+    ) {
         let mut subscriptions = self.subscriptions.write().await;
         if subscriptions
             .get(relay_url)
             .is_some_and(|subscription| subscription.id == *id)
         {
-            subscriptions.remove(relay_url);
+            if let Some(previous) = previous {
+                subscriptions.insert(relay_url.clone(), previous);
+            } else {
+                subscriptions.remove(relay_url);
+            }
         }
     }
 
-    async fn clear(&self) {
-        self.subscriptions.write().await.clear();
+    async fn invalidate_all_for_rebuild(&self) {
+        for subscription in self.subscriptions.write().await.values_mut() {
+            subscription.state = LiveGiftWrapSubscriptionState::Invalidated;
+        }
     }
 
     /// Fail closed after relay-pool notification loss and request fresh
     /// subscriptions for every relay that is still connected.
     pub(crate) async fn recover_after_notification_lag(&self) {
-        self.clear().await;
+        self.invalidate_all_for_rebuild().await;
         self.rebuild.notify_one();
     }
 
@@ -99,9 +151,14 @@ impl LiveGiftWrapSubscriptions {
         if subscription.id != *id {
             return false;
         }
-
-        subscription.received_eose = true;
-        true
+        match subscription.state {
+            LiveGiftWrapSubscriptionState::Pending => {
+                subscription.state = LiveGiftWrapSubscriptionState::Live;
+                true
+            }
+            LiveGiftWrapSubscriptionState::Live => true,
+            LiveGiftWrapSubscriptionState::Invalidated => false,
+        }
     }
 
     /// Return whether this is the current relay/subscription pair and its EOSE
@@ -111,7 +168,9 @@ impl LiveGiftWrapSubscriptions {
             .read()
             .await
             .get(relay_url)
-            .is_some_and(|subscription| subscription.id == *id && subscription.received_eose)
+            .is_some_and(|subscription| {
+                subscription.id == *id && subscription.state == LiveGiftWrapSubscriptionState::Live
+            })
     }
 }
 
@@ -236,23 +295,28 @@ async fn install_live_gift_wrap_subscription(
     relay_url: RelayUrl,
     server_pubkey: PublicKey,
 ) -> Result<()> {
-    let subscription_id = SubscriptionId::generate();
-    subscriptions
-        .replace_pending(relay_url.clone(), subscription_id.clone())
-        .await;
+    let LiveGiftWrapInstall::Replace {
+        subscription_id,
+        previous,
+    } = subscriptions
+        .prepare_install(relay_url.clone(), SubscriptionId::generate())
+        .await
+    else {
+        return Ok(());
+    };
 
     let filter = live_gift_wrap_subscription_filter(server_pubkey, Timestamp::now().as_secs());
-    let output = match client
-        .send_msg_to(
-            [relay_url.clone()],
-            ClientMessage::req(subscription_id.clone(), filter),
-        )
-        .await
-    {
+    let mut messages = Vec::with_capacity(usize::from(previous.is_some()) + 1);
+    if let Some(previous) = previous.as_ref() {
+        messages.push(ClientMessage::close(previous.id.clone()));
+    }
+    messages.push(ClientMessage::req(subscription_id.clone(), filter));
+
+    let output = match client.batch_msg_to([relay_url.clone()], messages).await {
         Ok(output) => output,
         Err(error) => {
             subscriptions
-                .invalidate_if_current(&relay_url, &subscription_id)
+                .restore_if_current(&relay_url, &subscription_id, previous)
                 .await;
             return Err(Error::Nostr(format!(
                 "Failed to send live subscription: {error}"
@@ -265,7 +329,7 @@ async fn install_live_gift_wrap_subscription(
     }
 
     subscriptions
-        .invalidate_if_current(&relay_url, &subscription_id)
+        .restore_if_current(&relay_url, &subscription_id, previous)
         .await;
     let reason = output
         .failed
@@ -315,9 +379,9 @@ async fn run_live_subscription_monitor(
         tokio::select! {
             _ = &mut rebuild_request => {
                 warn!("Relay notifications were lost; rebuilding live gift-wrap subscriptions");
-                // The event loop clears state before signaling, but clear again
-                // here so a concurrent install cannot leave an old ID eligible.
-                subscriptions.clear().await;
+                // The event loop invalidates current IDs before signaling.
+                // Installation is idempotent, so a queued Connected status that
+                // already replaced them is retained.
                 install_for_connected_relays(&client, &subscriptions, server_pubkey).await;
                 rebuild_request.set(subscriptions.wait_for_rebuild_request());
             }
@@ -357,7 +421,7 @@ async fn run_live_subscription_monitor(
                     // A lost status transition may hide a complete connection
                     // flap. Fail closed by invalidating every old ID, then install
                     // fresh raw subscriptions only on relays connected now.
-                    subscriptions.clear().await;
+                    subscriptions.invalidate_all_for_rebuild().await;
                     install_for_connected_relays(&client, &subscriptions, server_pubkey).await;
                 }
                 Err(broadcast::error::RecvError::Closed) => break,
@@ -1090,12 +1154,25 @@ mod tests {
         notifications: &mut broadcast::Receiver<RelayPoolNotification>,
         timeout: std::time::Duration,
     ) -> Option<Box<Event>> {
+        receive_gift_wrap_notification(notifications, timeout)
+            .await
+            .map(|(_, event)| event)
+    }
+
+    async fn receive_gift_wrap_notification(
+        notifications: &mut broadcast::Receiver<RelayPoolNotification>,
+        timeout: std::time::Duration,
+    ) -> Option<(SubscriptionId, Box<Event>)> {
         tokio::time::timeout(timeout, async {
             loop {
                 match notifications.recv().await {
-                    Ok(RelayPoolNotification::Event { event, .. }) => {
+                    Ok(RelayPoolNotification::Event {
+                        subscription_id,
+                        event,
+                        ..
+                    }) => {
                         if event.kind == Kind::GiftWrap {
-                            return Some(event);
+                            return Some((subscription_id, event));
                         }
                     }
                     Ok(_) => continue,
@@ -1819,6 +1896,31 @@ mod tests {
         )
         .await
         .unwrap();
+        assert!(
+            receive_eose(&mut notifications, &relay_url, Duration::from_millis(100))
+                .await
+                .is_none(),
+            "installing an existing live subscription must be idempotent"
+        );
+
+        assert!(
+            receiver
+                .gift_wrap_subscriptions
+                .mark_eose(&relay_url, &first_subscription)
+                .await
+        );
+        receiver
+            .gift_wrap_subscriptions
+            .invalidate_all_for_rebuild()
+            .await;
+        install_live_gift_wrap_subscription(
+            &receiver.client,
+            &receiver.gift_wrap_subscriptions,
+            relay_url.clone(),
+            server_pubkey,
+        )
+        .await
+        .unwrap();
         let replacement_subscription =
             receive_eose(&mut notifications, &relay_url, Duration::from_secs(2))
                 .await
@@ -1829,6 +1931,25 @@ mod tests {
                 .await
                 .is_none(),
             "rotating the raw subscription must not redispatch stored wraps"
+        );
+
+        let after_rotation = EventBuilder::new(Kind::GiftWrap, "after-rotation")
+            .tags([Tag::public_key(server_pubkey)])
+            .sign_with_keys(&sender_keys)
+            .unwrap();
+        sender.send_event(&after_rotation).await.unwrap();
+
+        let (delivery_subscription, delivery) =
+            receive_gift_wrap_notification(&mut notifications, Duration::from_secs(2))
+                .await
+                .expect("replacement subscription must receive new gift wraps");
+        assert_eq!(delivery.id, after_rotation.id);
+        assert_eq!(delivery_subscription, replacement_subscription);
+        assert!(
+            receive_gift_wrap_notification(&mut notifications, Duration::from_millis(100))
+                .await
+                .is_none(),
+            "rotation must close the old relay-side subscription"
         );
 
         receiver.disconnect().await.unwrap();
@@ -1885,6 +2006,10 @@ mod tests {
         assert!(!subscriptions.is_live(&relay_url, &new_id).await);
         assert!(subscriptions.mark_eose(&relay_url, &new_id).await);
         assert!(subscriptions.is_live(&relay_url, &new_id).await);
+
+        subscriptions.invalidate_all_for_rebuild().await;
+        assert!(!subscriptions.mark_eose(&relay_url, &new_id).await);
+        assert!(!subscriptions.is_live(&relay_url, &new_id).await);
     }
 
     #[tokio::test]
@@ -1970,6 +2095,36 @@ mod tests {
                 .contains("Failed to send live subscription")
         );
         assert!(subscriptions.subscriptions.read().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn failed_live_subscription_replacement_preserves_invalidated_id_for_retry() {
+        let client = Client::default();
+        let relay_url = RelayUrl::parse("wss://relay.example.com").unwrap();
+        client.add_relay(&relay_url).await.unwrap();
+        let subscriptions = LiveGiftWrapSubscriptions::default();
+        let previous_id = SubscriptionId::new("previous");
+        subscriptions
+            .replace_pending(relay_url.clone(), previous_id.clone())
+            .await;
+        assert!(subscriptions.mark_eose(&relay_url, &previous_id).await);
+        subscriptions.invalidate_all_for_rebuild().await;
+
+        install_live_gift_wrap_subscription(
+            &client,
+            &subscriptions,
+            relay_url.clone(),
+            Keys::generate().public_key(),
+        )
+        .await
+        .expect_err("an unconnected relay must reject the replacement");
+
+        let stored = subscriptions.subscriptions.read().await;
+        let restored = stored
+            .get(&relay_url)
+            .expect("failed replacement must retain the previous ID for retry");
+        assert_eq!(restored.id, previous_id);
+        assert_eq!(restored.state, LiveGiftWrapSubscriptionState::Invalidated);
     }
 
     #[tokio::test]
@@ -2064,7 +2219,7 @@ mod tests {
             .await;
         assert!(subscriptions.mark_eose(&relay_url, &stale_id).await);
 
-        let (_monitor_sender, monitor_notifications) = broadcast::channel(8);
+        let (monitor_sender, monitor_notifications) = broadcast::channel(8);
         let mut relay_notifications = client.notifications();
         let monitor_handle = tokio::spawn(run_live_subscription_monitor(
             monitor_notifications,
@@ -2075,6 +2230,12 @@ mod tests {
 
         subscriptions.recover_after_notification_lag().await;
         assert!(!subscriptions.is_live(&relay_url, &stale_id).await);
+        monitor_sender
+            .send(MonitorNotification::StatusChanged {
+                relay_url: relay_url.clone(),
+                status: NostrRelayStatus::Connected,
+            })
+            .unwrap();
 
         let replacement_id =
             receive_eose(&mut relay_notifications, &relay_url, Duration::from_secs(2))
@@ -2083,6 +2244,16 @@ mod tests {
         assert_ne!(replacement_id, stale_id);
         assert!(subscriptions.mark_eose(&relay_url, &replacement_id).await);
         assert!(subscriptions.is_live(&relay_url, &replacement_id).await);
+        assert!(
+            receive_eose(
+                &mut relay_notifications,
+                &relay_url,
+                Duration::from_millis(100)
+            )
+            .await
+            .is_none(),
+            "overlapping rebuild and Connected signals must install only once"
+        );
 
         monitor_handle.abort();
         let _ = monitor_handle.await;

--- a/src/nostr/client.rs
+++ b/src/nostr/client.rs
@@ -14,7 +14,7 @@ use tokio::sync::{RwLock, broadcast};
 use tracing::{debug, error, info, warn};
 
 use crate::config::RelayConfig;
-use crate::defaults::{DEFAULT_DEDUP_RETENTION_SECS, NIP59_TIMESTAMP_TWEAK_WINDOW_SECS};
+use crate::defaults::NIP59_TIMESTAMP_TWEAK_WINDOW_SECS;
 use crate::error::{Error, Result};
 use crate::metrics::Metrics;
 use crate::shutdown::ShutdownTrigger;
@@ -29,24 +29,75 @@ const TOR_FEATURE_ENABLED: bool = false;
 const RELAY_MONITOR_CHANNEL_SIZE: usize = 64;
 const DEGRADED_RELAY_CLASS_WARNING_GRACE: Duration = Duration::from_secs(10);
 
-#[derive(Debug, Clone, Copy)]
-struct SubscriptionLookbackConfig {
-    trigger_retention_secs: u64,
+#[derive(Debug, Clone)]
+struct LiveGiftWrapSubscription {
+    id: SubscriptionId,
+    received_eose: bool,
 }
 
-impl SubscriptionLookbackConfig {
-    fn from_server_config(server: &crate::config::ServerConfig) -> Self {
-        Self {
-            trigger_retention_secs: server.dedup_retention_secs,
+/// Relay-scoped state for live-only gift-wrap subscriptions.
+///
+/// A relay/subscription pair is not eligible for event processing until its
+/// matching EOSE has arrived. Replacing or removing an entry immediately makes
+/// notifications from the old subscription stale.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct LiveGiftWrapSubscriptions {
+    subscriptions: Arc<RwLock<BTreeMap<RelayUrl, LiveGiftWrapSubscription>>>,
+}
+
+impl LiveGiftWrapSubscriptions {
+    pub(crate) async fn replace_pending(&self, relay_url: RelayUrl, id: SubscriptionId) {
+        self.subscriptions.write().await.insert(
+            relay_url,
+            LiveGiftWrapSubscription {
+                id,
+                received_eose: false,
+            },
+        );
+    }
+
+    async fn invalidate(&self, relay_url: &RelayUrl) {
+        self.subscriptions.write().await.remove(relay_url);
+    }
+
+    async fn invalidate_if_current(&self, relay_url: &RelayUrl, id: &SubscriptionId) {
+        let mut subscriptions = self.subscriptions.write().await;
+        if subscriptions
+            .get(relay_url)
+            .is_some_and(|subscription| subscription.id == *id)
+        {
+            subscriptions.remove(relay_url);
         }
     }
-}
 
-impl Default for SubscriptionLookbackConfig {
-    fn default() -> Self {
-        Self {
-            trigger_retention_secs: DEFAULT_DEDUP_RETENTION_SECS,
+    async fn clear(&self) {
+        self.subscriptions.write().await.clear();
+    }
+
+    /// Mark a relay/subscription pair live after receiving its matching EOSE.
+    ///
+    /// Returns `true` only when the pair is the relay's current subscription.
+    pub(crate) async fn mark_eose(&self, relay_url: &RelayUrl, id: &SubscriptionId) -> bool {
+        let mut subscriptions = self.subscriptions.write().await;
+        let Some(subscription) = subscriptions.get_mut(relay_url) else {
+            return false;
+        };
+        if subscription.id != *id {
+            return false;
         }
+
+        subscription.received_eose = true;
+        true
+    }
+
+    /// Return whether this is the current relay/subscription pair and its EOSE
+    /// boundary has been observed.
+    pub(crate) async fn is_live(&self, relay_url: &RelayUrl, id: &SubscriptionId) -> bool {
+        self.subscriptions
+            .read()
+            .await
+            .get(relay_url)
+            .is_some_and(|subscription| subscription.id == *id && subscription.received_eose)
     }
 }
 
@@ -153,178 +204,125 @@ async fn resync_reconnect_attempts_from_client(client: &Client, limiter: &Reconn
     resync_reconnect_attempts(limiter, relays);
 }
 
-fn initial_subscription_since(now: u64, config: SubscriptionLookbackConfig) -> Timestamp {
-    Timestamp::from_secs(
-        now.saturating_sub(NIP59_TIMESTAMP_TWEAK_WINDOW_SECS)
-            .saturating_sub(config.trigger_retention_secs),
-    )
-}
-
-fn reconnect_subscription_since(
-    disconnect_started_at: u64,
-    now: u64,
-    config: SubscriptionLookbackConfig,
-) -> Timestamp {
-    let earliest_relevant_publish =
-        disconnect_started_at.max(now.saturating_sub(config.trigger_retention_secs));
-
-    Timestamp::from_secs(
-        earliest_relevant_publish.saturating_sub(NIP59_TIMESTAMP_TWEAK_WINDOW_SECS),
-    )
-}
-
-fn gift_wrap_subscription_filter(server_pubkey: PublicKey, since: Timestamp) -> Filter {
+fn live_gift_wrap_subscription_filter(server_pubkey: PublicKey, now: u64) -> Filter {
     Filter::new()
         .kind(Kind::GiftWrap)
         .pubkey(server_pubkey)
-        .since(since)
+        .since(Timestamp::from_secs(
+            now.saturating_sub(NIP59_TIMESTAMP_TWEAK_WINDOW_SECS),
+        ))
+        // NIP-01 applies `limit` only to the stored query. The relay keeps the
+        // subscription open after EOSE and ignores this limit for live events.
+        .limit(0)
 }
 
-async fn refresh_gift_wrap_subscription(
+async fn install_live_gift_wrap_subscription(
     client: &Client,
-    metrics: &Metrics,
-    subscription_id: &SubscriptionId,
-    server_pubkey: PublicKey,
-    since: Timestamp,
-) -> Result<()> {
-    let filter = gift_wrap_subscription_filter(server_pubkey, since);
-    client
-        .subscribe_with_id(subscription_id.clone(), filter, None)
-        .await
-        .map_err(|e| Error::Nostr(format!("Failed to subscribe: {e}")))?;
-
-    let now = Timestamp::now().as_secs();
-    metrics.set_relay_subscription_lookback(now.saturating_sub(since.as_secs()));
-    Ok(())
-}
-
-fn mark_disconnected_if_needed(
-    disconnected_since: &mut BTreeMap<RelayUrl, u64>,
+    subscriptions: &LiveGiftWrapSubscriptions,
     relay_url: RelayUrl,
-    now: u64,
-) {
-    disconnected_since.entry(relay_url).or_insert(now);
+    server_pubkey: PublicKey,
+) -> Result<()> {
+    let subscription_id = SubscriptionId::generate();
+    subscriptions
+        .replace_pending(relay_url.clone(), subscription_id.clone())
+        .await;
+
+    let filter = live_gift_wrap_subscription_filter(server_pubkey, Timestamp::now().as_secs());
+    let output = client
+        .send_msg_to(
+            [relay_url.clone()],
+            ClientMessage::req(subscription_id.clone(), filter),
+        )
+        .await
+        .map_err(|e| Error::Nostr(format!("Failed to send live subscription: {e}")))?;
+
+    if output.success.contains(&relay_url) {
+        return Ok(());
+    }
+
+    subscriptions
+        .invalidate_if_current(&relay_url, &subscription_id)
+        .await;
+    let reason = output
+        .failed
+        .get(&relay_url)
+        .map(String::as_str)
+        .unwrap_or("relay did not accept the request");
+    Err(Error::Nostr(format!(
+        "Failed to send live subscription: {reason}"
+    )))
 }
 
-async fn run_subscription_refresh_monitor(
+async fn install_for_connected_relays(
+    client: &Client,
+    subscriptions: &LiveGiftWrapSubscriptions,
+    server_pubkey: PublicKey,
+) -> usize {
+    let relays = client.relays().await;
+    let mut installed = 0;
+    for (relay_url, relay) in relays {
+        if relay.status() != NostrRelayStatus::Connected {
+            subscriptions.invalidate(&relay_url).await;
+            continue;
+        }
+
+        match install_live_gift_wrap_subscription(client, subscriptions, relay_url, server_pubkey)
+            .await
+        {
+            Ok(()) => installed += 1,
+            Err(error) => {
+                warn!(error = %error, "Failed to install live gift-wrap subscription");
+            }
+        }
+    }
+    installed
+}
+
+async fn run_live_subscription_monitor(
     mut notifications: broadcast::Receiver<MonitorNotification>,
     client: Client,
-    metrics: Metrics,
-    subscription_id: SubscriptionId,
+    subscriptions: LiveGiftWrapSubscriptions,
     server_pubkey: PublicKey,
-    lookback_config: SubscriptionLookbackConfig,
 ) {
-    let process_started_at = Timestamp::now().as_secs();
-    let mut disconnected_since = BTreeMap::new();
-
     loop {
         match notifications.recv().await {
-            Ok(MonitorNotification::StatusChanged { relay_url, status }) => {
-                let now = Timestamp::now().as_secs();
-                match status {
-                    NostrRelayStatus::Connected => {
-                        if disconnected_since.contains_key(&relay_url) {
-                            // A REQ refresh replaces the subscription on every
-                            // relay, so retain the oldest outstanding gap until
-                            // each catch-up refresh succeeds.
-                            let oldest_disconnect = disconnected_since
-                                .values()
-                                .copied()
-                                .min()
-                                .expect("connected relay has a disconnect record");
-                            let since = reconnect_subscription_since(
-                                oldest_disconnect,
-                                now,
-                                lookback_config,
-                            );
-                            match refresh_gift_wrap_subscription(
-                                &client,
-                                &metrics,
-                                &subscription_id,
-                                server_pubkey,
-                                since,
-                            )
-                            .await
-                            {
-                                Ok(()) => {
-                                    disconnected_since.remove(&relay_url);
-                                }
-                                Err(e) => {
-                                    warn!(error = %e, "Failed to refresh gift-wrap subscription after relay reconnect");
-                                }
-                            }
-                        }
-                    }
-                    NostrRelayStatus::Terminated | NostrRelayStatus::Banned => {
-                        disconnected_since.remove(&relay_url);
-                    }
-                    NostrRelayStatus::Initialized
-                    | NostrRelayStatus::Pending
-                    | NostrRelayStatus::Connecting
-                    | NostrRelayStatus::Disconnected
-                    | NostrRelayStatus::Sleeping => {
-                        mark_disconnected_if_needed(&mut disconnected_since, relay_url, now);
+            Ok(MonitorNotification::StatusChanged { relay_url, status }) => match status {
+                NostrRelayStatus::Connected => {
+                    if let Err(error) = install_live_gift_wrap_subscription(
+                        &client,
+                        &subscriptions,
+                        relay_url,
+                        server_pubkey,
+                    )
+                    .await
+                    {
+                        warn!(
+                            error = %error,
+                            "Failed to install live gift-wrap subscription after relay connection"
+                        );
                     }
                 }
-            }
+                NostrRelayStatus::Initialized
+                | NostrRelayStatus::Pending
+                | NostrRelayStatus::Connecting
+                | NostrRelayStatus::Disconnected
+                | NostrRelayStatus::Sleeping
+                | NostrRelayStatus::Terminated
+                | NostrRelayStatus::Banned => {
+                    subscriptions.invalidate(&relay_url).await;
+                }
+            },
             Err(broadcast::error::RecvError::Lagged(skipped)) => {
-                let now = Timestamp::now().as_secs();
                 warn!(
                     skipped,
-                    "Relay subscription refresh monitor lagged; conservatively refreshing gift-wrap subscription"
+                    "Relay live-subscription monitor lagged; rebuilding current relay subscriptions"
                 );
 
-                let current_relays = client.relays().await;
-                let mut connected_to_clear = Vec::new();
-                for (relay_url, relay) in &current_relays {
-                    match relay.status() {
-                        NostrRelayStatus::Connected => {
-                            if disconnected_since.contains_key(relay_url) {
-                                connected_to_clear.push(relay_url.clone());
-                            }
-                        }
-                        NostrRelayStatus::Terminated | NostrRelayStatus::Banned => {
-                            disconnected_since.remove(relay_url);
-                        }
-                        NostrRelayStatus::Initialized
-                        | NostrRelayStatus::Pending
-                        | NostrRelayStatus::Connecting
-                        | NostrRelayStatus::Disconnected
-                        | NostrRelayStatus::Sleeping => {
-                            disconnected_since
-                                .entry(relay_url.clone())
-                                .or_insert(process_started_at);
-                        }
-                    }
-                }
-
-                // Lost monitor messages can hide a complete disconnect/reconnect
-                // flap. Always refresh conservatively; retention caps the
-                // effective lookback even for a long-lived process.
-                let oldest_disconnect = std::iter::once(process_started_at)
-                    .chain(disconnected_since.values().copied())
-                    .min()
-                    .expect("process start provides a lag recovery bound");
-
-                let since = reconnect_subscription_since(oldest_disconnect, now, lookback_config);
-                match refresh_gift_wrap_subscription(
-                    &client,
-                    &metrics,
-                    &subscription_id,
-                    server_pubkey,
-                    since,
-                )
-                .await
-                {
-                    Ok(()) => {
-                        for relay_url in connected_to_clear {
-                            disconnected_since.remove(&relay_url);
-                        }
-                    }
-                    Err(e) => {
-                        warn!(error = %e, "Failed to refresh gift-wrap subscription after relay monitor lag");
-                    }
-                }
+                // A lost status transition may hide a complete connection
+                // flap. Fail closed by invalidating every old ID, then install
+                // fresh raw subscriptions only on relays connected now.
+                subscriptions.clear().await;
+                install_for_connected_relays(&client, &subscriptions, server_pubkey).await;
             }
             Err(broadcast::error::RecvError::Closed) => break,
         }
@@ -423,7 +421,7 @@ pub struct RelayClient {
     /// in [`RelayClient::connect`]. Used by [`RelayClient::refresh_status`] to
     /// classify connected relays by origin list instead of URL shape.
     origins: Mutex<BTreeMap<RelayUrl, RelayKind>>,
-    subscription_lookback: SubscriptionLookbackConfig,
+    gift_wrap_subscriptions: LiveGiftWrapSubscriptions,
     metrics: Metrics,
     shutting_down: Arc<AtomicBool>,
     shutdown_trigger: Option<ShutdownTrigger>,
@@ -438,38 +436,23 @@ impl RelayClient {
 
     /// Create a new relay client with metrics.
     pub async fn with_metrics(keys: Keys, config: RelayConfig, metrics: Metrics) -> Result<Self> {
-        Self::with_metrics_and_subscription_lookback(
-            keys,
-            config,
-            metrics,
-            SubscriptionLookbackConfig::default(),
-            None,
-        )
-        .await
+        Self::with_metrics_and_shutdown_trigger(keys, config, metrics, None).await
     }
 
     pub async fn with_metrics_and_server_config(
         keys: Keys,
         config: RelayConfig,
         metrics: Metrics,
-        server: &crate::config::ServerConfig,
+        _server: &crate::config::ServerConfig,
         shutdown_trigger: ShutdownTrigger,
     ) -> Result<Self> {
-        Self::with_metrics_and_subscription_lookback(
-            keys,
-            config,
-            metrics,
-            SubscriptionLookbackConfig::from_server_config(server),
-            Some(shutdown_trigger),
-        )
-        .await
+        Self::with_metrics_and_shutdown_trigger(keys, config, metrics, Some(shutdown_trigger)).await
     }
 
-    async fn with_metrics_and_subscription_lookback(
+    async fn with_metrics_and_shutdown_trigger(
         keys: Keys,
         config: RelayConfig,
         metrics: Metrics,
-        subscription_lookback: SubscriptionLookbackConfig,
         shutdown_trigger: Option<ShutdownTrigger>,
     ) -> Result<Self> {
         validate_relay_config(&config)?;
@@ -494,10 +477,7 @@ impl RelayClient {
         let total = config.clearnet.len() + config.onion.len();
 
         metrics.set_relay_counts(config.clearnet.len(), config.onion.len());
-        metrics.set_relay_subscription_lookback(
-            NIP59_TIMESTAMP_TWEAK_WINDOW_SECS
-                .saturating_add(subscription_lookback.trigger_retention_secs),
-        );
+        metrics.set_relay_subscription_lookback(NIP59_TIMESTAMP_TWEAK_WINDOW_SECS);
 
         Ok(Self {
             client,
@@ -509,7 +489,7 @@ impl RelayClient {
                 total_configured: total,
             })),
             origins: Mutex::new(BTreeMap::new()),
-            subscription_lookback,
+            gift_wrap_subscriptions: LiveGiftWrapSubscriptions::default(),
             metrics,
             shutting_down,
             shutdown_trigger,
@@ -617,54 +597,52 @@ impl RelayClient {
         }
     }
 
-    /// Subscribe to gift-wrapped events for the server's public key.
+    /// Subscribe to newly published gift-wrapped events for the server's public
+    /// key without replaying relay history.
     pub async fn subscribe(&self, server_pubkey: PublicKey) -> Result<()> {
-        let since =
-            initial_subscription_since(Timestamp::now().as_secs(), self.subscription_lookback);
-        let subscription_id = SubscriptionId::generate();
-
         debug!(
             pubkey = %server_pubkey,
-            lookback_secs = NIP59_TIMESTAMP_TWEAK_WINDOW_SECS
-                .saturating_add(self.subscription_lookback.trigger_retention_secs),
-            "Subscribing to gift wrap events"
+            timestamp_filter_lookback_secs = NIP59_TIMESTAMP_TWEAK_WINDOW_SECS,
+            "Subscribing to live gift wrap events"
         );
 
-        refresh_gift_wrap_subscription(
-            &self.client,
-            &self.metrics,
-            &subscription_id,
-            server_pubkey,
-            since,
-        )
-        .await?;
-
+        // Subscribe to monitor notifications before the initial relay snapshot
+        // so a concurrent connection transition is queued for reconciliation.
         let notifications = self.monitor.subscribe();
+        let installed = install_for_connected_relays(
+            &self.client,
+            &self.gift_wrap_subscriptions,
+            server_pubkey,
+        )
+        .await;
+        if installed == 0 {
+            return Err(Error::Nostr(
+                "Failed to install a live gift-wrap subscription on any connected relay".into(),
+            ));
+        }
+
         let client = self.client.clone();
-        let metrics = self.metrics.clone();
-        let lookback = self.subscription_lookback;
+        let subscriptions = self.gift_wrap_subscriptions.clone();
         let shutting_down = self.shutting_down.clone();
         let shutdown_trigger = self.shutdown_trigger.clone();
         std::mem::drop(tokio::spawn(async move {
-            run_subscription_refresh_monitor(
-                notifications,
-                client,
-                metrics,
-                subscription_id,
-                server_pubkey,
-                lookback,
-            )
-            .await;
+            run_live_subscription_monitor(notifications, client, subscriptions, server_pubkey)
+                .await;
             if !shutting_down.load(Ordering::SeqCst) {
-                error!("Relay subscription-refresh monitor exited unexpectedly");
+                error!("Relay live-subscription monitor exited unexpectedly");
                 if let Some(trigger) = shutdown_trigger {
                     trigger.trigger();
                 }
             }
         }));
 
-        info!("Subscribed to gift wrap events");
+        info!("Subscribed to live gift wrap events");
         Ok(())
+    }
+
+    /// Get relay-scoped gift-wrap subscription state for EOSE admission.
+    pub(crate) fn gift_wrap_subscriptions(&self) -> LiveGiftWrapSubscriptions {
+        self.gift_wrap_subscriptions.clone()
     }
 
     /// Get the event stream for handling incoming events.
@@ -1082,6 +1060,31 @@ mod tests {
                         if event.kind == Kind::GiftWrap {
                             return Some(event);
                         }
+                    }
+                    Ok(_) => continue,
+                    Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(broadcast::error::RecvError::Closed) => return None,
+                }
+            }
+        })
+        .await
+        .ok()
+        .flatten()
+    }
+
+    async fn receive_eose(
+        notifications: &mut broadcast::Receiver<RelayPoolNotification>,
+        relay_url: &RelayUrl,
+        timeout: std::time::Duration,
+    ) -> Option<SubscriptionId> {
+        tokio::time::timeout(timeout, async {
+            loop {
+                match notifications.recv().await {
+                    Ok(RelayPoolNotification::Message {
+                        relay_url: received_url,
+                        message: RelayMessage::EndOfStoredEvents(subscription_id),
+                    }) if received_url == *relay_url => {
+                        return Some(subscription_id.into_owned());
                     }
                     Ok(_) => continue,
                     Err(broadcast::error::RecvError::Lagged(_)) => continue,
@@ -1720,14 +1723,36 @@ mod tests {
         receiver.client.connect().await;
         tokio::time::sleep(Duration::from_millis(100)).await;
 
-        receiver.subscribe(server_pubkey).await.unwrap();
-        let mut notifications = receiver.notifications();
-
         let sender_keys = Keys::generate();
         let sender = Client::builder().signer(sender_keys.clone()).build();
         sender.add_relay(&relay_url).await.unwrap();
         sender.connect().await;
         tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let stored = EventBuilder::new(Kind::GiftWrap, "stored")
+            .tags([Tag::public_key(server_pubkey)])
+            .sign_with_keys(&sender_keys)
+            .unwrap();
+        sender.send_event(&stored).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let mut notifications = receiver.notifications();
+        receiver.subscribe(server_pubkey).await.unwrap();
+        let first_subscription =
+            receive_eose(&mut notifications, &relay_url, Duration::from_secs(2))
+                .await
+                .expect("live-only subscription must receive EOSE");
+
+        assert!(
+            receive_gift_wrap(&mut notifications, Duration::from_millis(100))
+                .await
+                .is_none(),
+            "limit zero must suppress stored gift wraps"
+        );
+        assert!(
+            receiver.client.subscriptions().await.is_empty(),
+            "raw live-only subscriptions must not be retained by nostr-sdk"
+        );
 
         let backdated = Timestamp::from_secs(
             Timestamp::now()
@@ -1749,77 +1774,118 @@ mod tests {
             "subscription must receive kind 1059 events backdated within the NIP-59 tweak window"
         );
 
+        install_live_gift_wrap_subscription(
+            &receiver.client,
+            &receiver.gift_wrap_subscriptions,
+            relay_url.clone(),
+            server_pubkey,
+        )
+        .await
+        .unwrap();
+        let replacement_subscription =
+            receive_eose(&mut notifications, &relay_url, Duration::from_secs(2))
+                .await
+                .expect("replacement subscription must receive EOSE");
+        assert_ne!(first_subscription, replacement_subscription);
+        assert!(
+            receive_gift_wrap(&mut notifications, Duration::from_millis(100))
+                .await
+                .is_none(),
+            "rotating the raw subscription must not redispatch stored wraps"
+        );
+
         receiver.disconnect().await.unwrap();
         sender.disconnect().await;
     }
 
     #[test]
-    fn test_initial_subscription_covers_tweak_and_trigger_retention() {
-        let now = 1_000_000;
-        let since = initial_subscription_since(
-            now,
-            SubscriptionLookbackConfig {
-                trigger_retention_secs: 300,
-            },
-        );
-        assert_eq!(
-            since.as_secs(),
-            now.saturating_sub(NIP59_TIMESTAMP_TWEAK_WINDOW_SECS)
-                .saturating_sub(300)
-        );
-    }
-
-    #[test]
-    fn test_reconnect_subscription_since_uses_disconnect_for_short_outage() {
-        let now = 1_000_000;
-        let disconnected_at = now - 60;
-        let config = SubscriptionLookbackConfig {
-            trigger_retention_secs: 300,
-        };
-
-        let since = reconnect_subscription_since(disconnected_at, now, config);
+    fn live_subscription_filter_uses_tweak_window_and_zero_limit() {
+        let now: u64 = 1_000_000;
+        let server_pubkey = Keys::generate().public_key();
+        let filter = live_gift_wrap_subscription_filter(server_pubkey, now);
 
         assert_eq!(
-            since.as_secs(),
-            disconnected_at.saturating_sub(NIP59_TIMESTAMP_TWEAK_WINDOW_SECS)
+            filter.since,
+            Some(Timestamp::from_secs(
+                now.saturating_sub(NIP59_TIMESTAMP_TWEAK_WINDOW_SECS)
+            ))
         );
-    }
-
-    #[test]
-    fn test_reconnect_subscription_since_caps_long_outage_to_retention_window() {
-        let now = 1_000_000;
-        let disconnected_at = now - 100_000;
-        let config = SubscriptionLookbackConfig {
-            trigger_retention_secs: 300,
-        };
-
-        let since = reconnect_subscription_since(disconnected_at, now, config);
-
-        assert_eq!(
-            since.as_secs(),
-            now.saturating_sub(300)
-                .saturating_sub(NIP59_TIMESTAMP_TWEAK_WINDOW_SECS)
+        assert_eq!(filter.limit, Some(0));
+        assert!(
+            filter
+                .kinds
+                .as_ref()
+                .is_some_and(|kinds| kinds.contains(&Kind::GiftWrap))
         );
-    }
-
-    #[test]
-    fn test_reconnect_subscription_since_zero_retention_uses_current_time() {
-        let now = 1_000_000;
-        let disconnected_at = now - 100_000;
-        let config = SubscriptionLookbackConfig {
-            trigger_retention_secs: 0,
-        };
-
-        let since = reconnect_subscription_since(disconnected_at, now, config);
-
-        assert_eq!(
-            since.as_secs(),
-            now.saturating_sub(NIP59_TIMESTAMP_TWEAK_WINDOW_SECS)
-        );
+        let matching_event = EventBuilder::new(Kind::GiftWrap, "ignored")
+            .tags([Tag::public_key(server_pubkey)])
+            .custom_created_at(Timestamp::from_secs(now))
+            .sign_with_keys(&Keys::generate())
+            .unwrap();
+        assert!(filter.match_event(&matching_event, MatchEventOptions::default()));
     }
 
     #[tokio::test]
-    async fn test_refresh_gift_wrap_subscription_reuses_subscription_id() {
+    async fn live_subscription_state_requires_current_id_and_matching_eose() {
+        let subscriptions = LiveGiftWrapSubscriptions::default();
+        let relay_url = RelayUrl::parse("wss://relay.example.com").unwrap();
+        let old_id = SubscriptionId::new("old");
+        let new_id = SubscriptionId::new("new");
+
+        subscriptions
+            .replace_pending(relay_url.clone(), old_id.clone())
+            .await;
+        assert!(!subscriptions.is_live(&relay_url, &old_id).await);
+        assert!(subscriptions.mark_eose(&relay_url, &old_id).await);
+        assert!(subscriptions.is_live(&relay_url, &old_id).await);
+
+        subscriptions
+            .replace_pending(relay_url.clone(), new_id.clone())
+            .await;
+        assert!(!subscriptions.mark_eose(&relay_url, &old_id).await);
+        assert!(!subscriptions.is_live(&relay_url, &old_id).await);
+        assert!(!subscriptions.is_live(&relay_url, &new_id).await);
+        assert!(subscriptions.mark_eose(&relay_url, &new_id).await);
+        assert!(subscriptions.is_live(&relay_url, &new_id).await);
+    }
+
+    #[tokio::test]
+    async fn live_subscription_monitor_invalidates_on_disconnect() {
+        let client = Client::default();
+        let server_pubkey = Keys::generate().public_key();
+        let subscriptions = LiveGiftWrapSubscriptions::default();
+        let relay_url = RelayUrl::parse("wss://relay.example.com").unwrap();
+        let subscription_id = SubscriptionId::new("active");
+        subscriptions
+            .replace_pending(relay_url.clone(), subscription_id.clone())
+            .await;
+        assert!(subscriptions.mark_eose(&relay_url, &subscription_id).await);
+        let (sender, receiver) = broadcast::channel(8);
+
+        sender
+            .send(MonitorNotification::StatusChanged {
+                relay_url: relay_url.clone(),
+                status: NostrRelayStatus::Disconnected,
+            })
+            .unwrap();
+        drop(sender);
+
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            run_live_subscription_monitor(
+                receiver,
+                client.clone(),
+                subscriptions.clone(),
+                server_pubkey,
+            ),
+        )
+        .await
+        .expect("closed notification channel must stop the monitor");
+        assert!(!subscriptions.is_live(&relay_url, &subscription_id).await);
+    }
+
+    #[tokio::test]
+    async fn live_subscription_monitor_rebuilds_after_lag() {
         use nostr_relay_builder::MockRelay;
 
         let mock = MockRelay::run().await.unwrap();
@@ -1829,105 +1895,15 @@ mod tests {
         client.connect().await;
         tokio::time::sleep(Duration::from_millis(100)).await;
 
-        let metrics = Metrics::disabled();
-        let subscription_id = SubscriptionId::generate();
         let server_pubkey = Keys::generate().public_key();
-        let first_since = Timestamp::from_secs(1_000);
-        let second_since = Timestamp::from_secs(2_000);
-
-        refresh_gift_wrap_subscription(
-            &client,
-            &metrics,
-            &subscription_id,
-            server_pubkey,
-            first_since,
-        )
-        .await
-        .unwrap();
-        refresh_gift_wrap_subscription(
-            &client,
-            &metrics,
-            &subscription_id,
-            server_pubkey,
-            second_since,
-        )
-        .await
-        .unwrap();
-
-        let subscriptions = client.subscriptions().await;
-        let filters_by_relay = subscriptions
-            .get(&subscription_id)
-            .expect("subscription id should be reused");
-        assert_eq!(
-            subscriptions.len(),
-            1,
-            "refreshing must not accumulate extra subscription IDs"
-        );
-
-        let filters = filters_by_relay
-            .values()
-            .next()
-            .expect("mock relay should have the subscription");
-        assert_eq!(filters.len(), 1);
-        assert_eq!(filters[0].since, Some(second_since));
-
-        client.disconnect().await;
-    }
-
-    #[tokio::test]
-    async fn subscription_refresh_monitor_reconciles_disconnect_and_terminal_transitions() {
-        let client = Client::default();
-        let metrics = Metrics::disabled();
-        let server_pubkey = Keys::generate().public_key();
-        let subscription_id = SubscriptionId::generate();
-        let relay_url = RelayUrl::parse("wss://relay.example.com").unwrap();
-        let (sender, receiver) = broadcast::channel(8);
-
-        sender
-            .send(MonitorNotification::StatusChanged {
-                relay_url: relay_url.clone(),
-                status: NostrRelayStatus::Disconnected,
-            })
-            .unwrap();
-        sender
-            .send(MonitorNotification::StatusChanged {
-                relay_url: relay_url.clone(),
-                status: NostrRelayStatus::Connected,
-            })
-            .unwrap();
-        sender
-            .send(MonitorNotification::StatusChanged {
-                relay_url,
-                status: NostrRelayStatus::Terminated,
-            })
-            .unwrap();
-        drop(sender);
-
-        tokio::time::timeout(
-            Duration::from_secs(2),
-            run_subscription_refresh_monitor(
-                receiver,
-                client,
-                metrics,
-                subscription_id,
-                server_pubkey,
-                SubscriptionLookbackConfig {
-                    trigger_retention_secs: 300,
-                },
-            ),
-        )
-        .await
-        .expect("closed notification channel must stop the monitor");
-    }
-
-    #[tokio::test]
-    async fn subscription_refresh_monitor_recovers_conservatively_after_lag() {
-        let client = Client::default();
-        let metrics = Metrics::disabled();
-        let server_pubkey = Keys::generate().public_key();
-        let subscription_id = SubscriptionId::generate();
-        let relay_url = RelayUrl::parse("wss://relay.example.com").unwrap();
+        let subscriptions = LiveGiftWrapSubscriptions::default();
+        let subscription_id = SubscriptionId::new("stale");
+        subscriptions
+            .replace_pending(relay_url.clone(), subscription_id.clone())
+            .await;
+        assert!(subscriptions.mark_eose(&relay_url, &subscription_id).await);
         let (sender, receiver) = broadcast::channel(1);
+        let mut relay_notifications = client.notifications();
 
         for status in [
             NostrRelayStatus::Disconnected,
@@ -1945,19 +1921,40 @@ mod tests {
 
         tokio::time::timeout(
             Duration::from_secs(2),
-            run_subscription_refresh_monitor(
+            run_live_subscription_monitor(
                 receiver,
-                client,
-                metrics,
-                subscription_id,
+                client.clone(),
+                subscriptions.clone(),
                 server_pubkey,
-                SubscriptionLookbackConfig {
-                    trigger_retention_secs: 300,
-                },
             ),
         )
         .await
         .expect("lag recovery must finish after the channel closes");
+        assert!(
+            !subscriptions.is_live(&relay_url, &subscription_id).await,
+            "monitor lag recovery must invalidate stale subscription IDs"
+        );
+
+        let mut replacement_subscription = None;
+        for _ in 0..3 {
+            let id = receive_eose(&mut relay_notifications, &relay_url, Duration::from_secs(2))
+                .await
+                .expect("lag recovery must install a fresh subscription");
+            if subscriptions.mark_eose(&relay_url, &id).await {
+                replacement_subscription = Some(id);
+                break;
+            }
+        }
+        let replacement_subscription =
+            replacement_subscription.expect("a fresh subscription must remain current");
+        assert_ne!(replacement_subscription, subscription_id);
+        assert!(
+            subscriptions
+                .is_live(&relay_url, &replacement_subscription)
+                .await
+        );
+
+        client.disconnect().await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- replace pool-wide backlog catch-up with relay-scoped, unregistered NIP-01 subscriptions
- request no stored events with `limit = 0` while retaining the full NIP-59 timestamp tweak window for newly published backdated wraps
- admit events only after the current relay/subscription pair receives its matching EOSE
- rotate subscription IDs after reconnect and rebuild fail-closed after monitor lag
- add backlog-ignore telemetry and document that push hints missed during downtime are intentionally not recovered

## Root cause

The existing reconnect refresh reused a pool-wide subscription and coupled its lookback to decoded-trigger deduplication retention. Relays could replay stored gift wraps during startup or reconnect, while outer gift-wrap IDs are intentionally not retained long enough to suppress those rewrap/replay storms.

## Impact

Transponder now processes only gift wraps published after each relay reaches EOSE. Push hints published while Transponder or a relay is offline may be missed; this is intentional because push is advisory. Normal Marmot message synchronization is unaffected.

There are no configuration or wire-format changes. `dedup_retention_secs` remains solely the short-lived decoded-content-hash replay window.

## Validation

- focused `nostr::client` live-subscription and mock-relay tests
- focused app EOSE/stale-ID admission tests
- metric regression test
- full `just ci` gate: formatting, clippy with warnings denied, 725 unit tests plus integration tests, and audit checks

Fixes #371

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Push notifications now use live-only relay gift-wrap subscriptions (stored/stale events are suppressed) and gate delivery until per-relay EOSE.
  - Live subscriptions automatically rebuild after reconnects or relay-notification lag interruptions.
  - Added relay metrics for ignored backlog events and clarified the subscription lookback window behavior.
- **Bug Fixes**
  - Push hints are now clearly advisory: hints received while offline/disconnected aren’t treated as message recovery.
  - Events from superseded subscription IDs are ignored.
- **Documentation**
  - Updated README and conformance docs to describe live-only behavior, metrics, and deduplication scope, plus expanded conformance coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->