### PR TITLE
Bound delivery-health recovery and redact partial keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Bound each provider's delivery-health failure score so `/ready` recovers after a fixed number of processed requests instead of remaining at 503 in proportion to the duration and traffic volume of a prior outage ([#372](https://github.com/marmot-protocol/transponder/issues/372)).
 - Drain every admitted push notification before closing the outbound concurrency semaphore during graceful shutdown, preventing a backlogged queue from being silently shed.
 - Protect in-flight Marmot Push deduplication reservations from LRU eviction so a waiting relay redelivery cannot re-acquire and dispatch the same trigger concurrently.
 - Made the deduplication reservation lifecycle unwind-safe: the owning task now holds an RAII guard, so a panic (or a task dropped mid-processing) gives the reservation up instead of stranding the content hash in flight forever. Previously such a reservation was never evicted or expired, every later delivery of that content blocked on it permanently while holding an event-processing permit, and enough redeliveries could exhaust the permit pool into a silent notification outage ([#370](https://github.com/marmot-protocol/transponder/issues/370)).
@@ -23,6 +24,7 @@
 
 ### Security
 
+- Redact truncated or unterminated PEM private keys from GlitchTip events by scrubbing from the private-key BEGIN marker through the end of the captured text when no END marker is present ([#376](https://github.com/marmot-protocol/transponder/issues/376)).
 - Changed `generate-keys` to hide the private key by default, write secrets with `0600` file permissions via `--output`, and require `--show-private-key` for explicit display, addressing marmot-security#77 ([#51](https://github.com/marmot-protocol/transponder/pull/51)).
 - Removed the unwrapped notification sender public key from event processing state and trace logs, addressing marmot-security#79.
 - Store the server secp256k1 secret key in zeroizing memory and erase temporary `SecretKey` values used during token decryption, addressing the long-term key retention risk reported in marmot-security#24 ([#36](https://github.com/marmot-protocol/transponder/pull/36)).

--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ When enabled, Transponder exposes HTTP endpoints for monitoring:
 | Endpoint | Description | Success |
 |----------|-------------|---------|
 | `GET /health` | Liveness check - is the server running? | Always 200 OK |
-| `GET /ready` | Readiness check - can the server currently deliver notifications? | 200 if relays connected, at least one push service configured, and no configured push service is in a sustained delivery-failure streak |
+| `GET /ready` | Readiness check - can the server currently deliver notifications? | 200 if relays connected, at least one push service configured, and no configured push service has crossed the delivery-failure score threshold |
 | `GET /metrics` | Prometheus metrics (when metrics enabled - served even if the health endpoints are disabled) | 200 with metrics in Prometheus text format |
 
 The default bind address is `127.0.0.1:8080` so these unauthenticated endpoints stay local. If external health checks are required, bind to a specific internal interface or put the endpoints behind a reverse proxy, VPN, or load balancer with access controls. The listener additionally enforces a per-request timeout, a small request-body limit, and a global concurrency cap.
@@ -435,7 +435,7 @@ The default bind address is `127.0.0.1:8080` so these unauthenticated endpoints 
 }
 ```
 
-Readiness probes are side-effect-free: they read a cached relay-status snapshot maintained by a background refresher instead of enumerating the relay pool per request. The `*_delivering` fields expose a passive per-provider signal derived from real send outcomes - a provider is reported as not delivering (and `/ready` returns 503) once it accumulates a sustained streak of consecutive hard send failures (authentication rejections, permanent errors, or exhausted retries) with no intervening success. The signal never probes the providers, so with zero push traffic it retains its last observed state.
+Readiness probes are side-effect-free: they read a cached relay-status snapshot maintained by a background refresher instead of enumerating the relay pool per request. The `*_delivering` fields expose a passive per-provider signal derived from real send outcomes - a provider is reported as not delivering (and `/ready` returns 503) once its bounded failure score crosses the threshold. Authentication rejections, permanent errors, and exhausted retries increase the score; successful sends and definitive invalid-token responses decay it. Bounding the score keeps recovery time independent of outage duration. The signal never probes the providers, so with zero push traffic it retains its last observed state.
 
 ## Metrics
 

--- a/src/nostr/events/processor.rs
+++ b/src/nostr/events/processor.rs
@@ -2343,9 +2343,9 @@ mod tests {
         // Reconciliation invariant with the push-provider rework (#233): a token
         // dropped by the #177 pre-filter in process_inner never reaches the send
         // path, so it is NOT a delivery attempt and must not touch the provider's
-        // DeliveryHealth streak (which gates /ready). No streak increment (would
-        // wrongly flag a healthy provider) and no reset (would wrongly clear a
-        // real failure streak).
+        // DeliveryHealth score (which gates /ready). No score increase (would
+        // wrongly flag a healthy provider) and no decay (would wrongly clear
+        // real outage evidence).
         use crate::push::FcmClient;
         use crate::test_vectors::{
             GiftWrapBuilder, NotificationContentBuilder, TestToken, TokenEncryptor,
@@ -2379,9 +2379,9 @@ mod tests {
             .metrics(metrics.clone())
             .build();
 
-        // Seed a real hard-failure streak on FCM just below the flagging
+        // Seed a real hard-failure score on FCM just below the flagging
         // threshold (a genuine prior outage), so we can prove a pre-filtered APNs
-        // drop neither resets FCM's streak nor touches APNs's.
+        // drop neither decays FCM's score nor touches APNs's.
         use crate::push::dispatcher::DELIVERY_FAILURE_STREAK_THRESHOLD;
         let failures_to_trip = DELIVERY_FAILURE_STREAK_THRESHOLD.div_ceil(2);
         for _ in 0..failures_to_trip - 1 {
@@ -2403,13 +2403,13 @@ mod tests {
 
         assert!(processor.process(&event).await.unwrap());
 
-        // APNs was never a delivery attempt: its streak is untouched (still 0 →
+        // APNs was never a delivery attempt: its score is untouched (still 0 →
         // delivering), so the pre-filter did not spuriously flag it.
         assert!(
             dispatcher_handle.is_apns_delivering(),
-            "a pre-filtered APNs drop must not increment APNs delivery-health streak"
+            "a pre-filtered APNs drop must not increase APNs delivery-health score"
         );
-        // FCM's genuine prior streak was NOT reset by the unrelated APNs drop.
+        // FCM's genuine prior score was NOT decayed by the unrelated APNs drop.
         assert_eq!(
             counter_value(
                 &metrics,
@@ -2420,17 +2420,17 @@ mod tests {
         );
         assert!(
             dispatcher_handle.is_fcm_delivering(),
-            "streak just below threshold is still delivering"
+            "score just below threshold is still delivering"
         );
         // One more FCM hard failure reaches the threshold — which only holds if
-        // the seeded streak survived, proving the APNs pre-filter drop did not
-        // silently reset FCM's real hard-failure streak.
+        // the seeded score survived, proving the APNs pre-filter drop did not
+        // silently decay FCM's real outage evidence.
         dispatcher_handle
             .delivery_health()
             .record_hard_failure(Platform::Fcm);
         assert!(
             !dispatcher_handle.is_fcm_delivering(),
-            "pre-filter drop must not have reset FCM's real hard-failure streak"
+            "pre-filter drop must not have decayed FCM's real hard-failure score"
         );
     }
 

--- a/src/push/dispatcher/health.rs
+++ b/src/push/dispatcher/health.rs
@@ -4,8 +4,8 @@ use std::sync::atomic::{AtomicU32, Ordering};
 
 use crate::crypto::Platform;
 
-/// Accumulated hard-failure score after which a provider is
-/// reported as not delivering (see [`DeliveryHealth`]).
+/// Accumulated hard-failure score after which a provider is reported as not
+/// delivering (see [`DeliveryHealth`]).
 ///
 /// "Hard" failures are outcomes indicating the provider itself is refusing or
 /// failing requests: permanent send errors (which include authentication
@@ -13,9 +13,16 @@ use crate::crypto::Platform;
 /// account) and exhausted retry budgets. Invalid device tokens do NOT count —
 /// a definitive invalid-token verdict proves the provider authenticated and
 /// processed the request. The threshold trades detection speed against
-/// flapping: five hard failures in a row with no intervening success is a
-/// sustained outage signal, not an isolated transient blip.
+/// flapping: five hard failures without enough processed requests to decay the
+/// score is a sustained outage signal, not an isolated transient blip.
 pub const DELIVERY_FAILURE_STREAK_THRESHOLD: u32 = 9;
+
+/// Maximum retained failure score.
+///
+/// Bounding the score keeps recovery time independent of outage duration: once
+/// a provider recovers, at most `DELIVERY_FAILURE_STREAK_THRESHOLD + 1`
+/// processed requests return it to delivering.
+const DELIVERY_FAILURE_SCORE_MAX: u32 = DELIVERY_FAILURE_STREAK_THRESHOLD * 2;
 
 /// Passive per-provider delivery-health signal derived from real send
 /// outcomes.
@@ -23,24 +30,24 @@ pub const DELIVERY_FAILURE_STREAK_THRESHOLD: u32 = 9;
 /// Tracks a bounded leaky failure score per provider. A hard failure adds two
 /// points while a demonstrably processed request removes one. This retains a
 /// fast signal for total outages while also detecting sustained brownouts;
-/// interleaved successes can no longer reset all accumulated evidence. The readiness
-/// endpoint uses [`DeliveryHealth::is_delivering`] to gate `/ready` on live
-/// delivery capability instead of static configuration alone.
+/// interleaved successes can no longer reset all accumulated evidence. The
+/// readiness endpoint uses [`DeliveryHealth::is_delivering`] to gate `/ready`
+/// on live delivery capability instead of static configuration alone.
 ///
 /// The signal is passive: it observes outcomes of real traffic and never
 /// probes the providers. If push traffic stops entirely, the last observed
 /// state is retained until the next send.
 #[derive(Debug, Default)]
 pub struct DeliveryHealth {
-    apns_hard_failure_streak: AtomicU32,
-    fcm_hard_failure_streak: AtomicU32,
+    apns_failure_score: AtomicU32,
+    fcm_failure_score: AtomicU32,
 }
 
 impl DeliveryHealth {
-    fn streak(&self, platform: Platform) -> &AtomicU32 {
+    fn score(&self, platform: Platform) -> &AtomicU32 {
         match platform {
-            Platform::Apns => &self.apns_hard_failure_streak,
-            Platform::Fcm => &self.fcm_hard_failure_streak,
+            Platform::Apns => &self.apns_failure_score,
+            Platform::Fcm => &self.fcm_failure_score,
         }
     }
 
@@ -48,7 +55,7 @@ impl DeliveryHealth {
     /// definitive invalid-token verdict), decaying the failure score.
     pub(crate) fn record_processed(&self, platform: Platform) {
         let _ = self
-            .streak(platform)
+            .score(platform)
             .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |score| {
                 Some(score.saturating_sub(1))
             });
@@ -56,21 +63,20 @@ impl DeliveryHealth {
 
     /// Record a hard send failure (permanent error or exhausted retries).
     ///
-    /// Saturates instead of wrapping so an arbitrarily long outage can never
-    /// roll the streak back over to "delivering".
+    /// Caps the score so an arbitrarily long outage cannot wrap it or make
+    /// recovery time grow with the outage duration.
     pub(crate) fn record_hard_failure(&self, platform: Platform) {
         let _ = self
-            .streak(platform)
-            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |streak| {
-                Some(streak.saturating_add(2))
+            .score(platform)
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |score| {
+                Some(score.saturating_add(2).min(DELIVERY_FAILURE_SCORE_MAX))
             });
     }
 
-    /// Whether the provider is currently considered to be delivering: its
-    /// consecutive hard-failure streak is below
+    /// Whether the provider's accumulated hard-failure score is below
     /// [`DELIVERY_FAILURE_STREAK_THRESHOLD`].
     #[must_use]
     pub fn is_delivering(&self, platform: Platform) -> bool {
-        self.streak(platform).load(Ordering::SeqCst) < DELIVERY_FAILURE_STREAK_THRESHOLD
+        self.score(platform).load(Ordering::SeqCst) < DELIVERY_FAILURE_STREAK_THRESHOLD
     }
 }

--- a/src/push/dispatcher/mod.rs
+++ b/src/push/dispatcher/mod.rs
@@ -250,8 +250,8 @@ impl PushDispatcher {
             }
             PushSendOutcome::InvalidToken => {
                 // A definitive invalid-token verdict proves the provider
-                // authenticated and processed the request, so it ends any
-                // hard-failure streak.
+                // authenticated and processed the request, so it decays the
+                // hard-failure score.
                 delivery_health.record_processed(platform);
                 trace!(
                     service = service_name,
@@ -323,7 +323,7 @@ impl PushDispatcher {
                         Err(e) => {
                             // Permanent send errors include provider auth
                             // rejections (revoked key, expired credentials),
-                            // so they count toward the hard-failure streak.
+                            // so they increase the hard-failure score.
                             delivery_health.record_hard_failure(platform);
                             // Redact any embedded URL before logging: the APNs
                             // URL carries the device token (#172). The send
@@ -352,7 +352,7 @@ impl PushDispatcher {
                         Err(e) => {
                             // Permanent send errors include provider auth
                             // rejections (revoked key, expired credentials),
-                            // so they count toward the hard-failure streak.
+                            // so they increase the hard-failure score.
                             delivery_health.record_hard_failure(platform);
                             // Uniform with APNs: strip any embedded URL before
                             // logging (#172). FCM's URL carries no token, but
@@ -682,17 +682,19 @@ impl PushDispatcher {
         &self.delivery_health
     }
 
-    /// Whether APNs is currently delivering: it is not in a sustained streak
-    /// of consecutive hard send failures (auth rejections, permanent errors,
-    /// exhausted retries). Always `true` until failures are observed.
+    /// Whether APNs is currently delivering: its bounded failure score is below
+    /// the threshold. Authentication rejections, permanent errors, and
+    /// exhausted retries increase the score. Always `true` until failures are
+    /// observed.
     #[must_use]
     pub fn is_apns_delivering(&self) -> bool {
         self.delivery_health.is_delivering(Platform::Apns)
     }
 
-    /// Whether FCM is currently delivering: it is not in a sustained streak
-    /// of consecutive hard send failures (auth rejections, permanent errors,
-    /// exhausted retries). Always `true` until failures are observed.
+    /// Whether FCM is currently delivering: its bounded failure score is below
+    /// the threshold. Authentication rejections, permanent errors, and
+    /// exhausted retries increase the score. Always `true` until failures are
+    /// observed.
     #[must_use]
     pub fn is_fcm_delivering(&self) -> bool {
         self.delivery_health.is_delivering(Platform::Fcm)
@@ -969,7 +971,7 @@ mod tests {
         }
         assert!(
             health.is_delivering(Platform::Apns),
-            "a streak below the threshold must not flag the provider"
+            "a score below the threshold must not flag the provider"
         );
 
         health.record_hard_failure(Platform::Apns);
@@ -984,7 +986,7 @@ mod tests {
     }
 
     #[test]
-    fn delivery_health_processed_request_ends_streak() {
+    fn delivery_health_processed_request_decays_score() {
         let health = DeliveryHealth::default();
 
         for _ in 0..DELIVERY_FAILURE_STREAK_THRESHOLD.div_ceil(2) {
@@ -1004,6 +1006,30 @@ mod tests {
     }
 
     #[test]
+    fn delivery_health_recovery_is_bounded_after_long_outage() {
+        let health = DeliveryHealth::default();
+
+        for _ in 0..10_000 {
+            health.record_hard_failure(Platform::Apns);
+        }
+        assert!(!health.is_delivering(Platform::Apns));
+
+        for _ in 0..DELIVERY_FAILURE_STREAK_THRESHOLD {
+            health.record_processed(Platform::Apns);
+        }
+        assert!(
+            !health.is_delivering(Platform::Apns),
+            "the bounded score must retain outage evidence through the threshold"
+        );
+
+        health.record_processed(Platform::Apns);
+        assert!(
+            health.is_delivering(Platform::Apns),
+            "recovery must be bounded independently of outage duration"
+        );
+    }
+
+    #[test]
     fn record_send_outcome_updates_delivery_health() {
         let metrics = Metrics::disabled();
         let delivery_health = DeliveryHealth::default();
@@ -1019,7 +1045,7 @@ mod tests {
         }
         assert!(
             !delivery_health.is_delivering(Platform::Apns),
-            "consecutive exhausted-retry outcomes must flag the provider"
+            "sustained exhausted-retry outcomes must flag the provider"
         );
 
         // An invalid-token verdict proves the provider processed a request and

--- a/src/redaction.rs
+++ b/src/redaction.rs
@@ -38,7 +38,7 @@ static REDACTIONS: LazyLock<[(Regex, &'static str); 8]> = LazyLock::new(|| {
         ),
         (
             Regex::new(
-                r"(?is)-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----",
+                r"(?is)-----BEGIN [A-Z ]*PRIVATE KEY-----.*?(?:-----END [A-Z ]*PRIVATE KEY-----|\z)",
             )
             .expect("static redaction regex is valid"),
             "[REDACTED-PRIVATE-KEY]",
@@ -228,12 +228,29 @@ mod tests {
     #[test]
     fn pem_private_keys_are_redacted_across_lines() {
         let pem = "-----BEGIN PRIVATE KEY-----\nMIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg\nsecret+/base64material==\n-----END PRIVATE KEY-----";
-        let input = format!("signing failed with key {pem}");
+        let input = format!("signing failed with key {pem} while loading provider");
 
         let output = redact(&input);
 
         assert!(!output.contains("secret+/base64material"));
-        assert_eq!(output, "signing failed with key [REDACTED-PRIVATE-KEY]");
+        assert_eq!(
+            output,
+            "signing failed with key [REDACTED-PRIVATE-KEY] while loading provider"
+        );
+    }
+
+    #[test]
+    fn truncated_pem_private_keys_are_redacted_to_end_of_input() {
+        let pem = "-----BEGIN PRIVATE KEY-----\nMIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEH\nsecret+/base64material==";
+        let input = format!("dependency panic included truncated key {pem}");
+
+        let output = redact(&input);
+
+        assert!(!output.contains("secret+/base64material"));
+        assert_eq!(
+            output,
+            "dependency panic included truncated key [REDACTED-PRIVATE-KEY]"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- cap each provider's leaky delivery-health score at twice the readiness threshold
- guarantee readiness recovery after at most ten processed requests, regardless of outage duration or traffic volume
- redact PEM private keys from their BEGIN marker through either the matching END marker or the end of captured text
- update readiness documentation, changelog entries, and stale failure-streak terminology

## Root cause

The delivery-health score increased without a practical upper bound, while successful or definitively processed requests only reduced it one point at a time. A busy provider outage could therefore leave `/ready` returning 503 long after delivery recovered.

The private-key redaction rule required a complete BEGIN/END pair. A dependency panic or error containing a truncated PEM key could bypass the mechanical GlitchTip scrubber.

## Impact

Long outages still make the affected provider unready, but recovery time is now bounded independently of outage length. Complete PEM keys retain diagnostic text after their END marker, while truncated keys are conservatively redacted through the end of the captured field.

## Validation

- focused delivery-health tests, including 10,000 simulated hard failures followed by bounded recovery
- all 20 redaction tests, including complete and truncated PEM boundaries
- `just ci`
  - formatting
  - Clippy with warnings denied
  - 741 unit tests and 4 integration tests
  - repository audit policy (5 existing allowed warnings)

Fixes #372
Fixes #376

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved readiness recovery by using a bounded delivery-failure score that decays as processing succeeds.
  * Pre-filtered token drops no longer incorrectly affect delivery health.
  * Readiness state remains accurate during periods with no push traffic.

* **Security**
  * Improved protection of GlitchTip events by redacting truncated or incomplete PEM private keys through the end of captured text.

* **Documentation**
  * Updated health-check documentation to explain the failure-score readiness model and recovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->